### PR TITLE
[codex] Fix Claude CLI spawn on Windows

### DIFF
--- a/src-tauri/src/commands/claude_cli.rs
+++ b/src-tauri/src/commands/claude_cli.rs
@@ -17,6 +17,7 @@
 //! capabilities JSON.
 
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::process::Stdio;
 use std::sync::Arc;
 use std::time::Duration;
@@ -52,19 +53,33 @@ pub struct ClaudeMessage {
     content: String,
 }
 
+fn find_claude_command() -> Result<PathBuf, String> {
+    #[cfg(windows)]
+    {
+        if let Ok(path) = which::which("claude.cmd") {
+            return Ok(path);
+        }
+        if let Ok(path) = which::which("claude.exe") {
+            return Ok(path);
+        }
+    }
+
+    which::which("claude").map_err(|_| "`claude` not found on PATH".to_string())
+}
+
 /// Locate `claude` on PATH and confirm it's runnable by calling
 /// `claude --version` with a short timeout. Cheap — safe to call on
 /// mount of the settings panel.
 #[tauri::command]
 pub async fn claude_cli_detect() -> Result<DetectResult, String> {
-    let path = match which::which("claude") {
+    let path = match find_claude_command() {
         Ok(p) => p,
-        Err(_) => {
+        Err(error) => {
             return Ok(DetectResult {
                 installed: false,
                 version: None,
                 path: None,
-                error: Some("`claude` not found on PATH".to_string()),
+                error: Some(error),
             });
         }
     };
@@ -172,7 +187,8 @@ pub async fn claude_cli_spawn(
         })
         .collect();
 
-    let mut cmd = Command::new("claude");
+    let claude = find_claude_command()?;
+    let mut cmd = Command::new(&claude);
     cmd.arg("-p")
         .arg("--output-format")
         .arg("stream-json")
@@ -235,11 +251,7 @@ pub async fn claude_cli_spawn(
     drop(stdin);
 
     // Register the child so `claude_cli_kill` can reach it.
-    state
-        .children
-        .lock()
-        .await
-        .insert(stream_id.clone(), child);
+    state.children.lock().await.insert(stream_id.clone(), child);
 
     let children = Arc::clone(&state.children);
     let app_for_task = app.clone();
@@ -327,4 +339,3 @@ pub async fn claude_cli_kill(
     }
     Ok(())
 }
-


### PR DESCRIPTION
## Summary

Fixes the Claude Code CLI provider on Windows when Settings detects a local `claude` install but chat fails with `Claude Code CLI not found`.

## Root Cause

The Settings health check resolved the CLI through `which::which("claude")`, but the chat transport spawned a bare `Command::new("claude")`. On Windows, the npm install usually exposes `claude.cmd` / `claude.ps1` shims and a real `claude.exe`; Rust/Tauri process spawning does not behave like PowerShell command resolution, so detection could pass while chat spawn failed.

## Changes

- Add a shared `find_claude_command()` helper for Claude CLI resolution.
- Prefer `claude.cmd` and `claude.exe` on Windows, then fall back to `claude` for other platforms.
- Use the same resolved path for both detection and chat subprocess spawn.

## Validation

- `rustfmt --edition 2021 --check src\commands\claude_cli.rs` passes.
- `cargo check --quiet` could not complete locally because the installed toolchain is `rustc 1.90.0`, while `lancedb` / `lance` dependencies require `rustc 1.91.0`.

Closes #106.

Related: #86.