### PR TITLE
fix sources scrolling

### DIFF
--- a/src/components/sources/sources-view.tsx
+++ b/src/components/sources/sources-view.tsx
@@ -360,7 +360,7 @@ export function SourcesView() {
   }
 
   return (
-    <div className="flex h-full flex-col">
+    <div className="flex h-full min-h-0 flex-col overflow-hidden">
       <div className="flex items-center justify-between border-b px-4 py-3">
         <h2 className="text-sm font-semibold">{t("sources.title")}</h2>
         <div className="flex gap-1">
@@ -378,7 +378,7 @@ export function SourcesView() {
         </div>
       </div>
 
-      <ScrollArea className="flex-1">
+      <ScrollArea className="min-h-0 flex-1 overflow-hidden">
         {sources.length === 0 ? (
           <div className="flex flex-col items-center justify-center gap-3 p-8 text-center text-sm text-muted-foreground">
             <p>{t("sources.noSources")}</p>


### PR DESCRIPTION
## What
Fix the Sources view so the raw sources page scrolls correctly again.

## Why
The Sources screen's flex layout lacked the height constraints needed for the inner `ScrollArea` to become a real scroll container.

## Validation
- `npm run typecheck`
- Verified the change is isolated to `src/components/sources/sources-view.tsx`