### PR TITLE
fix: UI language reverts to English after a second save in Settings

### DIFF
--- a/src/components/settings/settings-view.tsx
+++ b/src/components/settings/settings-view.tsx
@@ -151,8 +151,15 @@ export function SettingsView() {
   )
 
   // Resync draft from store if it changes out-of-band (e.g. project switch).
+  // IMPORTANT: keep the current draft.uiLanguage instead of re-reading
+  // `i18n.language`. handleSave calls multiple zustand setters before it
+  // calls `i18n.changeLanguage` at the end, and each setter triggers this
+  // effect mid-save — which used to clobber the user's pending language
+  // pick with the still-stale `i18n.language`. The next save would then
+  // see draft.uiLanguage out of sync with i18n.language and silently
+  // revert the UI to the previous language.
   useEffect(() => {
-    setDraftState(
+    setDraftState((prev) =>
       initialDraft(
         llmConfig,
         searchApiConfig,
@@ -161,7 +168,7 @@ export function SettingsView() {
         outputLanguage,
         proxyConfig,
         maxHistoryMessages,
-        i18n.language,
+        prev.uiLanguage,
       ),
     )
   }, [


### PR DESCRIPTION
Fixes #104.

## Problem

After switching the UI language to Chinese in **Settings → Interface** and saving, opening another draft-bound section (Embedding / Multimodal / Web Search / Network / Output), editing any field, and clicking **Save** again silently flips the entire UI back to English and persists `language=en` to the store. Reproduces 100% on `main` (v0.4.5).

## Root cause

`SettingsView` has a resync `useEffect` that rebuilds the whole draft whenever any of the store slices change, and re-reads `i18n.language` while doing so. `handleSave` calls multiple zustand setters before it finally calls `i18n.changeLanguage` at the end — and each `await` between setters lets React commit, which fires the resync effect mid-save. At that point `i18n.language` is still the OLD value, so the effect silently rewrites `draft.uiLanguage` back to the old language.

The first save still works because `handleSave` closes over its own snapshot of `draft` (with the new `uiLanguage`), so `if (draft.uiLanguage !== i18n.language)` still takes the change-language branch successfully. But after that save:

- `i18n.language === "zh"` ✅
- but the component's `draft.uiLanguage === "en"` (clobbered by the mid-save resync)

The **next** save reads the stale `draft.uiLanguage = "en"`, hits the same `if` condition with `"en" !== "zh"`, and helpfully calls `changeLanguage("en")` + `saveLanguage("en")` — reverting and persisting the language flip the user never asked for.

## Fix

One-line change in the resync effect: keep the current `draft.uiLanguage` via a functional setState instead of re-reading `i18n.language`. `uiLanguage` is only ever written by the Interface section's `setDraft`, never out-of-band, so preserving it across store-driven resyncs is correct.

```diff
 useEffect(() => {
-  setDraftState(
+  setDraftState((prev) =>
     initialDraft(
       llmConfig, searchApiConfig, embeddingConfig, multimodalConfig,
       outputLanguage, proxyConfig, maxHistoryMessages,
-      i18n.language,
+      prev.uiLanguage,
     ),
   );
 }, [...]);
```

Plus a code comment explaining why this is intentional, so the next person doesn't "fix" it back.

## Verification

Manual repro on `main`:
1. en → 中文 in Interface, Save → UI in Chinese ✅, `draft.uiLanguage` actually became `"en"` 🐛
2. Open Embedding, edit endpoint, Save → UI flips to English 🐛

After this patch, step 2 keeps the UI in Chinese, and `language=zh` stays persisted.

The fix doesn't change any other section's behavior:
- LLM section persists per-row independently (doesn't touch the shared draft Save)
- About / Maintenance / Changelog have no draft-bound fields
- Project switch → out-of-band store change → resync still happens, and `prev.uiLanguage` at that point is the value used to mount the panel (which equals `i18n.language` at mount time), so behavior is unchanged for that scenario.