### PR TITLE
Add Codex CLI provider

### DIFF
--- a/src-tauri/src/commands/codex_cli.rs
+++ b/src-tauri/src/commands/codex_cli.rs
@@ -1,0 +1,234 @@
+//! Codex CLI subprocess transport.
+//!
+//! This mirrors the Claude Code CLI transport, but treats `codex` as a
+//! local completion engine via `codex exec --json`. The webview can only
+//! spawn this fixed command; it cannot execute arbitrary shell commands.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::process::Stdio;
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde::Serialize;
+use tauri::{AppHandle, Emitter, State};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{Child, Command};
+use tokio::sync::Mutex;
+
+#[derive(Default)]
+pub struct CodexCliState {
+    children: Arc<Mutex<HashMap<String, Child>>>,
+}
+
+#[derive(Serialize)]
+pub struct DetectResult {
+    installed: bool,
+    version: Option<String>,
+    path: Option<String>,
+    error: Option<String>,
+}
+
+fn find_codex_command() -> Result<PathBuf, String> {
+    #[cfg(windows)]
+    {
+        if let Ok(path) = which::which("codex.cmd") {
+            return Ok(path);
+        }
+        if let Ok(path) = which::which("codex.exe") {
+            return Ok(path);
+        }
+    }
+
+    which::which("codex").map_err(|_| "`codex` not found on PATH".to_string())
+}
+
+#[tauri::command]
+pub async fn codex_cli_detect() -> Result<DetectResult, String> {
+    let path = match find_codex_command() {
+        Ok(p) => p,
+        Err(error) => {
+            return Ok(DetectResult {
+                installed: false,
+                version: None,
+                path: None,
+                error: Some(error),
+            });
+        }
+    };
+
+    let path_str = path.to_string_lossy().to_string();
+    let output = tokio::time::timeout(
+        Duration::from_secs(3),
+        Command::new(&path).arg("--version").output(),
+    )
+    .await;
+
+    match output {
+        Ok(Ok(out)) if out.status.success() => {
+            let stdout = String::from_utf8_lossy(&out.stdout).trim().to_string();
+            Ok(DetectResult {
+                installed: true,
+                version: Some(stdout),
+                path: Some(path_str),
+                error: None,
+            })
+        }
+        Ok(Ok(out)) => {
+            let stderr = String::from_utf8_lossy(&out.stderr).trim().to_string();
+            Ok(DetectResult {
+                installed: false,
+                version: None,
+                path: Some(path_str),
+                error: Some(if stderr.is_empty() {
+                    format!("`codex --version` exited with {}", out.status)
+                } else {
+                    stderr
+                }),
+            })
+        }
+        Ok(Err(e)) => Ok(DetectResult {
+            installed: false,
+            version: None,
+            path: Some(path_str),
+            error: Some(format!("Failed to spawn `codex`: {e}")),
+        }),
+        Err(_) => Ok(DetectResult {
+            installed: false,
+            version: None,
+            path: Some(path_str),
+            error: Some("`codex --version` timed out after 3s".to_string()),
+        }),
+    }
+}
+
+#[tauri::command]
+pub async fn codex_cli_spawn(
+    app: AppHandle,
+    state: State<'_, CodexCliState>,
+    stream_id: String,
+    model: String,
+    prompt: String,
+) -> Result<(), String> {
+    if prompt.trim().is_empty() {
+        return Err("No prompt to send to codex CLI".to_string());
+    }
+
+    let codex = find_codex_command()?;
+    let mut cmd = Command::new(&codex);
+    cmd.arg("-a")
+        .arg("never")
+        .arg("exec")
+        .arg("--json")
+        .arg("--skip-git-repo-check")
+        .arg("--sandbox")
+        .arg("read-only")
+        .arg("--ephemeral")
+        .arg("--model")
+        .arg(&model)
+        .arg("-");
+
+    cmd.stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+
+    let mut child = cmd
+        .spawn()
+        .map_err(|e| format!("Failed to spawn codex: {e}"))?;
+
+    let mut stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| "Missing stdin handle".to_string())?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| "Missing stdout handle".to_string())?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| "Missing stderr handle".to_string())?;
+
+    stdin
+        .write_all(prompt.as_bytes())
+        .await
+        .map_err(|e| format!("Failed to write to codex stdin: {e}"))?;
+    stdin
+        .flush()
+        .await
+        .map_err(|e| format!("Failed to flush codex stdin: {e}"))?;
+    drop(stdin);
+
+    state.children.lock().await.insert(stream_id.clone(), child);
+
+    let children = Arc::clone(&state.children);
+    let app_for_task = app.clone();
+    let stream_id_task = stream_id.clone();
+    let topic = format!("codex-cli:{stream_id}");
+    let done_topic = format!("codex-cli:{stream_id}:done");
+
+    tokio::spawn(async move {
+        let mut reader = BufReader::new(stdout).lines();
+        let mut stderr_reader = BufReader::new(stderr).lines();
+        let app = app_for_task;
+
+        let stderr_task = tokio::spawn(async move {
+            let mut collected = String::new();
+            while let Ok(Some(line)) = stderr_reader.next_line().await {
+                eprintln!("[codex-cli stderr] {line}");
+                collected.push_str(&line);
+                collected.push('\n');
+            }
+            collected
+        });
+
+        loop {
+            match reader.next_line().await {
+                Ok(Some(line)) => {
+                    if app.emit(&topic, line).is_err() {
+                        break;
+                    }
+                }
+                Ok(None) => break,
+                Err(e) => {
+                    eprintln!("[codex-cli stdout] read error: {e}");
+                    break;
+                }
+            }
+        }
+
+        let child_opt = children.lock().await.remove(&stream_id_task);
+        let exit_code = if let Some(mut child) = child_opt {
+            match child.wait().await {
+                Ok(status) => status.code(),
+                Err(_) => None,
+            }
+        } else {
+            None
+        };
+
+        let stderr_text = stderr_task.await.unwrap_or_default();
+
+        let _ = app.emit(
+            &done_topic,
+            serde_json::json!({
+                "code": exit_code,
+                "stderr": stderr_text,
+            }),
+        );
+    });
+
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn codex_cli_kill(
+    state: State<'_, CodexCliState>,
+    stream_id: String,
+) -> Result<(), String> {
+    if let Some(mut child) = state.children.lock().await.remove(&stream_id) {
+        let _ = child.start_kill();
+    }
+    Ok(())
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod claude_cli;
+pub mod codex_cli;
 pub mod extract_images;
 pub mod file_sync;
 pub mod fs;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -73,6 +73,7 @@ pub fn run() {
             // frontend-generated stream id. Populated by claude_cli_spawn,
             // drained on process exit or by claude_cli_kill.
             app.manage(commands::claude_cli::ClaudeCliState::default());
+            app.manage(commands::codex_cli::CodexCliState::default());
             app.manage(commands::file_sync::FileSyncState::default());
             Ok(())
         })
@@ -105,6 +106,9 @@ pub fn run() {
             commands::claude_cli::claude_cli_detect,
             commands::claude_cli::claude_cli_spawn,
             commands::claude_cli::claude_cli_kill,
+            commands::codex_cli::codex_cli_detect,
+            commands::codex_cli::codex_cli_spawn,
+            commands::codex_cli::codex_cli_kill,
             commands::extract_images::extract_pdf_images_cmd,
             commands::extract_images::extract_office_images_cmd,
             commands::extract_images::extract_and_save_pdf_images_cmd,

--- a/src/components/settings/llm-presets.ts
+++ b/src/components/settings/llm-presets.ts
@@ -16,6 +16,7 @@ export type Provider =
   | "custom"
   | "minimax"
   | "claude-code"
+  | "codex-cli"
 
 export interface LlmPreset {
   /** Stable id used as the dropdown value. */
@@ -88,6 +89,21 @@ export const LLM_PRESETS: LlmPreset[] = [
       "claude-sonnet-4-6",
       "claude-sonnet-4-5-20250929",
       "claude-haiku-4-5-20251001",
+    ],
+    suggestedContextSize: 200000,
+  },
+  {
+    id: "codex-cli",
+    label: "Codex CLI (local)",
+    hint: "Uses the local `codex` binary — no API key needed",
+    provider: "codex-cli",
+    defaultModel: "gpt-5.4-mini",
+    suggestedModels: [
+      "gpt-5.4-mini",
+      "gpt-5.4",
+      "gpt-5.3-codex",
+      "gpt-5.3-codex-spark",
+      "gpt-5.2",
     ],
     suggestedContextSize: 200000,
   },

--- a/src/components/settings/preset-resolver.ts
+++ b/src/components/settings/preset-resolver.ts
@@ -44,11 +44,11 @@ export function resolveConfig(
     }
   }
 
-  if (preset.provider === "claude-code") {
+  if (preset.provider === "claude-code" || preset.provider === "codex-cli") {
     // Subprocess transport — no apiKey, no endpoint URL. Model id is
-    // passed straight to `claude --model`.
+    // passed straight to the local CLI's model flag.
     return {
-      provider: "claude-code",
+      provider: preset.provider,
       apiKey: "",
       model,
       ollamaUrl: fallback.ollamaUrl,

--- a/src/components/settings/sections/llm-provider-section.tsx
+++ b/src/components/settings/sections/llm-provider-section.tsx
@@ -120,10 +120,13 @@ function PresetRow({
   const context = ov.maxContextSize ?? preset.suggestedContextSize ?? 131072
   const reasoning = ov.reasoning ?? { mode: "auto" as const }
   const hasConfig = !!apiKey || !!ov.baseUrl || !!ov.model
-  // Claude Code CLI authenticates via the user's existing ~/.claude OAuth
-  // (inherited from the spawned subprocess), so no API key field is
-  // shown. Ollama ditto for its local-only model.
-  const needsApiKey = preset.provider !== "ollama" && preset.provider !== "claude-code"
+  // Local CLI providers authenticate via their own existing login state
+  // (inherited by the spawned subprocess), so no API key field is shown.
+  // Ollama ditto for its local-only model.
+  const needsApiKey =
+    preset.provider !== "ollama" &&
+    preset.provider !== "claude-code" &&
+    preset.provider !== "codex-cli"
 
   return (
     <div
@@ -247,6 +250,7 @@ function PresetRow({
           )}
 
           {preset.provider === "claude-code" && <ClaudeCliStatusPill />}
+          {preset.provider === "codex-cli" && <CodexCliStatusPill />}
 
           {needsApiKey && (
             <div className="space-y-2">
@@ -589,6 +593,96 @@ function ClaudeCliStatusPill() {
                 Install from{" "}
                 <code className="rounded bg-background/60 px-1 py-0.5 font-mono text-[10px]">
                   npm i -g @anthropic-ai/claude-code
+                </code>{" "}
+                then re-check.
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function CodexCliStatusPill() {
+  const [state, setState] = useState<"loading" | "ok" | "err">("loading")
+  const [result, setResult] = useState<DetectResult | null>(null)
+
+  async function detect() {
+    setState("loading")
+    try {
+      const r = await invoke<DetectResult>("codex_cli_detect")
+      setResult(r)
+      setState(r.installed ? "ok" : "err")
+    } catch (e) {
+      setResult({
+        installed: false,
+        version: null,
+        path: null,
+        error: e instanceof Error ? e.message : String(e),
+      })
+      setState("err")
+    }
+  }
+
+  useEffect(() => {
+    void detect()
+  }, [])
+
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-center gap-2">
+        <Label className="m-0">CLI status</Label>
+        <button
+          type="button"
+          onClick={() => void detect()}
+          className="rounded border border-border px-2 py-0.5 text-xs text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+          disabled={state === "loading"}
+        >
+          {state === "loading" ? "Checking…" : "Re-check"}
+        </button>
+      </div>
+      <div
+        className={`flex items-start gap-1.5 rounded-md border px-2 py-1.5 text-xs ${
+          state === "ok"
+            ? "border-emerald-500/40 bg-emerald-500/5 text-emerald-700 dark:text-emerald-400"
+            : state === "err"
+              ? "border-rose-500/40 bg-rose-500/5 text-rose-700 dark:text-rose-400"
+              : "border-border bg-background/50 text-muted-foreground"
+        }`}
+      >
+        {state === "loading" && <Loader2 className="mt-0.5 h-3.5 w-3.5 shrink-0 animate-spin" />}
+        {state === "ok" && <CheckCircle2 className="mt-0.5 h-3.5 w-3.5 shrink-0" />}
+        {state === "err" && <XCircle className="mt-0.5 h-3.5 w-3.5 shrink-0" />}
+        <div className="min-w-0 flex-1 space-y-0.5">
+          {state === "loading" && <div>Detecting local codex binary…</div>}
+          {state === "ok" && (
+            <>
+              <div>
+                Detected{result?.version ? ` ${result.version}` : ""}. Ready to use your local
+                Codex login — no API key needed.
+              </div>
+              {result?.path && (
+                <div className="truncate font-mono text-[10px] text-muted-foreground">
+                  {result.path}
+                </div>
+              )}
+              <div className="text-muted-foreground">
+                If chat fails with an authentication error, run{" "}
+                <code className="rounded bg-background/60 px-1 py-0.5 font-mono text-[10px]">
+                  codex
+                </code>{" "}
+                in a terminal to refresh the login.
+              </div>
+            </>
+          )}
+          {state === "err" && (
+            <>
+              <div>{result?.error ?? "codex CLI not available."}</div>
+              <div className="text-muted-foreground">
+                Install from{" "}
+                <code className="rounded bg-background/60 px-1 py-0.5 font-mono text-[10px]">
+                  npm install -g @openai/codex
                 </code>{" "}
                 then re-check.
               </div>

--- a/src/components/settings/settings-types.ts
+++ b/src/components/settings/settings-types.ts
@@ -9,7 +9,7 @@ import type { ReasoningConfig } from "@/stores/wiki-store"
  */
 export interface SettingsDraft {
   // LLM provider
-  provider: "openai" | "anthropic" | "google" | "ollama" | "custom" | "minimax" | "claude-code"
+  provider: "openai" | "anthropic" | "google" | "ollama" | "custom" | "minimax" | "claude-code" | "codex-cli"
   apiKey: string
   model: string
   ollamaUrl: string
@@ -31,7 +31,7 @@ export interface SettingsDraft {
   // Multimodal (image captioning at ingest time)
   multimodalEnabled: boolean
   multimodalUseMainLlm: boolean
-  multimodalProvider: "openai" | "anthropic" | "google" | "ollama" | "custom" | "minimax" | "claude-code"
+  multimodalProvider: "openai" | "anthropic" | "google" | "ollama" | "custom" | "minimax" | "claude-code" | "codex-cli"
   multimodalApiKey: string
   multimodalModel: string
   multimodalOllamaUrl: string

--- a/src/lib/__tests__/llm-providers.test.ts
+++ b/src/lib/__tests__/llm-providers.test.ts
@@ -212,6 +212,21 @@ describe("Claude Code CLI provider — not reachable via getProviderConfig", () 
   })
 })
 
+describe("Codex CLI provider — not reachable via getProviderConfig", () => {
+  it("throws, because the subprocess transport dispatches one layer up in streamChat", () => {
+    expect(() =>
+      getProviderConfig({
+        provider: "codex-cli",
+        apiKey: "",
+        model: "gpt-5.4-mini",
+        ollamaUrl: "",
+        customEndpoint: "",
+        maxContextSize: 200000,
+      } as RealLlmConfig),
+    ).toThrow(/subprocess transport/)
+  })
+})
+
 describe("Google provider URL — model path encoding", () => {
   const makeGoogleConfig = (model: string): RealLlmConfig => ({
     provider: "google",

--- a/src/lib/codex-cli-transport.test.ts
+++ b/src/lib/codex-cli-transport.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest"
+import { parseCodexCliLine } from "./codex-cli-transport"
+
+describe("parseCodexCliLine", () => {
+  it("extracts completed agent messages from Codex JSONL", () => {
+    expect(
+      parseCodexCliLine(
+        JSON.stringify({
+          type: "item.completed",
+          item: { type: "agent_message", text: "pong" },
+        }),
+      ),
+    ).toBe("pong")
+  })
+
+  it("ignores lifecycle events and malformed lines", () => {
+    expect(parseCodexCliLine('{"type":"turn.started"}')).toBeNull()
+    expect(parseCodexCliLine("not json")).toBeNull()
+  })
+})

--- a/src/lib/codex-cli-transport.ts
+++ b/src/lib/codex-cli-transport.ts
@@ -1,0 +1,161 @@
+/**
+ * Codex CLI subprocess transport.
+ *
+ * Rust-side counterpart: src-tauri/src/commands/codex_cli.rs. The Rust
+ * command spawns `codex exec --json`, sends a single reconstructed prompt
+ * over stdin, and emits each JSONL stdout line back as `codex-cli:{streamId}`.
+ */
+
+import { invoke } from "@tauri-apps/api/core"
+import { listen, type UnlistenFn } from "@tauri-apps/api/event"
+import type { LlmConfig } from "@/stores/wiki-store"
+import type { ChatMessage, ContentBlock, RequestOverrides } from "./llm-providers"
+import type { StreamCallbacks } from "./llm-client"
+
+export function parseCodexCliLine(rawLine: string): string | null {
+  const line = rawLine.trim()
+  if (!line) return null
+
+  let evt: unknown
+  try {
+    evt = JSON.parse(line)
+  } catch {
+    return null
+  }
+
+  if (!evt || typeof evt !== "object") return null
+  const obj = evt as Record<string, unknown>
+  if (obj.type !== "item.completed") return null
+
+  const item = obj.item as Record<string, unknown> | undefined
+  if (item?.type !== "agent_message") return null
+  return typeof item.text === "string" && item.text.length > 0 ? item.text : null
+}
+
+function contentToText(content: string | ContentBlock[]): string {
+  if (typeof content === "string") return content
+  return content
+    .map((block) => {
+      if (block.type === "text") return block.text
+      return `[Image omitted: ${block.mediaType}]`
+    })
+    .join("\n")
+}
+
+function buildPrompt(messages: ChatMessage[]): string {
+  return messages
+    .map((message) => {
+      const role = message.role.toUpperCase()
+      return `<${role}>\n${contentToText(message.content)}\n</${role}>`
+    })
+    .join("\n\n")
+}
+
+type SpawnPayload = Record<string, unknown> & {
+  streamId: string
+  model: string
+  prompt: string
+}
+
+export async function streamCodexCli(
+  config: LlmConfig,
+  messages: ChatMessage[],
+  callbacks: StreamCallbacks,
+  signal?: AbortSignal,
+  overrides?: RequestOverrides,
+): Promise<void> {
+  const { onToken, onDone, onError } = callbacks
+
+  if (import.meta.env?.DEV && overrides) {
+    for (const key of ["temperature", "top_p", "top_k", "max_tokens", "stop"] as const) {
+      if (overrides[key] !== undefined) {
+        // eslint-disable-next-line no-console
+        console.warn(`[codex-cli] ignoring unsupported override "${key}": CLI has no equivalent flag`)
+      }
+    }
+  }
+
+  const streamId = crypto.randomUUID()
+  let unlistenData: UnlistenFn | undefined
+  let unlistenDone: UnlistenFn | undefined
+  let finished = false
+
+  const unparsedLines: string[] = []
+  let unparsedSize = 0
+  function captureUnparsed(line: string) {
+    if (unparsedSize >= 4096) return
+    const trimmed = line.trim()
+    if (!trimmed) return
+    unparsedLines.push(line)
+    unparsedSize += line.length + 1
+  }
+
+  const cleanup = () => {
+    unlistenData?.()
+    unlistenDone?.()
+  }
+
+  const finishWith = (cb: () => void) => {
+    if (finished) return
+    finished = true
+    cleanup()
+    cb()
+  }
+
+  const abortListener = () => {
+    void invoke("codex_cli_kill", { streamId }).catch(() => {})
+    finishWith(onDone)
+  }
+  signal?.addEventListener("abort", abortListener)
+
+  try {
+    unlistenData = await listen<string>(`codex-cli:${streamId}`, (event) => {
+      const token = parseCodexCliLine(event.payload)
+      if (token !== null) {
+        onToken(token)
+      } else {
+        captureUnparsed(event.payload)
+      }
+    })
+
+    unlistenDone = await listen<{ code: number | null; stderr: string }>(
+      `codex-cli:${streamId}:done`,
+      (event) => {
+        const code = event.payload?.code
+        const stderr = event.payload?.stderr?.trim() ?? ""
+        if (code !== null && code !== undefined && code !== 0) {
+          const details = stderr || unparsedLines.join("\n")
+          finishWith(() =>
+            onError(new Error(
+              details
+                ? `Codex CLI exited with code ${code}:\n${details}`
+                : `Codex CLI exited with code ${code}. Run \`codex\` in a terminal to inspect the problem.`,
+            )),
+          )
+        } else {
+          finishWith(onDone)
+        }
+      },
+    )
+
+    const payload: SpawnPayload = {
+      streamId,
+      model: config.model,
+      prompt: buildPrompt(messages),
+    }
+    await invoke("codex_cli_spawn", payload)
+  } catch (err) {
+    finishWith(() => {
+      const message = err instanceof Error ? err.message : String(err)
+      if (/not found|No such file|executable file not found/i.test(message)) {
+        onError(new Error(
+          "Codex CLI not found. Install `codex` with `npm install -g @openai/codex` or pick a different provider.",
+        ))
+      } else {
+        onError(err instanceof Error ? err : new Error(message))
+      }
+    })
+  } finally {
+    signal?.removeEventListener("abort", abortListener)
+  }
+}

--- a/src/lib/has-usable-llm.test.ts
+++ b/src/lib/has-usable-llm.test.ts
@@ -37,6 +37,12 @@ describe("hasUsableLlm", () => {
     ).toBe(true)
   })
 
+  it("returns true for codex-cli with no API key", () => {
+    expect(
+      hasUsableLlm({ provider: "codex-cli", apiKey: "" }),
+    ).toBe(true)
+  })
+
   it("returns false for openai with no API key", () => {
     expect(
       hasUsableLlm({ provider: "openai", apiKey: "" }),
@@ -74,6 +80,7 @@ describe("hasUsableLlm", () => {
     expect(PROVIDERS_WITHOUT_KEY.has("ollama")).toBe(true)
     expect(PROVIDERS_WITHOUT_KEY.has("custom")).toBe(true)
     expect(PROVIDERS_WITHOUT_KEY.has("claude-code")).toBe(true)
+    expect(PROVIDERS_WITHOUT_KEY.has("codex-cli")).toBe(true)
   })
 
   it("PROVIDERS_WITHOUT_KEY does not include hosted-API providers", () => {
@@ -96,6 +103,7 @@ describe("hasUsableLlm", () => {
       "custom",
       "minimax",
       "claude-code",
+      "codex-cli",
     ]
     for (const p of allProviders) {
       const inNoKey = PROVIDERS_WITHOUT_KEY.has(p)

--- a/src/lib/has-usable-llm.ts
+++ b/src/lib/has-usable-llm.ts
@@ -12,6 +12,8 @@ export type LlmProvider = LlmConfig["provider"]
  *   - `claude-code` spawns the Claude Code CLI subprocess, which
  *     authenticates via the user's existing ~/.claude OAuth — no
  *     API key is needed (or accepted) at this layer.
+ *   - `codex-cli` spawns the Codex CLI subprocess, which authenticates
+ *     via the user's existing Codex/ChatGPT login.
  *
  * Hosted providers (openai, anthropic, google, minimax) require a
  * key from the user.
@@ -20,6 +22,7 @@ export const PROVIDERS_WITHOUT_KEY: ReadonlySet<LlmProvider> = new Set<LlmProvid
   "ollama",
   "custom",
   "claude-code",
+  "codex-cli",
 ])
 
 /**

--- a/src/lib/llm-client.ts
+++ b/src/lib/llm-client.ts
@@ -26,6 +26,17 @@ async function streamViaClaudeCodeCli(
   return mod.streamClaudeCodeCli(config, messages, callbacks, signal, requestOverrides)
 }
 
+async function streamViaCodexCli(
+  config: LlmConfig,
+  messages: import("./llm-providers").ChatMessage[],
+  callbacks: StreamCallbacks,
+  signal?: AbortSignal,
+  requestOverrides?: RequestOverrides,
+) {
+  const mod = await import("./codex-cli-transport")
+  return mod.streamCodexCli(config, messages, callbacks, signal, requestOverrides)
+}
+
 const DECODER = new TextDecoder()
 
 function parseLines(chunk: Uint8Array, buffer: string): [string[], string] {
@@ -57,6 +68,10 @@ export async function streamChat(
   // this provider because it has no URL/headers.
   if (config.provider === "claude-code") {
     return streamViaClaudeCodeCli(config, messages, callbacks, signal, requestOverrides)
+  }
+
+  if (config.provider === "codex-cli") {
+    return streamViaCodexCli(config, messages, callbacks, signal, requestOverrides)
   }
 
   const providerConfig = getProviderConfig(config)

--- a/src/lib/llm-providers.ts
+++ b/src/lib/llm-providers.ts
@@ -640,12 +640,13 @@ export function getProviderConfig(config: LlmConfig): ProviderConfig {
     }
 
     case "claude-code":
-      // Claude Code CLI uses a subprocess transport (stdin/stdout JSON
-      // stream), not HTTP. Dispatch happens one layer up in
+    case "codex-cli":
+      // Local CLI providers use subprocess transports (stdin/stdout JSON
+      // streams), not HTTP. Dispatch happens one layer up in
       // streamChat() before getProviderConfig is called. Reaching this
       // branch means wiring is broken somewhere upstream.
       throw new Error(
-        "claude-code provider uses subprocess transport; getProviderConfig should not be called for it",
+        `${provider} provider uses subprocess transport; getProviderConfig should not be called for it`,
       )
 
     case "custom": {

--- a/src/stores/wiki-store.ts
+++ b/src/stores/wiki-store.ts
@@ -16,7 +16,7 @@ export interface ReasoningConfig {
 }
 
 interface LlmConfig {
-  provider: "openai" | "anthropic" | "google" | "ollama" | "custom" | "minimax" | "claude-code"
+  provider: "openai" | "anthropic" | "google" | "ollama" | "custom" | "minimax" | "claude-code" | "codex-cli"
   apiKey: string
   model: string
   ollamaUrl: string


### PR DESCRIPTION
## Summary
- add a local Codex CLI provider preset that uses the existing \ login instead of an API key
- add a Tauri subprocess transport for \ with detect/spawn/kill commands
- wire the frontend streaming path, settings status pill, provider typing, and no-key provider checks

## Testing
- \
> llm-wiki@0.4.9 typecheck
> tsc --build --pretty
- \
> llm-wiki@0.4.9 test:mocks
> vitest run --exclude='**/*.real-llm.test.ts' --run src/lib/codex-cli-transport.test.ts src/lib/has-usable-llm.test.ts src/lib/__tests__/llm-providers.test.ts


 RUN  v4.1.4 /Users/zhuyuxiang/Projects/LLM-wiki/llm_wiki_repo


 Test Files  3 passed (3)
      Tests  53 passed (53)
   Start at  13:19:06
   Duration  287ms (transform 225ms, setup 118ms, import 192ms, tests 19ms, environment 0ms)
- \
> llm-wiki@0.4.9 build
> npm run typecheck && vite build


> llm-wiki@0.4.9 typecheck
> tsc --build --pretty

vite v8.0.3 building client environment for production...
[2Ktransforming...✓ 4235 modules transformed.
rendering chunks...
computing gzip size...
dist/index.html                                             2.46 kB │ gzip:   0.69 kB
dist/assets/KaTeX_Size3-Regular-CTq5MqoE.woff               4.42 kB
dist/assets/KaTeX_Size4-Regular-Dl5lxZxV.woff2              4.92 kB
dist/assets/KaTeX_Size2-Regular-Dy4dx90m.woff2              5.20 kB
dist/assets/KaTeX_Size1-Regular-mCD8mA8B.woff2              5.46 kB
dist/assets/KaTeX_Size4-Regular-BF-4gkZK.woff               5.98 kB
dist/assets/KaTeX_Size2-Regular-oD1tc_U0.woff               6.18 kB
dist/assets/KaTeX_Size1-Regular-C195tn64.woff               6.49 kB
dist/assets/KaTeX_Caligraphic-Regular-Di6jR-x-.woff2        6.90 kB
dist/assets/KaTeX_Caligraphic-Bold-Dq_IR9rO.woff2           6.91 kB
dist/assets/KaTeX_Size3-Regular-DgpXs0kz.ttf                7.58 kB
dist/assets/KaTeX_Caligraphic-Regular-CTRA-rTL.woff         7.65 kB
dist/assets/KaTeX_Caligraphic-Bold-BEiXGLvX.woff            7.71 kB
dist/assets/KaTeX_Script-Regular-D3wIWfF6.woff2             9.64 kB
dist/assets/KaTeX_SansSerif-Regular-DDBCnlJ7.woff2         10.34 kB
dist/assets/KaTeX_Size4-Regular-DWFBv043.ttf               10.36 kB
dist/assets/KaTeX_Script-Regular-D5yQViql.woff             10.58 kB
dist/assets/KaTeX_Fraktur-Regular-CTYiF6lA.woff2           11.31 kB
dist/assets/KaTeX_Fraktur-Bold-CL6g_b3V.woff2              11.34 kB
dist/assets/KaTeX_Size2-Regular-B7gKUWhC.ttf               11.50 kB
dist/assets/KaTeX_SansSerif-Italic-C3H0VqGB.woff2          12.02 kB
dist/assets/KaTeX_SansSerif-Bold-D1sUS0GD.woff2            12.21 kB
dist/assets/KaTeX_Size1-Regular-Dbsnue_I.ttf               12.22 kB
dist/assets/KaTeX_SansSerif-Regular-CS6fqUqJ.woff          12.31 kB
dist/assets/KaTeX_Caligraphic-Regular-wX97UBjC.ttf         12.34 kB
dist/assets/KaTeX_Caligraphic-Bold-ATXxdsX0.ttf            12.36 kB
dist/assets/KaTeX_Fraktur-Regular-Dxdc4cR9.woff            13.20 kB
dist/assets/KaTeX_Fraktur-Bold-BsDP51OF.woff               13.29 kB
dist/assets/KaTeX_Typewriter-Regular-CO6r4hn1.woff2        13.56 kB
dist/assets/KaTeX_SansSerif-Italic-DN2j7dab.woff           14.11 kB
dist/assets/KaTeX_SansSerif-Bold-DbIhKOiC.woff             14.40 kB
dist/assets/geist-cyrillic-wght-normal-CHSlOQsW.woff2      14.69 kB
dist/assets/geist-latin-ext-wght-normal-DMtmJ5ZE.woff2     15.30 kB
dist/assets/KaTeX_Typewriter-Regular-C0xS9mPB.woff         16.02 kB
dist/assets/KaTeX_Math-BoldItalic-CZnvNsCZ.woff2           16.40 kB
dist/assets/KaTeX_Math-Italic-t53AETM-.woff2               16.44 kB
dist/assets/KaTeX_Script-Regular-C5JkGWo-.ttf              16.64 kB
dist/assets/KaTeX_Main-BoldItalic-DxDJ3AOS.woff2           16.78 kB
dist/assets/KaTeX_Main-Italic-NWA7e6Wa.woff2               16.98 kB
dist/assets/KaTeX_Math-BoldItalic-iY-2wyZ7.woff            18.66 kB
dist/assets/KaTeX_Math-Italic-DA0__PXp.woff                18.74 kB
dist/assets/KaTeX_Main-BoldItalic-SpSLRI95.woff            19.41 kB
dist/assets/KaTeX_SansSerif-Regular-BNo7hRIc.ttf           19.43 kB
dist/assets/KaTeX_Fraktur-Regular-CB_wures.ttf             19.57 kB
dist/assets/KaTeX_Fraktur-Bold-BdnERNNW.ttf                19.58 kB
dist/assets/KaTeX_Main-Italic-BMLOBm91.woff                19.67 kB
dist/assets/KaTeX_SansSerif-Italic-YYjJ1zSn.ttf            22.36 kB
dist/assets/KaTeX_SansSerif-Bold-CFMepnvq.ttf              24.50 kB
dist/assets/KaTeX_Main-Bold-Cx986IdX.woff2                 25.32 kB
dist/assets/KaTeX_Main-Regular-B22Nviop.woff2              26.27 kB
dist/assets/KaTeX_Typewriter-Regular-D3Ib7_Hf.ttf          27.55 kB
dist/assets/KaTeX_AMS-Regular-BQhdFMY1.woff2               28.07 kB
dist/assets/geist-latin-wght-normal-Dm3htQBi.woff2         28.40 kB
dist/assets/KaTeX_Main-Bold-Jm3AIy58.woff                  29.91 kB
dist/assets/logo-DuXFhhUB.jpg                              30.49 kB
dist/assets/KaTeX_Main-Regular-Dr94JaBh.woff               30.77 kB
dist/assets/KaTeX_Math-BoldItalic-B3XSjfu4.ttf             31.19 kB
dist/assets/KaTeX_Math-Italic-flOr_0UB.ttf                 31.30 kB
dist/assets/KaTeX_Main-BoldItalic-DzxPMmG6.ttf             32.96 kB
dist/assets/KaTeX_AMS-Regular-DMm9YOAa.woff                33.51 kB
dist/assets/KaTeX_Main-Italic-3WenGoN9.ttf                 33.58 kB
dist/assets/KaTeX_Main-Bold-waoOVXN0.ttf                   51.33 kB
dist/assets/KaTeX_Main-Regular-ypZvNtVU.ttf                53.58 kB
dist/assets/KaTeX_AMS-Regular-DRggAlZN.ttf                 63.63 kB
dist/assets/index-BXZNe86V.css                            123.52 kB │ gzip:  23.65 kB
dist/assets/ingest-EqGv7OqW.js                              0.06 kB │ gzip:   0.07 kB
dist/assets/llm-presets-DyBsRxNt.js                         0.06 kB │ gzip:   0.08 kB
dist/assets/preset-resolver-C_sJ6ZjH.js                     0.06 kB │ gzip:   0.08 kB
dist/assets/search-C9JSiMzr.js                              0.06 kB │ gzip:   0.08 kB
dist/assets/update-store-KAdhN41X.js                        0.06 kB │ gzip:   0.08 kB
dist/assets/wiki-store-5V6ZX2JJ.js                          0.07 kB │ gzip:   0.08 kB
dist/assets/clone-C3g6YeAR.js                               0.09 kB │ gzip:   0.10 kB
dist/assets/update-check-CrmtRX58.js                        0.10 kB │ gzip:   0.11 kB
dist/assets/array-o2rfyIz3.js                               0.10 kB │ gzip:   0.11 kB
dist/assets/channel-BZcFXpda.js                             0.11 kB │ gzip:   0.12 kB
dist/assets/pie-ZZUOXDRM-DO_cuJng.js                        0.11 kB │ gzip:   0.11 kB
dist/assets/info-OMHHGYJF-qFQ4wai5.js                       0.11 kB │ gzip:   0.11 kB
dist/assets/radar-PYXPWWZC-6yCKZVKU.js                      0.11 kB │ gzip:   0.12 kB
dist/assets/packet-4T2RLAQJ-uSJ0bOgN.js                     0.12 kB │ gzip:   0.12 kB
dist/assets/treemap-W4RFUUIX-BEnC21nC.js                    0.12 kB │ gzip:   0.12 kB
dist/assets/wardley-RL74JXVD-D1GioSMd.js                    0.12 kB │ gzip:   0.12 kB
dist/assets/gitGraph-7Q5UKJZL-DMSF_94e.js                   0.12 kB │ gzip:   0.12 kB
dist/assets/treeView-SZITEDCU-CYwnebjp.js                   0.12 kB │ gzip:   0.12 kB
dist/assets/architecture-YZFGNWBL-GTQZTpNc.js               0.12 kB │ gzip:   0.12 kB
dist/assets/has-usable-llm-BToNJYMe.js                      0.13 kB │ gzip:   0.14 kB
dist/assets/isSymbol-csiuvw5k.js                            0.14 kB │ gzip:   0.14 kB
dist/assets/init-8GNx5phc.js                                0.14 kB │ gzip:   0.12 kB
dist/assets/chunk-QZHKN3VN-xheSk9Md.js                      0.18 kB │ gzip:   0.15 kB
dist/assets/chunk-4BX2VUAB-D9IT3xe8.js                      0.21 kB │ gzip:   0.16 kB
dist/assets/chunk-55IACEB6-DTROcb7e.js                      0.22 kB │ gzip:   0.19 kB
dist/assets/dedup-queue-C0VmIJyu.js                         0.25 kB │ gzip:   0.18 kB
dist/assets/chunk-426QAEUC-BHtXE9gs.js                      0.27 kB │ gzip:   0.23 kB
dist/assets/chunk-FMBD7UC4-BDGT74vm.js                      0.35 kB │ gzip:   0.26 kB
dist/assets/ingest-queue-C4TwbSyn.js                        0.35 kB │ gzip:   0.22 kB
dist/assets/project-store-xCM1TnAo.js                       0.39 kB │ gzip:   0.24 kB
dist/assets/chunk-FOC6F5B3-BO2N9HLC.js                      0.45 kB │ gzip:   0.31 kB
dist/assets/chunk-2KRD3SAO-DscA3ljP.js                      0.45 kB │ gzip:   0.31 kB
dist/assets/chunk-67CJDMHE-Bmg8fGmn.js                      0.46 kB │ gzip:   0.32 kB
dist/assets/chunk-KGLVRYIC-B3bKrToH.js                      0.46 kB │ gzip:   0.31 kB
dist/assets/chunk-CIAEETIT-p8F23p3F.js                      0.50 kB │ gzip:   0.35 kB
dist/assets/chunk-EDXVE4YY-Cb9cXaUG.js                      0.53 kB │ gzip:   0.37 kB
dist/assets/chunk-AA7GKIK3-D1SMgBvB.js                      0.60 kB │ gzip:   0.39 kB
dist/assets/min-BOPoyCWI.js                                 0.61 kB │ gzip:   0.37 kB
dist/assets/infoDiagram-42DDH7IO-Dc3REY8t.js                0.61 kB │ gzip:   0.40 kB
dist/assets/tauri-fetch-BQSIUS3t.js                         0.62 kB │ gzip:   0.39 kB
dist/assets/chunk-ORNJ4GCN-CIIhEVGC.js                      0.65 kB │ gzip:   0.40 kB
dist/assets/stateDiagram-v2-QKLJ7IA2-XNSTAjmg.js            0.67 kB │ gzip:   0.40 kB
dist/assets/wiki-cleanup-0RBoj6Di.js                        0.71 kB │ gzip:   0.41 kB
dist/assets/classDiagram-6PBFFD2Q-U6798MiO.js               0.74 kB │ gzip:   0.43 kB
dist/assets/classDiagram-v2-HSJHXN6E-DjJHWOG6.js            0.74 kB │ gzip:   0.43 kB
dist/assets/isObject-D0A9g1OR.js                            0.74 kB │ gzip:   0.38 kB
dist/assets/chunk-CFjPhJqf.js                               0.87 kB │ gzip:   0.48 kB
dist/assets/chunk-7N4EOEYR-CmEDH82r.js                      0.90 kB │ gzip:   0.49 kB
dist/assets/line-DHA3jWs6.js                                0.94 kB │ gzip:   0.47 kB
dist/assets/chunk-ZZ45TVLE-DAt51nxD.js                      0.95 kB │ gzip:   0.58 kB
dist/assets/event-CluvUUj6.js                               0.95 kB │ gzip:   0.50 kB
dist/assets/core-i0BmTXcT.js                                1.08 kB │ gzip:   0.51 kB
dist/assets/ordinal-Ck2LSlNu.js                             1.17 kB │ gzip:   0.56 kB
dist/assets/preload-helper-CsoeaaUJ.js                      1.19 kB │ gzip:   0.68 kB
dist/assets/isEmpty-DHz93zic.js                             1.20 kB │ gzip:   0.65 kB
dist/assets/sources-merge-D5i-c5bM.js                       1.42 kB │ gzip:   0.70 kB
dist/assets/chunk-LIHQZDEY-Bx0OY_RC.js                      1.46 kB │ gzip:   0.78 kB
dist/assets/wiki-store-Bw-ipCg6.js                          1.48 kB │ gzip:   0.63 kB
dist/assets/dist-js-DHNxvq1O.js                             1.49 kB │ gzip:   0.50 kB
dist/assets/wiki-page-delete-DuPmNa8I.js                    1.53 kB │ gzip:   0.78 kB
dist/assets/codex-cli-transport-BU9QUTlK.js                 1.68 kB │ gzip:   0.93 kB
dist/assets/activity-store-fovN04rB.js                      1.70 kB │ gzip:   0.78 kB
dist/assets/chunk-X2U36JSP-_BQkE05h.js                      1.83 kB │ gzip:   0.89 kB
dist/assets/dist-js-C5CyNNB_.js                             1.86 kB │ gzip:   0.84 kB
dist/assets/chunk-YZCP3GAM-7ZIO5Qh6.js                      1.93 kB │ gzip:   0.86 kB
dist/assets/chunk-BSJP7CBP-I7s0C_eB.js                      2.09 kB │ gzip:   0.81 kB
dist/assets/dist-TlK-S7KL.js                                2.16 kB │ gzip:   0.97 kB
dist/assets/path-C-grg3CZ.js                                2.31 kB │ gzip:   0.99 kB
dist/assets/chat-store-3dCDz18K.js                          2.55 kB │ gzip:   0.87 kB
dist/assets/claude-cli-transport-zNpSX173.js                2.56 kB │ gzip:   1.33 kB
dist/assets/fs-BjAiTbfz.js                                  2.67 kB │ gzip:   1.13 kB
dist/assets/diagram-5BDNPKRD-BQWDE7nG.js                    2.79 kB │ gzip:   1.34 kB
dist/assets/reset-project-state-BofUumE5.js                 2.81 kB │ gzip:   1.10 kB
dist/assets/project-file-sync-qR89klvn.js                   3.02 kB │ gzip:   1.25 kB
dist/assets/graph-relevance-CrFaeRST.js                     3.40 kB │ gzip:   1.51 kB
dist/assets/arc-DP-9ChFU.js                                 3.47 kB │ gzip:   1.46 kB
dist/assets/diagram-TYMM5635-DtA1UbF_.js                    4.24 kB │ gzip:   1.83 kB
dist/assets/chunk-336JU56O-D_c5TlSw.js                      4.28 kB │ gzip:   1.91 kB
dist/assets/mermaid-parser.core-CNm9m-ET.js                 4.63 kB │ gzip:   1.47 kB
dist/assets/defaultLocale-CoF2cqkH.js                       4.64 kB │ gzip:   2.12 kB
dist/assets/sweep-reviews-DAwa8LQk.js                       5.21 kB │ gzip:   2.36 kB
dist/assets/pieDiagram-DEJITSTG-DM5cP4Lr.js                 5.23 kB │ gzip:   2.27 kB
dist/assets/linear-BOhYfWQp.js                              5.52 kB │ gzip:   2.25 kB
dist/assets/diagram-MMDJMWI5-BvUSUBge.js                    5.76 kB │ gzip:   2.39 kB
dist/assets/ingest-queue-DgT_tM5c.js                        6.33 kB │ gzip:   2.37 kB
dist/assets/_baseFor-CqZypurl.js                            6.83 kB │ gzip:   2.62 kB
dist/assets/react-0UhoXI6A.js                               8.10 kB │ gzip:   3.12 kB
dist/assets/_baseUniq-CM5qW-xS.js                           8.56 kB │ gzip:   3.57 kB
dist/assets/graphlib-BiX5jT18.js                            9.40 kB │ gzip:   3.19 kB
dist/assets/llm-client-DYQYp8M3.js                         10.24 kB │ gzip:   3.72 kB
dist/assets/embedding-DDiMUJ8X.js                          10.33 kB │ gzip:   3.93 kB
dist/assets/stateDiagram-FHFEXIEX-CwtZhvQB.js              10.52 kB │ gzip:   3.66 kB
dist/assets/dagre-KV5264BT-DK78l3i-.js                     11.07 kB │ gzip:   4.11 kB
dist/assets/dedup-queue-DoM-UQ2j.js                        13.23 kB │ gzip:   5.39 kB
dist/assets/diagram-G4DWMVQ6-fdSI4WSB.js                   15.52 kB │ gzip:   5.42 kB
dist/assets/ishikawaDiagram-UXIWVN3A-BYU6e8Hr.js           17.31 kB │ gzip:   6.52 kB
dist/assets/kanban-definition-6JOO6SKY-CJvTvhZk.js         20.22 kB │ gzip:   7.13 kB
dist/assets/sankeyDiagram-XADWPNL6-DLHV7j63.js             21.69 kB │ gzip:   7.81 kB
dist/assets/journeyDiagram-VCZTEJTY-qbJ0CBLp.js            23.16 kB │ gzip:   8.16 kB
dist/assets/mindmap-definition-QFDTVHPH-Cf-SVpdI.js        23.66 kB │ gzip:   8.06 kB
dist/assets/wardleyDiagram-NUSXRM2D-BpZ74xf1.js            23.87 kB │ gzip:   6.29 kB
dist/assets/erDiagram-SMLLAGMA-kioYPULs.js                 26.81 kB │ gzip:   9.33 kB
dist/assets/rough.esm-zabqYs6f.js                          27.10 kB │ gzip:   8.85 kB
dist/assets/chunk-5PVQY5BW-DJkZtrws.js                     28.20 kB │ gzip:   8.17 kB
dist/assets/gitGraphDiagram-UUTBAWPF-DxlDzt0B.js           28.97 kB │ gzip:   8.52 kB
dist/assets/dagre-BTKkjBe9.js                              30.00 kB │ gzip:  10.75 kB
dist/assets/timeline-definition-GMOUNBTQ-o0XBRtDm.js       30.39 kB │ gzip:   9.93 kB
dist/assets/requirementDiagram-MS252O5E-Zcyn763b.js        30.96 kB │ gzip:   9.74 kB
dist/assets/mermaid.core-CebWKHi5.js                       32.69 kB │ gzip:  11.38 kB
dist/assets/quadrantDiagram-34T5L4WZ-JdRjFkhp.js           33.34 kB │ gzip:   9.70 kB
dist/assets/chunk-ENJZ2VHE-CTu_4q3e.js                     33.38 kB │ gzip:   7.01 kB
dist/assets/chunk-OYMX7WX6-BrpFc1_I.js                     36.59 kB │ gzip:  11.80 kB
dist/assets/ingest-DmL2HOuv.js                             39.57 kB │ gzip:  15.73 kB
dist/assets/xychartDiagram-5P7HB3ND-B9N4JpQe.js            40.04 kB │ gzip:  11.20 kB
dist/assets/vennDiagram-DHZGUBPP-BUa-srIF.js               40.63 kB │ gzip:  14.89 kB
dist/assets/frontmatter-DkWneFf2.js                        40.90 kB │ gzip:  13.86 kB
dist/assets/chunk-XPW4576I-9WrVFHA_.js                     41.85 kB │ gzip:  14.22 kB
dist/assets/src-CRKu9sKn.js                                45.80 kB │ gzip:  16.04 kB
dist/assets/chunk-4TB4RGXK-BtGR3JbF.js                     46.88 kB │ gzip:  15.13 kB
dist/assets/chunk-U2HBQHQK-CAe1TNAn.js                     52.52 kB │ gzip:  17.13 kB
dist/assets/flowDiagram-DWJPFMVM-n-uQE_zE.js               60.22 kB │ gzip:  19.54 kB
dist/assets/ganttDiagram-T4ZO3ILL-CGi-nmXV.js              69.14 kB │ gzip:  22.64 kB
dist/assets/c4Diagram-AHTNJAMY-CZaIE4en.js                 69.17 kB │ gzip:  19.34 kB
dist/assets/blockDiagram-DXYQGD6D-BWRKdcIV.js              69.87 kB │ gzip:  19.54 kB
dist/assets/cose-bilkent-S5V4N54A-DYUG28KO.js              81.39 kB │ gzip:  21.56 kB
dist/assets/chunk-5FUZZQ4R-ed0knHi_.js                     97.90 kB │ gzip:  23.74 kB
dist/assets/sequenceDiagram-FGHM5R23-CkapHnvE.js          115.51 kB │ gzip:  30.51 kB
dist/assets/architectureDiagram-Q4EWVU46-X5yvfknx.js      146.78 kB │ gzip:  40.25 kB
dist/assets/chunk-ICPOFSXX-DmBV0DAW.js                    214.90 kB │ gzip:  33.82 kB
dist/assets/katex-DqTq2qz5.js                             257.04 kB │ gzip:  76.96 kB
dist/assets/cytoscape.esm-LMoHTWL4.js                     434.29 kB │ gzip: 137.56 kB
dist/assets/chunk-K5T4RW27-DJObzpX2.js                    474.02 kB │ gzip: 102.20 kB
dist/assets/index-HtizIqM3.js                           1,446.82 kB │ gzip: 432.98 kB

✓ built in 973ms

Rust build was not run locally because \ is not installed in this environment.