### PR TITLE
fix: local LLM ingest — add max_tokens and handle reasoning_content

### DIFF
--- a/src/lib/llm-providers.ts
+++ b/src/lib/llm-providers.ts
@@ -20,9 +20,13 @@ function parseOpenAiLine(line: string): string | null {
   if (data === "[DONE]") return null
   try {
     const parsed = JSON.parse(data) as {
-      choices: Array<{ delta: { content?: string } }>
+      choices: Array<{ delta: { content?: string; reasoning_content?: string } }>
     }
-    return parsed.choices?.[0]?.delta?.content ?? null
+    const delta = parsed.choices?.[0]?.delta
+    // Reasoning models (e.g. Nemotron, DeepSeek-R1) emit thinking tokens in
+    // reasoning_content while content is null. Fall back so the accumulated
+    // text includes both the thinking phase and the final answer.
+    return delta?.content ?? delta?.reasoning_content ?? null
   } catch {
     return null
   }
@@ -64,7 +68,11 @@ function parseGoogleLine(line: string): string | null {
 }
 
 function buildOpenAiBody(messages: ChatMessage[]): Record<string, unknown> {
-  return { messages, stream: true }
+  // max_tokens must be set explicitly: without it many local servers (LM Studio,
+  // llama.cpp) fall back to a small default (often 2 048) that is too short for
+  // multi-file wiki generation. 8 192 matches common local model limits while
+  // leaving ample room for reasoning models that spend tokens on thinking first.
+  return { messages, stream: true, max_tokens: 8192 }
 }
 
 function buildAnthropicBody(messages: ChatMessage[]): Record<string, unknown> {


### PR DESCRIPTION
## Problem

Two bugs in  prevent ingest analysis from working with local OpenAI-compatible endpoints (LM Studio, llama.cpp, Ollama).

**Bug 1 — missing ** (affects all local models)

 sends no . Many local servers default to ~2 048 output tokens, far too short to emit all  blocks for a typical wiki ingest. The response is truncated, no FILE blocks are parsed, and the app falls back to .

The Anthropic branch already sets  explicitly. This fix applies the same principle to the OpenAI-compatible path with , covering multi-file wiki generation while staying within common local model limits.

**Bug 2 —  ignored** (affects Nemotron, DeepSeek-R1, Qwen3-thinking, …)

 only reads  and returns  during the thinking phase, when tokens flow through  instead. The entire thinking phase produces zero accumulated text, so even if the final answer is present it may arrive too late and truncated (compounded by Bug 1).

## Fix

- : add 
- : fall back to  when  is 

## Related issues

Fixes #41, #26, #22