### PR TITLE
[codex] Fix ingest queue persistence and polish UI

### DIFF
--- a/src/components/layout/app-layout.tsx
+++ b/src/components/layout/app-layout.tsx
@@ -98,14 +98,14 @@ export function AppLayout({ onSwitchProject }: AppLayoutProps) {
     // it fills the rest of the viewport.
     <div className="flex h-screen flex-col bg-background text-foreground">
       <UpdateBanner />
-      <div className="flex min-h-0 flex-1">
+      <div className="flex min-h-0 flex-1 bg-background/80">
         <IconSidebar onSwitchProject={onSwitchProject} />
         <div ref={containerRef} className="flex min-w-0 flex-1 overflow-hidden">
         {!isSettings && (
           <>
             {/* Left: File tree + Activity */}
             <div
-              className="flex shrink-0 flex-col overflow-hidden border-r"
+              className="flex shrink-0 flex-col overflow-hidden border-r border-border/80 bg-card/70 shadow-sm shadow-foreground/5"
               style={{ width: leftWidth }}
             >
               <div className="flex-1 overflow-hidden">
@@ -114,14 +114,14 @@ export function AppLayout({ onSwitchProject }: AppLayoutProps) {
               <ActivityPanel />
             </div>
             <div
-              className="w-1.5 shrink-0 cursor-col-resize bg-border/40 transition-colors hover:bg-primary/30 active:bg-primary/40"
+              className="w-1.5 shrink-0 cursor-col-resize bg-border/40 transition-colors hover:bg-primary/35 active:bg-primary/45"
               onMouseDown={startDrag("left")}
             />
           </>
         )}
 
         {/* Center: Chat or view (sources/settings/review) */}
-        <div className="min-w-0 flex-1 overflow-hidden">
+        <div className="min-w-0 flex-1 overflow-hidden bg-background/65">
           <ErrorBoundary>
             <ContentArea />
           </ErrorBoundary>
@@ -131,11 +131,11 @@ export function AppLayout({ onSwitchProject }: AppLayoutProps) {
         {hasRightPanel && (
           <>
             <div
-              className="w-1.5 shrink-0 cursor-col-resize bg-border/40 transition-colors hover:bg-primary/30 active:bg-primary/40"
+              className="w-1.5 shrink-0 cursor-col-resize bg-border/40 transition-colors hover:bg-primary/35 active:bg-primary/45"
               onMouseDown={startDrag("right")}
             />
             <div
-              className="flex shrink-0 flex-col overflow-hidden border-l"
+              className="flex shrink-0 flex-col overflow-hidden border-l border-border/80 bg-card/75 shadow-sm shadow-foreground/5"
               style={{ width: rightWidth }}
             >
               <ErrorBoundary>

--- a/src/components/layout/icon-sidebar.tsx
+++ b/src/components/layout/icon-sidebar.tsx
@@ -62,9 +62,9 @@ export function IconSidebar({ onSwitchProject }: IconSidebarProps) {
 
   return (
     <TooltipProvider delay={300}>
-      <div className="flex h-full w-12 flex-col items-center border-r bg-muted/50 py-2">
+      <div className="flex h-full w-14 flex-col items-center border-r border-sidebar-border bg-sidebar/95 py-2 text-sidebar-foreground shadow-sm shadow-foreground/5">
         {/* Logo */}
-        <div className="mb-2 flex items-center justify-center">
+        <div className="mb-3 flex items-center justify-center rounded-md border border-sidebar-border/80 bg-card/80 p-1 shadow-sm">
           <img
             src={logoImg}
             alt="LLM Wiki"
@@ -72,15 +72,15 @@ export function IconSidebar({ onSwitchProject }: IconSidebarProps) {
           />
         </div>
         {/* Top: main nav items + Deep Research */}
-        <div className="flex flex-1 flex-col items-center gap-1">
+        <div className="flex flex-1 flex-col items-center gap-1.5">
           {NAV_ITEMS.map(({ view, icon: Icon, labelKey }) => (
             <Tooltip key={view}>
               <TooltipTrigger
                 onClick={() => setActiveView(view)}
-                className={`relative flex h-10 w-10 items-center justify-center rounded-md transition-colors ${
+                className={`relative flex h-10 w-10 items-center justify-center rounded-md transition-all ${
                   activeView === view
-                    ? "bg-accent text-accent-foreground"
-                    : "text-muted-foreground hover:bg-accent/50 hover:text-accent-foreground"
+                    ? "bg-sidebar-primary text-sidebar-primary-foreground shadow-sm shadow-primary/25"
+                    : "text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
                 }`}
               >
                 <Icon className="h-5 w-5" />
@@ -100,10 +100,10 @@ export function IconSidebar({ onSwitchProject }: IconSidebarProps) {
           <Tooltip>
             <TooltipTrigger
               onClick={() => toggleResearchPanel(!researchPanelOpen)}
-              className={`relative flex h-10 w-10 items-center justify-center rounded-md transition-colors ${
+              className={`relative flex h-10 w-10 items-center justify-center rounded-md transition-all ${
                 researchPanelOpen
-                  ? "bg-accent text-accent-foreground"
-                  : "text-muted-foreground hover:bg-accent/50 hover:text-accent-foreground"
+                  ? "bg-sidebar-primary text-sidebar-primary-foreground shadow-sm shadow-primary/25"
+                  : "text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
               }`}
             >
               <Globe className="h-5 w-5" />
@@ -117,7 +117,7 @@ export function IconSidebar({ onSwitchProject }: IconSidebarProps) {
           </Tooltip>
         </div>
         {/* Bottom: daemon status + settings + switch project */}
-        <div className="flex flex-col items-center gap-1 pb-1">
+        <div className="flex flex-col items-center gap-1.5 border-t border-sidebar-border/70 pt-2 pb-1">
           {/* Daemon status indicator */}
           <Tooltip>
             <TooltipTrigger className="flex h-6 w-6 items-center justify-center">
@@ -140,10 +140,10 @@ export function IconSidebar({ onSwitchProject }: IconSidebarProps) {
           <Tooltip>
             <TooltipTrigger
               onClick={() => setActiveView("settings")}
-              className={`relative flex h-10 w-10 items-center justify-center rounded-md transition-colors ${
+              className={`relative flex h-10 w-10 items-center justify-center rounded-md transition-all ${
                 activeView === "settings"
-                  ? "bg-accent text-accent-foreground"
-                  : "text-muted-foreground hover:bg-accent/50 hover:text-accent-foreground"
+                  ? "bg-sidebar-primary text-sidebar-primary-foreground shadow-sm shadow-primary/25"
+                  : "text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
               }`}
             >
               <Settings className="h-5 w-5" />
@@ -171,7 +171,7 @@ export function IconSidebar({ onSwitchProject }: IconSidebarProps) {
           <Tooltip>
             <TooltipTrigger
               onClick={onSwitchProject}
-              className="flex h-10 w-10 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent/50 hover:text-accent-foreground"
+              className="flex h-10 w-10 items-center justify-center rounded-md text-muted-foreground transition-all hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
             >
               <ArrowLeftRight className="h-5 w-5" />
             </TooltipTrigger>

--- a/src/components/project/welcome-screen.tsx
+++ b/src/components/project/welcome-screen.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/button"
 import { getRecentProjects, removeFromRecentProjects } from "@/lib/project-store"
 import type { WikiProject } from "@/types/wiki"
 import { useTranslation } from "react-i18next"
+import logoImg from "@/assets/logo.jpg"
 
 interface WelcomeScreenProps {
   onCreateProject: () => void
@@ -31,17 +32,27 @@ export function WelcomeScreen({
   }
 
   return (
-    <div className="flex h-full items-center justify-center bg-background">
-      <div className="flex flex-col items-center gap-8 px-4">
-        <div className="text-center">
-          <h1 className="text-3xl font-bold">{t("app.title")}</h1>
-          <p className="mt-2 text-muted-foreground">
+    <div className="relative flex h-full items-center justify-center overflow-hidden bg-background px-5">
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_20%_20%,color-mix(in_oklch,var(--accent)_72%,transparent),transparent_32%),radial-gradient(circle_at_80%_10%,color-mix(in_oklch,var(--secondary)_88%,transparent),transparent_26%)]" />
+      <div className="absolute inset-x-0 bottom-0 h-1/2 bg-gradient-to-t from-background to-transparent" />
+
+      <div className="relative flex w-full max-w-3xl flex-col items-center gap-8">
+        <div className="flex flex-col items-center text-center">
+          <div className="mb-5 rounded-md border border-border/70 bg-card/90 p-2 shadow-sm shadow-primary/10">
+            <img
+              src={logoImg}
+              alt="LLM Wiki"
+              className="h-14 w-14 rounded-[22%]"
+            />
+          </div>
+          <h1 className="text-4xl font-semibold tracking-normal text-foreground">{t("app.title")}</h1>
+          <p className="mt-3 max-w-xl text-sm leading-6 text-muted-foreground">
             {t("app.subtitle")}
           </p>
         </div>
 
-        <div className="flex gap-3">
-          <Button onClick={onCreateProject}>
+        <div className="flex flex-wrap justify-center gap-3">
+          <Button onClick={onCreateProject} className="shadow-sm shadow-primary/20">
             <Plus className="mr-2 h-4 w-4" />
             {t("welcome.newProject")}
           </Button>
@@ -52,17 +63,17 @@ export function WelcomeScreen({
         </div>
 
         {recentProjects.length > 0 && (
-          <div className="w-full max-w-md">
-            <div className="mb-2 flex items-center gap-2 text-sm text-muted-foreground">
+          <div className="w-full max-w-2xl">
+            <div className="mb-3 flex items-center gap-2 text-sm font-medium text-muted-foreground">
               <Clock className="h-3.5 w-3.5" />
               {t("welcome.recentProjects")}
             </div>
-            <div className="rounded-lg border">
+            <div className="grid gap-2">
               {recentProjects.map((proj) => (
                 <button
                   key={proj.path}
                   onClick={() => onSelectProject(proj)}
-                  className="group flex w-full items-center justify-between border-b px-4 py-3 text-left transition-colors last:border-b-0 hover:bg-accent"
+                  className="group flex w-full items-center justify-between rounded-md border border-border/80 bg-card/85 px-4 py-3 text-left shadow-sm shadow-foreground/5 transition-all hover:-translate-y-0.5 hover:border-primary/40 hover:bg-card hover:shadow-md hover:shadow-primary/10"
                 >
                   <div className="min-w-0 flex-1">
                     <div className="truncate text-sm font-medium">{proj.name}</div>
@@ -77,7 +88,7 @@ export function WelcomeScreen({
                     onKeyDown={(e) => {
                       if (e.key === "Enter") handleRemoveRecent(e as unknown as React.MouseEvent, proj.path)
                     }}
-                    className="ml-2 shrink-0 rounded p-1 opacity-0 transition-opacity hover:bg-destructive/10 group-hover:opacity-100"
+                    className="ml-2 shrink-0 rounded-md p-1 opacity-0 transition-opacity hover:bg-destructive/10 group-hover:opacity-100"
                   >
                     <X className="h-3.5 w-3.5 text-muted-foreground" />
                   </div>

--- a/src/index.css
+++ b/src/index.css
@@ -49,38 +49,38 @@
 }
 
 :root {
-    --background: oklch(1 0 0);
-    --foreground: oklch(0.145 0 0);
-    --card: oklch(1 0 0);
-    --card-foreground: oklch(0.145 0 0);
-    --popover: oklch(1 0 0);
-    --popover-foreground: oklch(0.145 0 0);
-    --primary: oklch(0.205 0 0);
-    --primary-foreground: oklch(0.985 0 0);
-    --secondary: oklch(0.97 0 0);
-    --secondary-foreground: oklch(0.205 0 0);
-    --muted: oklch(0.97 0 0);
-    --muted-foreground: oklch(0.556 0 0);
-    --accent: oklch(0.97 0 0);
-    --accent-foreground: oklch(0.205 0 0);
+    --background: oklch(0.982 0.006 204);
+    --foreground: oklch(0.192 0.029 230);
+    --card: oklch(0.998 0.002 204);
+    --card-foreground: oklch(0.192 0.029 230);
+    --popover: oklch(0.998 0.002 204);
+    --popover-foreground: oklch(0.192 0.029 230);
+    --primary: oklch(0.446 0.113 179);
+    --primary-foreground: oklch(0.985 0.009 180);
+    --secondary: oklch(0.945 0.017 212);
+    --secondary-foreground: oklch(0.246 0.039 224);
+    --muted: oklch(0.949 0.012 214);
+    --muted-foreground: oklch(0.486 0.034 223);
+    --accent: oklch(0.925 0.045 175);
+    --accent-foreground: oklch(0.234 0.047 203);
     --destructive: oklch(0.577 0.245 27.325);
-    --border: oklch(0.922 0 0);
-    --input: oklch(0.922 0 0);
-    --ring: oklch(0.708 0 0);
-    --chart-1: oklch(0.87 0 0);
-    --chart-2: oklch(0.556 0 0);
-    --chart-3: oklch(0.439 0 0);
-    --chart-4: oklch(0.371 0 0);
-    --chart-5: oklch(0.269 0 0);
+    --border: oklch(0.884 0.018 213);
+    --input: oklch(0.884 0.018 213);
+    --ring: oklch(0.598 0.105 179);
+    --chart-1: oklch(0.617 0.136 178);
+    --chart-2: oklch(0.603 0.151 36);
+    --chart-3: oklch(0.499 0.104 259);
+    --chart-4: oklch(0.686 0.117 92);
+    --chart-5: oklch(0.542 0.102 322);
     --radius: 0.625rem;
-    --sidebar: oklch(0.985 0 0);
-    --sidebar-foreground: oklch(0.145 0 0);
-    --sidebar-primary: oklch(0.205 0 0);
-    --sidebar-primary-foreground: oklch(0.985 0 0);
-    --sidebar-accent: oklch(0.97 0 0);
-    --sidebar-accent-foreground: oklch(0.205 0 0);
-    --sidebar-border: oklch(0.922 0 0);
-    --sidebar-ring: oklch(0.708 0 0);
+    --sidebar: oklch(0.968 0.018 207);
+    --sidebar-foreground: oklch(0.254 0.042 225);
+    --sidebar-primary: oklch(0.446 0.113 179);
+    --sidebar-primary-foreground: oklch(0.985 0.009 180);
+    --sidebar-accent: oklch(0.914 0.036 181);
+    --sidebar-accent-foreground: oklch(0.234 0.047 203);
+    --sidebar-border: oklch(0.86 0.025 211);
+    --sidebar-ring: oklch(0.598 0.105 179);
 }
 
 .dark {
@@ -123,6 +123,8 @@
     }
   body {
     @apply bg-background text-foreground;
+    background:
+      linear-gradient(140deg, oklch(0.988 0.01 206) 0%, oklch(0.972 0.014 188) 45%, oklch(0.982 0.008 232) 100%);
     }
   html {
     @apply font-sans;

--- a/src/lib/ingest-queue.ts
+++ b/src/lib/ingest-queue.ts
@@ -49,8 +49,11 @@ function queueFilePath(projectPath: string): string {
 
 async function saveQueue(projectPath: string): Promise<void> {
   try {
-    // Only save pending and failed tasks (done tasks are removed)
-    const toSave = queue.filter((t) => t.status !== "done")
+    // Persist in-flight work as pending. If the app exits mid-ingest, restore
+    // can retry from the beginning without relying on a transient status.
+    const toSave = queue
+      .filter((t) => t.status !== "done")
+      .map((t) => (t.status === "processing" ? { ...t, status: "pending" as const } : t))
     await writeFile(queueFilePath(projectPath), JSON.stringify(toSave, null, 2))
   } catch {
     // non-critical
@@ -467,7 +470,6 @@ async function processNext(projectId: string): Promise<void> {
 
   processing = true
   next.status = "processing"
-  await saveQueue(pp)
   if (currentProjectId !== projectId) return
 
   const llmConfig = useWikiStore.getState().llmConfig


### PR DESCRIPTION
## Summary
- Fix ingest queue persistence so in-flight tasks are written as retryable pending work instead of transient processing state.
- Avoid the extra queue-file write when a task first starts processing, which removes the observed partial JSON read race in real-FS persistence tests.
- Refresh the welcome screen, app shell panels, sidebar active states, and light theme palette for a cleaner desktop feel.

## Why
The ingest queue integration tests exposed an intermittent JSON parse failure while reading `.llm-wiki/ingest-queue.json`. The processing transition caused an immediate second write to the same file after enqueue. Persisting active work as pending is enough for recovery and avoids that fragile write window.

## Validation
- `npm run test:mocks`
- `npm run build`

Note: build still reports existing Vite chunk-size and ineffective dynamic import warnings, but it completes successfully.