### PR TITLE
feat: add Alibaba Bailian Token Plan preset

### DIFF
--- a/src/components/settings/llm-presets.test.ts
+++ b/src/components/settings/llm-presets.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest"
+import type { LlmConfig, ProviderOverride } from "@/stores/wiki-store"
+import { LLM_PRESETS, matchPreset } from "./llm-presets"
+import { resolveConfig } from "./preset-resolver"
+
+const fallback: LlmConfig = {
+  provider: "openai",
+  apiKey: "",
+  model: "",
+  ollamaUrl: "http://localhost:11434",
+  customEndpoint: "",
+  maxContextSize: 204800,
+}
+
+describe("Alibaba Bailian Token Plan preset", () => {
+  const preset = LLM_PRESETS.find((p) => p.id === "bailian-token")
+
+  it("is registered with the Token Plan OpenAI-compatible defaults", () => {
+    expect(preset).toMatchObject({
+      label: "阿里百炼 Token Plan",
+      provider: "custom",
+      baseUrl: "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1",
+      apiMode: "chat_completions",
+      defaultModel: "qwen3.6-plus",
+    })
+    expect(preset?.suggestedModels).toEqual([
+      "qwen3.6-plus",
+      "deepseek-v3.2",
+      "glm-5",
+      "MiniMax-M2.6",
+    ])
+  })
+
+  it("resolves the Anthropic-compatible Token Plan endpoint when the mode is overridden", () => {
+    expect(preset).toBeDefined()
+    const override: ProviderOverride = {
+      apiMode: "anthropic_messages",
+    }
+
+    const cfg = resolveConfig(preset!, override, fallback)
+
+    expect(cfg.provider).toBe("custom")
+    expect(cfg.apiMode).toBe("anthropic_messages")
+    expect(cfg.customEndpoint).toBe(
+      "https://token-plan.cn-beijing.maas.aliyuncs.com/apps/anthropic",
+    )
+    expect(cfg.model).toBe("qwen3.6-plus")
+  })
+
+  it("matches either Token Plan wire endpoint back to the same preset", () => {
+    expect(
+      matchPreset({
+        provider: "custom",
+        customEndpoint: "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1",
+        ollamaUrl: "",
+        apiMode: "chat_completions",
+      })?.id,
+    ).toBe("bailian-token")
+
+    expect(
+      matchPreset({
+        provider: "custom",
+        customEndpoint: "https://token-plan.cn-beijing.maas.aliyuncs.com/apps/anthropic",
+        ollamaUrl: "",
+        apiMode: "anthropic_messages",
+      })?.id,
+    ).toBe("bailian-token")
+  })
+})

--- a/src/components/settings/llm-presets.ts
+++ b/src/components/settings/llm-presets.ts
@@ -342,6 +342,26 @@ export const LLM_PRESETS: LlmPreset[] = [
     suggestedContextSize: 131072,
   },
   {
+    id: "bailian-token",
+    label: "阿里百炼 Token Plan",
+    hint: "token-plan.cn-beijing.maas.aliyuncs.com",
+    provider: "custom",
+    baseUrl: "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1",
+    apiMode: "chat_completions",
+    baseUrlByMode: {
+      chat_completions: "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1",
+      anthropic_messages: "https://token-plan.cn-beijing.maas.aliyuncs.com/apps/anthropic",
+    },
+    defaultModel: "qwen3.6-plus",
+    suggestedModels: [
+      "qwen3.6-plus",
+      "deepseek-v3.2",
+      "glm-5",
+      "MiniMax-M2.6",
+    ],
+    suggestedContextSize: 131072,
+  },
+  {
     id: "xiaomi-mimo",
     label: "小米 MiMo (Xiaomi)",
     hint: "api.xiaomimimo.com",
@@ -443,9 +463,12 @@ export function matchPreset(params: {
   for (const preset of LLM_PRESETS) {
     if (preset.provider !== provider) continue
     if (provider === "custom") {
-      if (!preset.baseUrl) continue // skip the generic Custom catch-alls
-      if (norm(preset.baseUrl) !== norm(customEndpoint)) continue
-      if ((preset.apiMode ?? "chat_completions") !== (apiMode ?? "chat_completions"))
+      const mode = apiMode ?? "chat_completions"
+      const presetMode = preset.apiMode ?? "chat_completions"
+      const presetBaseUrl = preset.baseUrlByMode?.[mode] ?? preset.baseUrl
+      if (!presetBaseUrl) continue // skip the generic Custom catch-alls
+      if (norm(presetBaseUrl) !== norm(customEndpoint)) continue
+      if (!preset.baseUrlByMode && presetMode !== mode)
         continue
       return preset
     }

--- a/src/components/settings/preset-resolver.ts
+++ b/src/components/settings/preset-resolver.ts
@@ -19,14 +19,15 @@ export function resolveConfig(
     ov.maxContextSize ?? preset.suggestedContextSize ?? fallback.maxContextSize
 
   if (preset.provider === "custom") {
+    const apiMode = ov.apiMode ?? preset.apiMode ?? "chat_completions"
     return {
       provider: "custom",
       apiKey,
       model,
       ollamaUrl: fallback.ollamaUrl,
-      customEndpoint: ov.baseUrl ?? preset.baseUrl ?? "",
+      customEndpoint: ov.baseUrl ?? preset.baseUrlByMode?.[apiMode] ?? preset.baseUrl ?? "",
       maxContextSize,
-      apiMode: ov.apiMode ?? preset.apiMode ?? "chat_completions",
+      apiMode,
     }
   }
 

--- a/src/lib/__tests__/llm-providers.test.ts
+++ b/src/lib/__tests__/llm-providers.test.ts
@@ -158,6 +158,26 @@ describe("buildAnthropicUrl — URL suffix handling", () => {
   })
 })
 
+describe("Alibaba Bailian Token Plan provider config", () => {
+  it("uses bearer auth on the Anthropic-compatible gateway", () => {
+    const cfg = getProviderConfig({
+      provider: "custom",
+      apiKey: "sk-token-plan",
+      model: "qwen3.6-plus",
+      ollamaUrl: "",
+      customEndpoint: "https://token-plan.cn-beijing.maas.aliyuncs.com/apps/anthropic",
+      maxContextSize: 131072,
+      apiMode: "anthropic_messages",
+    } as RealLlmConfig)
+
+    expect(cfg.url).toBe(
+      "https://token-plan.cn-beijing.maas.aliyuncs.com/apps/anthropic/v1/messages",
+    )
+    expect(cfg.headers.Authorization).toBe("Bearer sk-token-plan")
+    expect(cfg.headers["x-api-key"]).toBeUndefined()
+  })
+})
+
 describe("parseGoogleLine — Gemini SSE parsing", () => {
   it("extracts plain text from a single-part event", () => {
     const line = 'data: {"candidates":[{"content":{"parts":[{"text":"Hello"}]}}]}'

--- a/src/lib/llm-providers.ts
+++ b/src/lib/llm-providers.ts
@@ -187,7 +187,10 @@ function requiresBearerAuth(url: string): boolean {
     // Alibaba Bailian Coding Plan — issues sk-xxx bearer-style tokens
     // on its /apps/anthropic gateway; behavior matches the other
     // Chinese Anthropic-wire proxies above.
-    normalized.startsWith("https://coding.dashscope.aliyuncs.com/apps/anthropic")
+    normalized.startsWith("https://coding.dashscope.aliyuncs.com/apps/anthropic") ||
+    // Alibaba Bailian Token Plan — same bearer-style auth on its
+    // Anthropic-compatible gateway.
+    normalized.startsWith("https://token-plan.cn-beijing.maas.aliyuncs.com/apps/anthropic")
   )
 }
 


### PR DESCRIPTION
## Summary
- Add an Alibaba Bailian Token Plan preset with OpenAI- and Anthropic-compatible base URLs.
- Resolve mode-specific preset base URLs so switching API modes selects the matching endpoint by default.
- Use bearer auth for the Token Plan Anthropic-compatible gateway and cover the preset/auth behavior with tests.

## Test plan
- npm run test:mocks -- src/components/settings/llm-presets.test.ts src/lib/__tests__/llm-providers.test.ts
- npm run typecheck


Made with [Cursor](https://cursor.com)