### PR TITLE
Add OAuth-backed CLI providers

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -40,7 +40,7 @@ futures = "0.3"
 # Claude Code CLI subprocess transport: spawn `claude` as a child process,
 # stream stdout line-by-line back to the frontend. tokio::process gives us
 # async io and clean cancellation; `which` locates the binary on PATH.
-tokio = { version = "1", features = ["process", "io-util", "sync", "macros", "rt"] }
+tokio = { version = "1", features = ["process", "io-util", "sync", "macros", "rt", "fs"] }
 which = "7"
 uuid = { version = "1", features = ["v4"] }
 # Multimodal image extraction (Phase 1):

--- a/src-tauri/src/commands/claude_cli.rs
+++ b/src-tauri/src/commands/claude_cli.rs
@@ -18,7 +18,7 @@
 
 use std::collections::HashMap;
 use std::path::PathBuf;
-use std::process::Stdio;
+use std::process::{Command as StdCommand, Stdio};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -136,6 +136,71 @@ pub async fn claude_cli_detect() -> Result<DetectResult, String> {
             error: Some("`claude --version` timed out after 3s".to_string()),
         }),
     }
+}
+
+/// Open an interactive terminal running `claude` so the Claude Code CLI
+/// can complete or refresh its browser OAuth flow. We intentionally do
+/// not handle tokens in LLM Wiki; the official CLI owns credential
+/// storage under ~/.claude and this app only reuses the authenticated
+/// subprocess transport after login succeeds.
+#[tauri::command]
+pub async fn claude_cli_open_login() -> Result<(), String> {
+    let claude = find_claude_command()?;
+    let claude_display = claude.to_string_lossy().to_string();
+
+    #[cfg(target_os = "macos")]
+    {
+        let script = format!(
+            r#"tell application "Terminal"
+    activate
+    do script "{}"
+end tell"#,
+            shell_quote(&claude_display)
+        );
+        StdCommand::new("osascript")
+            .arg("-e")
+            .arg(script)
+            .spawn()
+            .map_err(|e| format!("Failed to open Terminal for Claude OAuth login: {e}"))?;
+        return Ok(());
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        StdCommand::new("cmd")
+            .args(["/C", "start", "", "cmd", "/K", &claude_display])
+            .spawn()
+            .map_err(|e| format!("Failed to open Command Prompt for Claude OAuth login: {e}"))?;
+        return Ok(());
+    }
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        let command = format!("{}; exec $SHELL", shell_quote(&claude_display));
+        let terminals: [(&str, &[&str]); 4] = [
+            ("x-terminal-emulator", &["-e", "sh", "-lc"]),
+            ("gnome-terminal", &["--", "sh", "-lc"]),
+            ("konsole", &["-e", "sh", "-lc"]),
+            ("xterm", &["-e", "sh", "-lc"]),
+        ];
+
+        for (terminal, args) in terminals {
+            let Ok(path) = which::which(terminal) else {
+                continue;
+            };
+            let mut cmd = StdCommand::new(path);
+            cmd.args(args).arg(&command);
+            if cmd.spawn().is_ok() {
+                return Ok(());
+            }
+        }
+
+        Err("No supported terminal emulator found. Run `claude` in a terminal to complete OAuth login.".to_string())
+    }
+}
+
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\"'\"'"))
 }
 
 /// Spawn `claude -p --output-format stream-json --input-format stream-json

--- a/src-tauri/src/commands/local_cli.rs
+++ b/src-tauri/src/commands/local_cli.rs
@@ -1,0 +1,329 @@
+//! Local OAuth-backed CLI transports for providers that do not expose a
+//! stable desktop-app OAuth token we should handle directly.
+//!
+//! GPT uses the official Codex CLI login (`codex login` / ChatGPT OAuth).
+//! Gemini / Antigravity uses the official Gemini CLI login path. LLM Wiki
+//! never reads or stores their tokens; it only spawns the vendor CLI.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::process::{Command as StdCommand, Stdio};
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Emitter, State};
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::process::{Child, Command};
+use tokio::sync::Mutex;
+
+#[derive(Default)]
+pub struct LocalCliState {
+    children: Arc<Mutex<HashMap<String, Child>>>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum LocalCliProvider {
+    CodexCli,
+    GeminiCli,
+}
+
+#[derive(Deserialize)]
+pub struct LocalCliMessage {
+    role: String,
+    content: String,
+}
+
+#[derive(Serialize)]
+pub struct LocalCliDetectResult {
+    installed: bool,
+    version: Option<String>,
+    path: Option<String>,
+    auth_status: Option<String>,
+    error: Option<String>,
+}
+
+fn command_name(provider: &LocalCliProvider) -> &'static str {
+    match provider {
+        LocalCliProvider::CodexCli => "codex",
+        LocalCliProvider::GeminiCli => "gemini",
+    }
+}
+
+fn find_command(provider: &LocalCliProvider) -> Result<PathBuf, String> {
+    which::which(command_name(provider))
+        .map_err(|_| format!("`{}` not found on PATH", command_name(provider)))
+}
+
+#[tauri::command]
+pub async fn local_cli_detect(provider: LocalCliProvider) -> Result<LocalCliDetectResult, String> {
+    let path = match find_command(&provider) {
+        Ok(p) => p,
+        Err(error) => {
+            return Ok(LocalCliDetectResult {
+                installed: false,
+                version: None,
+                path: None,
+                auth_status: None,
+                error: Some(error),
+            });
+        }
+    };
+    let path_str = path.to_string_lossy().to_string();
+
+    let version = tokio::time::timeout(
+        Duration::from_secs(3),
+        Command::new(&path).arg("--version").output(),
+    )
+    .await
+    .ok()
+    .and_then(Result::ok)
+    .filter(|out| out.status.success())
+    .map(|out| String::from_utf8_lossy(&out.stdout).trim().to_string())
+    .filter(|s| !s.is_empty());
+
+    let auth_status = match provider {
+        LocalCliProvider::CodexCli => {
+            let out = tokio::time::timeout(
+                Duration::from_secs(3),
+                Command::new(&path).args(["login", "status"]).output(),
+            )
+            .await;
+            match out {
+                Ok(Ok(out)) => {
+                    let stdout = String::from_utf8_lossy(&out.stdout).trim().to_string();
+                    let stderr = String::from_utf8_lossy(&out.stderr).trim().to_string();
+                    Some(if stdout.is_empty() { stderr } else { stdout }).filter(|s| !s.is_empty())
+                }
+                _ => None,
+            }
+        }
+        // Gemini CLI currently exposes login through its interactive UI,
+        // but no cheap stable auth-status subcommand.
+        LocalCliProvider::GeminiCli => None,
+    };
+
+    Ok(LocalCliDetectResult {
+        installed: true,
+        version,
+        path: Some(path_str),
+        auth_status,
+        error: None,
+    })
+}
+
+#[tauri::command]
+pub async fn local_cli_open_login(provider: LocalCliProvider) -> Result<(), String> {
+    let path = find_command(&provider)?;
+    let command = match provider {
+        LocalCliProvider::CodexCli => {
+            format!("{} login", shell_quote(&path.to_string_lossy()))
+        }
+        LocalCliProvider::GeminiCli => shell_quote(&path.to_string_lossy()),
+    };
+    open_terminal(&command)
+}
+
+fn open_terminal(command: &str) -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    {
+        let script = format!(
+            r#"tell application "Terminal"
+    activate
+    do script "{}"
+end tell"#,
+            command.replace('\\', "\\\\").replace('"', "\\\"")
+        );
+        StdCommand::new("osascript")
+            .arg("-e")
+            .arg(script)
+            .spawn()
+            .map_err(|e| format!("Failed to open Terminal for OAuth login: {e}"))?;
+        return Ok(());
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        StdCommand::new("cmd")
+            .args(["/C", "start", "", "cmd", "/K", command])
+            .spawn()
+            .map_err(|e| format!("Failed to open Command Prompt for OAuth login: {e}"))?;
+        return Ok(());
+    }
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        let command = format!("{command}; exec $SHELL");
+        let terminals: [(&str, &[&str]); 4] = [
+            ("x-terminal-emulator", &["-e", "sh", "-lc"]),
+            ("gnome-terminal", &["--", "sh", "-lc"]),
+            ("konsole", &["-e", "sh", "-lc"]),
+            ("xterm", &["-e", "sh", "-lc"]),
+        ];
+
+        for (terminal, args) in terminals {
+            let Ok(path) = which::which(terminal) else {
+                continue;
+            };
+            let mut cmd = StdCommand::new(path);
+            cmd.args(args).arg(&command);
+            if cmd.spawn().is_ok() {
+                return Ok(());
+            }
+        }
+
+        Err("No supported terminal emulator found. Run the provider CLI in a terminal to complete OAuth login.".to_string())
+    }
+}
+
+#[tauri::command]
+pub async fn local_cli_spawn(
+    app: AppHandle,
+    state: State<'_, LocalCliState>,
+    stream_id: String,
+    provider: LocalCliProvider,
+    model: String,
+    messages: Vec<LocalCliMessage>,
+) -> Result<(), String> {
+    let exe = find_command(&provider)?;
+    let prompt = render_prompt(&messages);
+    if prompt.trim().is_empty() {
+        return Err("No prompt content to send to local CLI".to_string());
+    }
+
+    let mut cmd = Command::new(exe);
+    let mut output_file: Option<PathBuf> = None;
+    match provider {
+        LocalCliProvider::CodexCli => {
+            let path = std::env::temp_dir().join(format!("llm-wiki-codex-{stream_id}.txt"));
+            cmd.arg("exec")
+                .arg("--skip-git-repo-check")
+                .arg("--sandbox")
+                .arg("read-only")
+                .arg("-c")
+                .arg("mcp_servers={}")
+                .arg("-m")
+                .arg(&model)
+                .arg("-o")
+                .arg(&path)
+                .arg(&prompt);
+            output_file = Some(path);
+        }
+        LocalCliProvider::GeminiCli => {
+            cmd.arg("--model")
+                .arg(&model)
+                .arg("--output-format")
+                .arg("text")
+                .arg(prompt);
+        }
+    }
+
+    cmd.stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+
+    let mut child = cmd
+        .spawn()
+        .map_err(|e| format!("Failed to spawn local CLI: {e}"))?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| "Missing stdout handle".to_string())?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| "Missing stderr handle".to_string())?;
+
+    state.children.lock().await.insert(stream_id.clone(), child);
+
+    let children = Arc::clone(&state.children);
+    let topic = format!("local-cli:{stream_id}");
+    let done_topic = format!("local-cli:{stream_id}:done");
+    let stream_id_task = stream_id.clone();
+    let output_file_task = output_file.clone();
+
+    tokio::spawn(async move {
+        let mut stdout_reader = BufReader::new(stdout).lines();
+        let mut stderr_reader = BufReader::new(stderr).lines();
+        let app_for_stdout = app.clone();
+        let topic_for_stdout = topic.clone();
+
+        let stdout_task = tokio::spawn(async move {
+            let mut collected = String::new();
+            while let Ok(Some(line)) = stdout_reader.next_line().await {
+                collected.push_str(&line);
+                collected.push('\n');
+                let _ = app_for_stdout.emit(&topic_for_stdout, line);
+            }
+            collected
+        });
+
+        let stderr_task = tokio::spawn(async move {
+            let mut collected = String::new();
+            while let Ok(Some(line)) = stderr_reader.next_line().await {
+                eprintln!("[local-cli stderr] {line}");
+                collected.push_str(&line);
+                collected.push('\n');
+            }
+            collected
+        });
+
+        let child_opt = children.lock().await.remove(&stream_id_task);
+        let exit_code = if let Some(mut child) = child_opt {
+            match child.wait().await {
+                Ok(status) => status.code(),
+                Err(_) => None,
+            }
+        } else {
+            None
+        };
+
+        let mut stdout_text = stdout_task.await.unwrap_or_default();
+        if let Some(path) = output_file_task {
+            if let Ok(text) = tokio::fs::read_to_string(&path).await {
+                if !text.trim().is_empty() {
+                    stdout_text.push_str("\n--- out ---\n");
+                    stdout_text.push_str(&text);
+                }
+            }
+            let _ = tokio::fs::remove_file(path).await;
+        }
+        let stderr_text = stderr_task.await.unwrap_or_default();
+
+        let _ = app.emit(
+            &done_topic,
+            serde_json::json!({
+                "code": exit_code,
+                "stdout": stdout_text,
+                "stderr": stderr_text,
+            }),
+        );
+    });
+
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn local_cli_kill(
+    state: State<'_, LocalCliState>,
+    stream_id: String,
+) -> Result<(), String> {
+    if let Some(mut child) = state.children.lock().await.remove(&stream_id) {
+        let _ = child.start_kill();
+    }
+    Ok(())
+}
+
+fn render_prompt(messages: &[LocalCliMessage]) -> String {
+    messages
+        .iter()
+        .map(|m| format!("{}:\n{}", m.role.to_uppercase(), m.content))
+        .collect::<Vec<_>>()
+        .join("\n\n")
+}
+
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\"'\"'"))
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod claude_cli;
 pub mod extract_images;
 pub mod fs;
+pub mod local_cli;
 pub mod project;
 pub mod vectorstore;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -73,6 +73,7 @@ pub fn run() {
             // frontend-generated stream id. Populated by claude_cli_spawn,
             // drained on process exit or by claude_cli_kill.
             app.manage(commands::claude_cli::ClaudeCliState::default());
+            app.manage(commands::local_cli::LocalCliState::default());
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
@@ -101,8 +102,13 @@ pub fn run() {
             commands::vectorstore::vector_legacy_row_count,
             commands::vectorstore::vector_drop_legacy,
             commands::claude_cli::claude_cli_detect,
+            commands::claude_cli::claude_cli_open_login,
             commands::claude_cli::claude_cli_spawn,
             commands::claude_cli::claude_cli_kill,
+            commands::local_cli::local_cli_detect,
+            commands::local_cli::local_cli_open_login,
+            commands::local_cli::local_cli_spawn,
+            commands::local_cli::local_cli_kill,
             commands::extract_images::extract_pdf_images_cmd,
             commands::extract_images::extract_office_images_cmd,
             commands::extract_images::extract_and_save_pdf_images_cmd,

--- a/src/components/settings/llm-presets.ts
+++ b/src/components/settings/llm-presets.ts
@@ -16,6 +16,8 @@ export type Provider =
   | "custom"
   | "minimax"
   | "claude-code"
+  | "codex-cli"
+  | "gemini-cli"
 
 export interface LlmPreset {
   /** Stable id used as the dropdown value. */
@@ -52,6 +54,35 @@ export interface LlmPreset {
 }
 
 export const LLM_PRESETS: LlmPreset[] = [
+  {
+    id: "codex-cli",
+    label: "Codex CLI (GPT OAuth)",
+    hint: "Uses local `codex login` / ChatGPT OAuth — no API key needed",
+    provider: "codex-cli",
+    defaultModel: "gpt-5.1-codex-mini",
+    suggestedModels: [
+      "gpt-5.1-codex-mini",
+      "gpt-5.1-codex",
+      "gpt-5.1",
+      "gpt-5-mini",
+      "o3",
+    ],
+    suggestedContextSize: 128000,
+  },
+  {
+    id: "gemini-cli-oauth",
+    label: "Gemini CLI (Antigravity OAuth)",
+    hint: "Uses local `gemini` Google OAuth — no API key needed",
+    provider: "gemini-cli",
+    defaultModel: "gemini-2.5-flash",
+    suggestedModels: [
+      "gemini-2.5-pro",
+      "gemini-2.5-flash",
+      "gemini-2.5-flash-lite",
+      "gemini-2.0-flash",
+    ],
+    suggestedContextSize: 1000000,
+  },
   {
     id: "anthropic",
     label: "Anthropic (Claude)",

--- a/src/components/settings/preset-resolver.ts
+++ b/src/components/settings/preset-resolver.ts
@@ -54,6 +54,17 @@ export function resolveConfig(
     }
   }
 
+  if (preset.provider === "codex-cli" || preset.provider === "gemini-cli") {
+    return {
+      provider: preset.provider,
+      apiKey: "",
+      model,
+      ollamaUrl: fallback.ollamaUrl,
+      customEndpoint: fallback.customEndpoint,
+      maxContextSize,
+    }
+  }
+
   // openai / anthropic / google / minimax — use fixed endpoint baked into the
   // provider dispatch. We still let users override baseUrl via apiKey env if
   // needed by editing manually, but presets for these don't expose it.

--- a/src/components/settings/sections/llm-provider-section.tsx
+++ b/src/components/settings/sections/llm-provider-section.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react"
-import { ChevronDown, ChevronRight, AlertCircle, CheckCircle2, Loader2, XCircle } from "lucide-react"
+import { ChevronDown, ChevronRight, AlertCircle, CheckCircle2, Loader2, LogIn, XCircle } from "lucide-react"
 import { useTranslation } from "react-i18next"
 import { invoke } from "@tauri-apps/api/core"
 import { Input } from "@/components/ui/input"
@@ -122,7 +122,7 @@ function PresetRow({
   // Claude Code CLI authenticates via the user's existing ~/.claude OAuth
   // (inherited from the spawned subprocess), so no API key field is
   // shown. Ollama ditto for its local-only model.
-  const needsApiKey = preset.provider !== "ollama" && preset.provider !== "claude-code"
+  const needsApiKey = !["ollama", "claude-code", "codex-cli", "gemini-cli"].includes(preset.provider)
 
   return (
     <div
@@ -246,6 +246,9 @@ function PresetRow({
           )}
 
           {preset.provider === "claude-code" && <ClaudeCliStatusPill />}
+          {(preset.provider === "codex-cli" || preset.provider === "gemini-cli") && (
+            <LocalCliStatusPill provider={preset.provider} />
+          )}
 
           {needsApiKey && (
             <div className="space-y-2">
@@ -426,6 +429,136 @@ interface DetectResult {
   error: string | null
 }
 
+interface LocalCliDetectResult extends DetectResult {
+  auth_status: string | null
+}
+
+function LocalCliStatusPill({ provider }: { provider: "codex-cli" | "gemini-cli" }) {
+  const [state, setState] = useState<"loading" | "ok" | "err">("loading")
+  const [result, setResult] = useState<LocalCliDetectResult | null>(null)
+  const [loginState, setLoginState] = useState<"idle" | "opening" | "opened" | "err">("idle")
+  const [loginError, setLoginError] = useState<string | null>(null)
+  const label = provider === "codex-cli" ? "Codex CLI" : "Gemini CLI"
+  const authText = provider === "codex-cli"
+    ? "Uses ChatGPT OAuth through `codex login`; LLM Wiki does not store OpenAI tokens."
+    : "Uses Google OAuth through the official Gemini CLI. Antigravity private tokens are not read or copied."
+
+  async function detect() {
+    setState("loading")
+    try {
+      const r = await invoke<LocalCliDetectResult>("local_cli_detect", { provider })
+      setResult(r)
+      setState(r.installed ? "ok" : "err")
+    } catch (e) {
+      setResult({
+        installed: false,
+        version: null,
+        path: null,
+        auth_status: null,
+        error: e instanceof Error ? e.message : String(e),
+      })
+      setState("err")
+    }
+  }
+
+  useEffect(() => {
+    void detect()
+  }, [provider])
+
+  async function openLogin() {
+    setLoginState("opening")
+    setLoginError(null)
+    try {
+      await invoke("local_cli_open_login", { provider })
+      setLoginState("opened")
+      setTimeout(() => setLoginState((cur) => (cur === "opened" ? "idle" : cur)), 3000)
+      setTimeout(() => void detect(), 1500)
+    } catch (e) {
+      setLoginError(e instanceof Error ? e.message : String(e))
+      setLoginState("err")
+    }
+  }
+
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-center gap-2">
+        <Label className="m-0">{label} status</Label>
+        <button
+          type="button"
+          onClick={() => void openLogin()}
+          className="inline-flex items-center gap-1 rounded border border-border px-2 py-0.5 text-xs text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+          disabled={loginState === "opening"}
+          title={`Open ${label} OAuth login in a terminal`}
+        >
+          {loginState === "opening" ? (
+            <Loader2 className="h-3 w-3 animate-spin" />
+          ) : (
+            <LogIn className="h-3 w-3" />
+          )}
+          {loginState === "opening" ? "Opening…" : "OAuth login"}
+        </button>
+        <button
+          type="button"
+          onClick={() => void detect()}
+          className="rounded border border-border px-2 py-0.5 text-xs text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+          disabled={state === "loading"}
+        >
+          {state === "loading" ? "Checking…" : "Re-check"}
+        </button>
+      </div>
+      <div
+        className={`flex items-start gap-1.5 rounded-md border px-2 py-1.5 text-xs ${
+          state === "ok"
+            ? "border-emerald-500/40 bg-emerald-500/5 text-emerald-700 dark:text-emerald-400"
+            : state === "err"
+              ? "border-rose-500/40 bg-rose-500/5 text-rose-700 dark:text-rose-400"
+              : "border-border bg-background/50 text-muted-foreground"
+        }`}
+      >
+        {state === "loading" && <Loader2 className="mt-0.5 h-3.5 w-3.5 shrink-0 animate-spin" />}
+        {state === "ok" && <CheckCircle2 className="mt-0.5 h-3.5 w-3.5 shrink-0" />}
+        {state === "err" && <XCircle className="mt-0.5 h-3.5 w-3.5 shrink-0" />}
+        <div className="min-w-0 flex-1 space-y-0.5">
+          {state === "loading" && <div>Detecting local {label} binary…</div>}
+          {state === "ok" && (
+            <>
+              <div>
+                Detected{result?.version ? ` ${result.version}` : ""}. No API key needed.
+              </div>
+              {result?.path && (
+                <div className="truncate font-mono text-[10px] text-muted-foreground">
+                  {result.path}
+                </div>
+              )}
+              {result?.auth_status && <div>{result.auth_status}</div>}
+              <div className="text-muted-foreground">{authText}</div>
+              {loginState === "opened" && (
+                <div className="text-emerald-600 dark:text-emerald-400">
+                  Terminal opened. Complete OAuth there, then re-check.
+                </div>
+              )}
+              {loginState === "err" && loginError && (
+                <div className="text-rose-600 dark:text-rose-400">{loginError}</div>
+              )}
+            </>
+          )}
+          {state === "err" && (
+            <>
+              <div>{result?.error ?? `${label} not available.`}</div>
+              <div className="text-muted-foreground">
+                Install the official {label}, then re-check.
+              </div>
+              {loginState === "err" && loginError && (
+                <div className="text-rose-600 dark:text-rose-400">{loginError}</div>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
 /**
  * Health-check pill for the Claude Code CLI provider. Auto-runs
  * `claude --version` on mount, with a refresh button for when the user
@@ -436,6 +569,8 @@ interface DetectResult {
 function ClaudeCliStatusPill() {
   const [state, setState] = useState<"loading" | "ok" | "err">("loading")
   const [result, setResult] = useState<DetectResult | null>(null)
+  const [loginState, setLoginState] = useState<"idle" | "opening" | "opened" | "err">("idle")
+  const [loginError, setLoginError] = useState<string | null>(null)
 
   async function detect() {
     setState("loading")
@@ -458,10 +593,38 @@ function ClaudeCliStatusPill() {
     void detect()
   }, [])
 
+  async function openLogin() {
+    setLoginState("opening")
+    setLoginError(null)
+    try {
+      await invoke("claude_cli_open_login")
+      setLoginState("opened")
+      setTimeout(() => setLoginState((cur) => (cur === "opened" ? "idle" : cur)), 3000)
+      setTimeout(() => void detect(), 1500)
+    } catch (e) {
+      setLoginError(e instanceof Error ? e.message : String(e))
+      setLoginState("err")
+    }
+  }
+
   return (
     <div className="space-y-1.5">
       <div className="flex items-center gap-2">
         <Label className="m-0">CLI status</Label>
+        <button
+          type="button"
+          onClick={() => void openLogin()}
+          className="inline-flex items-center gap-1 rounded border border-border px-2 py-0.5 text-xs text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+          disabled={loginState === "opening"}
+          title="Open Claude Code OAuth login in a terminal"
+        >
+          {loginState === "opening" ? (
+            <Loader2 className="h-3 w-3 animate-spin" />
+          ) : (
+            <LogIn className="h-3 w-3" />
+          )}
+          {loginState === "opening" ? "Opening…" : "OAuth login"}
+        </button>
         <button
           type="button"
           onClick={() => void detect()}
@@ -502,12 +665,17 @@ function ClaudeCliStatusPill() {
                   the resulting "Unauthenticated" exit-1 as a LLM
                   Wiki bug. */}
               <div className="text-muted-foreground">
-                If chat fails with an authentication error, run{" "}
-                <code className="rounded bg-background/60 px-1 py-0.5 font-mono text-[10px]">
-                  claude
-                </code>{" "}
-                in a terminal to refresh the OAuth login.
+                If chat fails with an authentication error, use OAuth login to refresh your
+                local Claude Code session.
               </div>
+              {loginState === "opened" && (
+                <div className="text-emerald-600 dark:text-emerald-400">
+                  Terminal opened. Complete the Claude OAuth flow there, then re-check.
+                </div>
+              )}
+              {loginState === "err" && loginError && (
+                <div className="text-rose-600 dark:text-rose-400">{loginError}</div>
+              )}
             </>
           )}
           {state === "err" && (
@@ -520,6 +688,9 @@ function ClaudeCliStatusPill() {
                 </code>{" "}
                 then re-check.
               </div>
+              {loginState === "err" && loginError && (
+                <div className="text-rose-600 dark:text-rose-400">{loginError}</div>
+              )}
             </>
           )}
         </div>

--- a/src/components/settings/settings-types.ts
+++ b/src/components/settings/settings-types.ts
@@ -8,7 +8,7 @@ import type { CustomApiMode } from "./llm-presets"
  */
 export interface SettingsDraft {
   // LLM provider
-  provider: "openai" | "anthropic" | "google" | "ollama" | "custom" | "minimax" | "claude-code"
+  provider: "openai" | "anthropic" | "google" | "ollama" | "custom" | "minimax" | "claude-code" | "codex-cli" | "gemini-cli"
   apiKey: string
   model: string
   ollamaUrl: string
@@ -29,7 +29,7 @@ export interface SettingsDraft {
   // Multimodal (image captioning at ingest time)
   multimodalEnabled: boolean
   multimodalUseMainLlm: boolean
-  multimodalProvider: "openai" | "anthropic" | "google" | "ollama" | "custom" | "minimax" | "claude-code"
+  multimodalProvider: "openai" | "anthropic" | "google" | "ollama" | "custom" | "minimax" | "claude-code" | "codex-cli" | "gemini-cli"
   multimodalApiKey: string
   multimodalModel: string
   multimodalOllamaUrl: string

--- a/src/lib/__tests__/llm-providers.test.ts
+++ b/src/lib/__tests__/llm-providers.test.ts
@@ -195,15 +195,19 @@ describe("parseGoogleLine — Gemini SSE parsing", () => {
 })
 
 describe("Claude Code CLI provider — not reachable via getProviderConfig", () => {
-  it("throws, because the subprocess transport dispatches one layer up in streamChat", () => {
+  it.each([
+    ["claude-code", "claude-sonnet-4-6"],
+    ["codex-cli", "gpt-5.1-codex-mini"],
+    ["gemini-cli", "gemini-2.5-flash"],
+  ] as const)("throws for %s, because the subprocess transport dispatches one layer up in streamChat", (provider, model) => {
     // If this ever stops throwing, someone wired claude-code into the
     // HTTP path by mistake — it has no URL/headers and would crash
     // silently inside fetch() otherwise.
     expect(() =>
       getProviderConfig({
-        provider: "claude-code",
+        provider,
         apiKey: "",
-        model: "claude-sonnet-4-6",
+        model,
         ollamaUrl: "",
         customEndpoint: "",
         maxContextSize: 200000,

--- a/src/lib/has-usable-llm.test.ts
+++ b/src/lib/has-usable-llm.test.ts
@@ -37,6 +37,18 @@ describe("hasUsableLlm", () => {
     ).toBe(true)
   })
 
+  it("returns true for codex-cli with no API key", () => {
+    expect(
+      hasUsableLlm({ provider: "codex-cli", apiKey: "" }),
+    ).toBe(true)
+  })
+
+  it("returns true for gemini-cli with no API key", () => {
+    expect(
+      hasUsableLlm({ provider: "gemini-cli", apiKey: "" }),
+    ).toBe(true)
+  })
+
   it("returns false for openai with no API key", () => {
     expect(
       hasUsableLlm({ provider: "openai", apiKey: "" }),
@@ -74,6 +86,8 @@ describe("hasUsableLlm", () => {
     expect(PROVIDERS_WITHOUT_KEY.has("ollama")).toBe(true)
     expect(PROVIDERS_WITHOUT_KEY.has("custom")).toBe(true)
     expect(PROVIDERS_WITHOUT_KEY.has("claude-code")).toBe(true)
+    expect(PROVIDERS_WITHOUT_KEY.has("codex-cli")).toBe(true)
+    expect(PROVIDERS_WITHOUT_KEY.has("gemini-cli")).toBe(true)
   })
 
   it("PROVIDERS_WITHOUT_KEY does not include hosted-API providers", () => {
@@ -96,6 +110,8 @@ describe("hasUsableLlm", () => {
       "custom",
       "minimax",
       "claude-code",
+      "codex-cli",
+      "gemini-cli",
     ]
     for (const p of allProviders) {
       const inNoKey = PROVIDERS_WITHOUT_KEY.has(p)

--- a/src/lib/has-usable-llm.ts
+++ b/src/lib/has-usable-llm.ts
@@ -12,6 +12,8 @@ export type LlmProvider = LlmConfig["provider"]
  *   - `claude-code` spawns the Claude Code CLI subprocess, which
  *     authenticates via the user's existing ~/.claude OAuth — no
  *     API key is needed (or accepted) at this layer.
+ *   - `codex-cli` and `gemini-cli` spawn official local CLIs that own
+ *     their OAuth state; LLM Wiki never stores those tokens.
  *
  * Hosted providers (openai, anthropic, google, minimax) require a
  * key from the user.
@@ -20,6 +22,8 @@ export const PROVIDERS_WITHOUT_KEY: ReadonlySet<LlmProvider> = new Set<LlmProvid
   "ollama",
   "custom",
   "claude-code",
+  "codex-cli",
+  "gemini-cli",
 ])
 
 /**

--- a/src/lib/llm-client.ts
+++ b/src/lib/llm-client.ts
@@ -25,6 +25,17 @@ async function streamViaClaudeCodeCli(
   return mod.streamClaudeCodeCli(config, messages, callbacks, signal, requestOverrides)
 }
 
+async function streamViaLocalCli(
+  config: LlmConfig,
+  messages: import("./llm-providers").ChatMessage[],
+  callbacks: StreamCallbacks,
+  signal?: AbortSignal,
+  requestOverrides?: RequestOverrides,
+) {
+  const mod = await import("./local-cli-transport")
+  return mod.streamLocalCli(config, messages, callbacks, signal, requestOverrides)
+}
+
 const DECODER = new TextDecoder()
 
 function parseLines(chunk: Uint8Array, buffer: string): [string[], string] {
@@ -56,6 +67,9 @@ export async function streamChat(
   // this provider because it has no URL/headers.
   if (config.provider === "claude-code") {
     return streamViaClaudeCodeCli(config, messages, callbacks, signal, requestOverrides)
+  }
+  if (config.provider === "codex-cli" || config.provider === "gemini-cli") {
+    return streamViaLocalCli(config, messages, callbacks, signal, requestOverrides)
   }
 
   const providerConfig = getProviderConfig(config)

--- a/src/lib/llm-providers.ts
+++ b/src/lib/llm-providers.ts
@@ -528,12 +528,15 @@ export function getProviderConfig(config: LlmConfig): ProviderConfig {
     }
 
     case "claude-code":
+    case "codex-cli":
+    case "gemini-cli":
       // Claude Code CLI uses a subprocess transport (stdin/stdout JSON
-      // stream), not HTTP. Dispatch happens one layer up in
-      // streamChat() before getProviderConfig is called. Reaching this
-      // branch means wiring is broken somewhere upstream.
+      // stream); Codex/Gemini CLI use a local non-streaming subprocess
+      // transport. Dispatch happens one layer up in streamChat() before
+      // getProviderConfig is called. Reaching this branch means wiring is
+      // broken somewhere upstream.
       throw new Error(
-        "claude-code provider uses subprocess transport; getProviderConfig should not be called for it",
+        `${provider} provider uses subprocess transport; getProviderConfig should not be called for it`,
       )
 
     case "custom": {

--- a/src/lib/local-cli-transport.ts
+++ b/src/lib/local-cli-transport.ts
@@ -1,0 +1,149 @@
+import { invoke } from "@tauri-apps/api/core"
+import { listen, type UnlistenFn } from "@tauri-apps/api/event"
+import type { LlmConfig } from "@/stores/wiki-store"
+import type { ChatMessage, ContentBlock, RequestOverrides } from "./llm-providers"
+import type { StreamCallbacks } from "./llm-client"
+
+type LocalCliProvider = "codex-cli" | "gemini-cli"
+
+type SpawnPayload = Record<string, unknown> & {
+  streamId: string
+  provider: LocalCliProvider
+  model: string
+  messages: Array<{ role: ChatMessage["role"]; content: string }>
+}
+
+function stringifyContent(content: string | ContentBlock[]): string {
+  if (typeof content === "string") return content
+  return content
+    .map((block) => block.type === "text" ? block.text : `[image: ${block.mediaType}]`)
+    .join("\n")
+}
+
+export async function streamLocalCli(
+  config: LlmConfig,
+  messages: ChatMessage[],
+  callbacks: StreamCallbacks,
+  signal?: AbortSignal,
+  overrides?: RequestOverrides,
+): Promise<void> {
+  const { onToken, onDone, onError } = callbacks
+  const provider = config.provider
+  if (provider !== "codex-cli" && provider !== "gemini-cli") {
+    onError(new Error(`Unsupported local CLI provider: ${String(provider)}`))
+    return
+  }
+
+  if (import.meta.env?.DEV && overrides) {
+    for (const key of ["temperature", "top_p", "top_k", "max_tokens", "stop"] as const) {
+      if (overrides[key] !== undefined) {
+        // eslint-disable-next-line no-console
+        console.warn(`[${provider}] ignoring unsupported override "${key}": CLI transport has no equivalent flag`)
+      }
+    }
+  }
+
+  const streamId = crypto.randomUUID()
+  let unlistenData: UnlistenFn | undefined
+  let unlistenDone: UnlistenFn | undefined
+  let finished = false
+  const stdoutLines: string[] = []
+
+  const cleanup = () => {
+    unlistenData?.()
+    unlistenDone?.()
+  }
+
+  const finishWith = (cb: () => void) => {
+    if (finished) return
+    finished = true
+    cleanup()
+    cb()
+  }
+
+  const abortListener = () => {
+    void invoke("local_cli_kill", { streamId }).catch(() => {})
+    finishWith(onDone)
+  }
+  signal?.addEventListener("abort", abortListener)
+
+  try {
+    unlistenData = await listen<string>(`local-cli:${streamId}`, (event) => {
+      const line = event.payload.trim()
+      if (line) stdoutLines.push(line)
+    })
+
+    unlistenDone = await listen<{ code: number | null; stdout: string; stderr: string }>(
+      `local-cli:${streamId}:done`,
+      (event) => {
+        const code = event.payload?.code
+        const stdout = event.payload?.stdout?.trim() || stdoutLines.join("\n").trim()
+        const stderr = event.payload?.stderr?.trim() ?? ""
+
+        if (code !== null && code !== undefined && code !== 0) {
+          finishWith(() => onError(new Error(buildLocalCliError(provider, code, stderr, stdout))))
+          return
+        }
+
+        const text = extractAssistantText(provider, stdout)
+        if (!text) {
+          finishWith(() => onError(new Error(`${provider} returned no assistant text.`)))
+          return
+        }
+        finishWith(() => {
+          onToken(text)
+          onDone()
+        })
+      },
+    )
+
+    const payload: SpawnPayload = {
+      streamId,
+      provider,
+      model: config.model,
+      messages: messages.map((m) => ({
+        role: m.role,
+        content: stringifyContent(m.content),
+      })),
+    }
+    await invoke("local_cli_spawn", payload)
+  } catch (err) {
+    finishWith(() => onError(err instanceof Error ? err : new Error(String(err))))
+  } finally {
+    signal?.removeEventListener("abort", abortListener)
+  }
+}
+
+function extractAssistantText(provider: LocalCliProvider, stdout: string): string {
+  if (provider === "codex-cli") {
+    // Codex writes the final answer into --output-last-message when
+    // available; older/failed runs may only have terminal output. The
+    // Rust side emits stdout either way, so strip common transcript
+    // noise before falling back to the raw capture.
+    const marker = "--- out ---"
+    const markerIndex = stdout.lastIndexOf(marker)
+    if (markerIndex >= 0) return stdout.slice(markerIndex + marker.length).trim()
+  }
+  return stdout.trim()
+}
+
+function buildLocalCliError(
+  provider: LocalCliProvider,
+  code: number,
+  stderr: string,
+  stdout: string,
+): string {
+  const providerName = provider === "codex-cli" ? "Codex CLI" : "Gemini CLI"
+  const authHint = provider === "codex-cli"
+    ? "Use OAuth login in Settings, or run `codex login` in a terminal."
+    : "Use OAuth login in Settings, or run `gemini` in a terminal and complete Google sign-in."
+
+  if (/unauth|auth|login|oauth|credential|not logged/i.test(`${stderr}\n${stdout}`)) {
+    return `${providerName} is not authenticated. ${authHint}`
+  }
+  return [
+    `${providerName} exited with code ${code}.`,
+    stderr ? `\n\nstderr:\n${stderr}` : "",
+    stdout ? `\n\nstdout:\n${stdout}` : "",
+  ].join("").trim()
+}

--- a/src/stores/wiki-store.ts
+++ b/src/stores/wiki-store.ts
@@ -10,7 +10,7 @@ import type { WikiProject, FileNode } from "@/types/wiki"
 export type CustomApiMode = "chat_completions" | "anthropic_messages"
 
 interface LlmConfig {
-  provider: "openai" | "anthropic" | "google" | "ollama" | "custom" | "minimax" | "claude-code"
+  provider: "openai" | "anthropic" | "google" | "ollama" | "custom" | "minimax" | "claude-code" | "codex-cli" | "gemini-cli"
   apiKey: string
   model: string
   ollamaUrl: string


### PR DESCRIPTION
## Summary

Adds OAuth-backed local CLI providers for users who want to reuse existing vendor login flows instead of entering API keys:

- `Codex CLI (GPT OAuth)` via the official `codex login` / ChatGPT OAuth flow
- `Gemini CLI (Antigravity OAuth)` via the official local `gemini` CLI Google OAuth flow
- explicit OAuth login buttons in the LLM provider settings panel
- a shared Tauri local CLI command layer and frontend transport for CLI-backed providers

This keeps LLM Wiki out of the token handling path: it opens or spawns the official CLIs and does not read or persist OAuth credentials.

## Notes

The new Codex/Gemini CLI transports are intentionally non-streaming for the first slice: the app receives the final CLI output and emits it as one assistant response. This keeps the OAuth-backed path simple and avoids depending on private web/IDE tokens.

## Validation

- `npm run build`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `npm run test:mocks` (`62` files, `988` tests)
