### PR TITLE
feat: Deep Research crawl + selective source import & HTML preview

### DIFF
--- a/src/components/editor/file-preview.tsx
+++ b/src/components/editor/file-preview.tsx
@@ -45,6 +45,8 @@ export function FilePreview({ filePath, textContent }: FilePreviewProps) {
       return <VideoPreview filePath={filePath} fileName={fileName} />
     case "audio":
       return <AudioPreview filePath={filePath} fileName={fileName} />
+    case "html":
+      return <HtmlPreview filePath={filePath} content={textContent} />
     case "pdf":
       return <TextPreview filePath={filePath} content={textContent} label="PDF (extracted text)" />
     case "code":
@@ -278,6 +280,35 @@ function TextPreview({ filePath, content, label }: { filePath: string; content: 
           {body}
         </ReactMarkdown>
       </div>
+    </div>
+  )
+}
+
+function HtmlPreview({ filePath, content }: { filePath: string; content: string }) {
+  const iframeRef = useRef<HTMLIFrameElement>(null)
+
+  useEffect(() => {
+    const iframe = iframeRef.current
+    if (!iframe) return
+    const doc = iframe.contentDocument
+    if (!doc) return
+    doc.open()
+    doc.write(content)
+    doc.close()
+  }, [content])
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="shrink-0 border-b px-6 py-2 text-xs text-muted-foreground">
+        {filePath}
+        <span className="ml-2 rounded bg-muted px-1.5 py-0.5 text-[10px] uppercase">HTML</span>
+      </div>
+      <iframe
+        ref={iframeRef}
+        sandbox="allow-same-origin"
+        className="flex-1 w-full border-0"
+        title="HTML Preview"
+      />
     </div>
   )
 }

--- a/src/components/layout/research-panel.tsx
+++ b/src/components/layout/research-panel.tsx
@@ -6,13 +6,13 @@ import rehypeKatex from "rehype-katex"
 import "katex/dist/katex.min.css"
 import {
   Search, Loader2, CheckCircle2, AlertCircle, ChevronRight, ChevronDown, X,
-  FileSearch, FileText, Globe2, Send,
+  FileSearch, FileText, Globe2, Send, Download, CheckSquare, Square, AlertTriangle,
 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { useResearchStore, type ResearchTask } from "@/stores/research-store"
 import { useWikiStore } from "@/stores/wiki-store"
 import { readFile } from "@/commands/fs"
-import { queueResearch } from "@/lib/deep-research"
+import { queueResearch, importSelectedSources } from "@/lib/deep-research"
 import { normalizePath } from "@/lib/path-utils"
 import { hasConfiguredDeepResearchSources } from "@/lib/web-search"
 import { isImeComposing } from "@/lib/keyboard-utils"
@@ -31,7 +31,7 @@ export function ResearchPanel() {
   const searchApiConfig = useWikiStore((s) => s.searchApiConfig)
   const [inputValue, setInputValue] = useState("")
 
-  const running = tasks.filter((t) => ["searching", "synthesizing", "saving"].includes(t.status))
+  const running = tasks.filter((t) => ["searching", "crawling", "synthesizing", "saving"].includes(t.status))
   const queued = tasks.filter((t) => t.status === "queued")
   const done = tasks.filter((t) => t.status === "done" || t.status === "error")
 
@@ -109,9 +109,8 @@ export function ResearchPanel() {
   )
 }
 
-/** Separate <think>/<thinking> blocks from main content */
+/** Separate <think/<thinking> blocks from main content */
 function separateThinking(text: string): { thinking: string; answer: string } {
-  // Match <think>...</think> or <thinking>...</thinking>
   const thinkRegex = /^<think(?:ing)?>([\s\S]*?)(?:<\/think(?:ing)?>|$)/i
   const match = text.match(thinkRegex)
   if (match) {
@@ -225,10 +224,16 @@ function ResearchTaskCard({ task, onRemove }: { task: ResearchTask; onRemove: (i
   const setSelectedFile = useWikiStore((s) => s.setSelectedFile)
   const setFileContent = useWikiStore((s) => s.setFileContent)
   const project = useWikiStore((s) => s.project)
+  const llmConfig = useWikiStore((s) => s.llmConfig)
+  const toggleUrlSelection = useResearchStore((s) => s.toggleUrlSelection)
+  const selectAllSuccessful = useResearchStore((s) => s.selectAllSuccessful)
+  const clearSelection = useResearchStore((s) => s.clearSelection)
+  const [importing, setImporting] = useState(false)
 
   const statusIcon = {
     queued: <div className="h-3 w-3 rounded-full border-2 border-muted-foreground" />,
     searching: <Loader2 className="h-3 w-3 animate-spin text-blue-500" />,
+    crawling: <Loader2 className="h-3 w-3 animate-spin text-cyan-500" />,
     synthesizing: <Loader2 className="h-3 w-3 animate-spin text-purple-500" />,
     saving: <Loader2 className="h-3 w-3 animate-spin text-orange-500" />,
     done: <CheckCircle2 className="h-3 w-3 text-emerald-500" />,
@@ -238,6 +243,7 @@ function ResearchTaskCard({ task, onRemove }: { task: ResearchTask; onRemove: (i
   const statusText = {
     queued: t("research.status.queued"),
     searching: t("research.status.searching"),
+    crawling: t("research.crawling") + "...",
     synthesizing: t("research.status.synthesizing"),
     saving: t("research.status.saving"),
     done: task.savedPath ? t("research.status.saved") : t("research.status.done"),
@@ -255,6 +261,28 @@ function ResearchTaskCard({ task, onRemove }: { task: ResearchTask; onRemove: (i
       // ignore
     }
   }
+
+  async function handleImport() {
+    if (!project) return
+    setImporting(true)
+    try {
+      await importSelectedSources(project.path, task.id, llmConfig)
+    } catch (err) {
+      console.error("Failed to import sources:", err)
+    } finally {
+      setImporting(false)
+    }
+  }
+
+  const crawledByUrl = useMemo(() => {
+    const map = new Map<string, typeof task.crawledPages[0]>()
+    for (const p of task.crawledPages) map.set(p.url, p)
+    return map
+  }, [task.crawledPages])
+
+  const selectedCount = task.selectedUrls.size
+  const successfulCount = task.crawledPages.filter((p) => p.status === "success").length
+  const hasCrawlResults = task.crawledPages.length > 0
 
   return (
     <div className="rounded-lg border text-xs">
@@ -281,31 +309,103 @@ function ResearchTaskCard({ task, onRemove }: { task: ResearchTask; onRemove: (i
             <p className="mb-2 text-destructive">{task.error}</p>
           )}
 
-          {/* Web results */}
+          {/* Crawl progress */}
+          {task.crawlProgress && task.crawlProgress.done < task.crawlProgress.total && (
+            <div className="mb-2 rounded bg-muted/50 px-2 py-1.5">
+              <div className="flex items-center gap-1.5 text-muted-foreground">
+                <Loader2 className="h-3 w-3 animate-spin" />
+                <span>{t("research.crawlProgress", task.crawlProgress)}</span>
+              </div>
+              <div className="mt-1 h-1.5 w-full rounded-full bg-muted">
+                <div
+                  className="h-1.5 rounded-full bg-cyan-500 transition-all"
+                  style={{ width: `${(task.crawlProgress.done / task.crawlProgress.total) * 100}%` }}
+                />
+              </div>
+            </div>
+          )}
+
+          {/* Web results with checkboxes */}
           {task.webResults.length > 0 && (
             <div className="mb-2">
-              <div className="mb-1 font-medium text-muted-foreground">
-                {t("research.sourcesCount", { count: task.webResults.length })}
+              <div className="mb-1 flex items-center justify-between">
+                <span className="font-medium text-muted-foreground">
+                  {t("research.sourcesCount", { count: task.webResults.length })}
+                  {hasCrawlResults ? ` · ${successfulCount} ${t("research.crawlDone", { count: successfulCount }).split(" ").slice(-1)}` : ""}
+                </span>
+                {hasCrawlResults && (
+                  <div className="flex gap-1">
+                    <button
+                      onClick={() => selectAllSuccessful(task.id)}
+                      className="text-[10px] text-muted-foreground hover:text-foreground"
+                    >
+                      {t("research.selectAll")}
+                    </button>
+                    <span className="text-muted-foreground">·</span>
+                    <button
+                      onClick={() => clearSelection(task.id)}
+                      className="text-[10px] text-muted-foreground hover:text-foreground"
+                    >
+                      {t("research.deselectAll")}
+                    </button>
+                  </div>
+                )}
               </div>
-              <div className="flex flex-col gap-1">
+              <div className="flex flex-col gap-0.5">
                 {task.webResults.map((r, i) => {
-                  const isAnyTxt = r.source.toLowerCase() === "anytxt"
-                  const SourceIcon = isAnyTxt ? FileSearch : Globe2
+                  const crawled = crawledByUrl.get(r.url)
+                  const isSelected = task.selectedUrls.has(r.url)
+                  const canSelect = crawled?.status === "success"
+
                   return (
-                    <div key={i} className="flex items-start gap-1.5 rounded bg-muted/50 px-2 py-1">
-                      <span className="shrink-0 font-mono text-muted-foreground">[{i + 1}]</span>
-                      <SourceIcon
-                        className={`mt-0.5 h-3.5 w-3.5 shrink-0 ${isAnyTxt ? "text-amber-600" : "text-blue-600"}`}
-                        aria-label={isAnyTxt ? t("research.anyTxtSource") : t("research.webSource")}
+                    <label
+                      key={i}
+                      className={`flex items-start gap-1.5 rounded px-2 py-1 ${
+                        canSelect ? "cursor-pointer hover:bg-accent/50" : "opacity-60"
+                      }`}
+                    >
+                      {hasCrawlResults ? (
+                        canSelect ? (
+                          isSelected ? (
+                            <CheckSquare className="mt-0.5 h-3 w-3 shrink-0 text-primary" />
+                          ) : (
+                            <Square className="mt-0.5 h-3 w-3 shrink-0 text-muted-foreground" />
+                          )
+                        ) : (
+                          <AlertTriangle className="mt-0.5 h-3 w-3 shrink-0 text-amber-500" />
+                        )
+                      ) : null}
+                      <input
+                        type="checkbox"
+                        checked={isSelected}
+                        onChange={() => canSelect && toggleUrlSelection(task.id, r.url)}
+                        className="sr-only"
                       />
                       <div className="min-w-0 flex-1">
                         <div className="truncate font-medium">{r.title}</div>
-                        <div className="truncate text-muted-foreground">{isAnyTxt ? "AnyTXT" : r.source}</div>
+                        <div className="truncate text-muted-foreground">{r.source}</div>
                       </div>
-                    </div>
+                    </label>
                   )
                 })}
               </div>
+
+              {/* Import button */}
+              {hasCrawlResults && selectedCount > 0 && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="mt-2 h-6 w-full text-[11px] gap-1"
+                  onClick={handleImport}
+                  disabled={importing}
+                >
+                  {importing ? (
+                    <><Loader2 className="h-3 w-3 animate-spin" /> {t("research.importingSources", { count: selectedCount })}</>
+                  ) : (
+                    <><Download className="h-3 w-3" /> {t("research.importSelected", { count: selectedCount })}</>
+                  )}
+                </Button>
+              )}
             </div>
           )}
 

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -655,5 +655,16 @@
     "minutesAgo": "{{count}} min ago",
     "hoursAgo": "{{count}} h ago",
     "daysAgo": "{{count}} d ago"
+  },
+  "research": {
+    "crawlProgress": "Crawling pages... {{done}}/{{total}}",
+    "crawlDone": "{{count}} pages crawled",
+    "crawlFailed": "Crawl failed",
+    "selectAll": "Select All",
+    "deselectAll": "Deselect All",
+    "importSelected": "Import Selected ({{count}})",
+    "importingSources": "Importing {{count}} sources...",
+    "crawling": "Crawling",
+    "notCrawledYet": "Waiting to crawl"
   }
 }

--- a/src/i18n/zh.json
+++ b/src/i18n/zh.json
@@ -655,5 +655,16 @@
     "minutesAgo": "{{count}} 分钟前",
     "hoursAgo": "{{count}} 小时前",
     "daysAgo": "{{count}} 天前"
+  },
+  "research": {
+    "crawlProgress": "正在爬取页面... {{done}}/{{total}}",
+    "crawlDone": "已爬取 {{count}} 个页面",
+    "crawlFailed": "爬取失败",
+    "selectAll": "全选",
+    "deselectAll": "取消全选",
+    "importSelected": "导入选中 ({{count}})",
+    "importingSources": "正在导入 {{count}} 个源文件...",
+    "crawling": "爬取中",
+    "notCrawledYet": "等待爬取"
   }
 }

--- a/src/lib/deep-research.ts
+++ b/src/lib/deep-research.ts
@@ -2,11 +2,14 @@ import { anyTxtSearchSmart, hasConfiguredAnyTxt } from "./anytxt-search"
 import { hasConfiguredSearchProvider, resolveSearchConfig, webSearch } from "./web-search"
 import { streamChat } from "./llm-client"
 import { autoIngest } from "./ingest"
-import { writeFile, readFile, listDirectory } from "@/commands/fs"
+import { writeFile, readFile, listDirectory, createDirectory } from "@/commands/fs"
 import { useWikiStore, type LlmConfig, type SearchApiConfig } from "@/stores/wiki-store"
 import { useResearchStore } from "@/stores/research-store"
 import { normalizePath } from "@/lib/path-utils"
 import { buildLanguageDirective } from "@/lib/output-language"
+import { crawlUrls } from "@/lib/web-crawler"
+import { getHttpFetch } from "@/lib/tauri-fetch"
+import { enqueueSourceIngest } from "@/lib/source-lifecycle"
 
 const MAX_RESEARCH_SOURCES = 20
 
@@ -172,8 +175,23 @@ async function executeResearch(
       return
     }
 
-    // Step 2: LLM synthesis
-    store.updateTask(taskId, { status: "synthesizing" })
+    // Step 1.5: Crawl all result URLs (runs in parallel with LLM synthesis)
+    const httpFetch = await getHttpFetch()
+    const crawlPromise = crawlUrls(
+      webResults.map((r) => r.url),
+      httpFetch,
+      {
+        concurrency: 4,
+        onProgress: (done, total) => {
+          useResearchStore.getState().updateCrawlProgress(taskId, done, total)
+        },
+      },
+    ).then((pages) => {
+      useResearchStore.getState().setCrawledPages(taskId, pages)
+    })
+
+    // Step 2: LLM synthesis (runs in parallel with crawl)
+    store.updateTask(taskId, { status: "synthesizing", crawlProgress: { done: 0, total: webResults.length } })
 
     const searchContext = webResults
       .map((r, i) => `[${i + 1}] **${r.title}** (${r.source})\n${r.snippet}`)
@@ -232,6 +250,9 @@ async function executeResearch(
       },
     )
 
+    // Wait for crawl to finish before saving
+    await crawlPromise
+
     // Check if errored during streaming
     if (useResearchStore.getState().tasks.find((t) => t.id === taskId)?.status === "error") {
       onTaskFinished(pp, llmConfig, searchConfig)
@@ -250,7 +271,7 @@ async function executeResearch(
       .map((r, i) => `${i + 1}. [${r.title}](${r.url}) — ${r.source}`)
       .join("\n")
 
-    // Strip <think>/<thinking> blocks before saving
+    // Strip <think/<thinking> blocks before saving
     const cleanedSynthesis = accumulated
       .replace(/<think(?:ing)?>\s*[\s\S]*?<\/think(?:ing)?>\s*/gi, "")
       .replace(/<think(?:ing)?>\s*[\s\S]*$/gi, "") // unclosed thinking block
@@ -305,6 +326,85 @@ async function executeResearch(
   }
 
   onTaskFinished(pp, llmConfig, searchConfig)
+}
+
+/**
+ * Import user-selected crawled pages as source files for ingest.
+ */
+export async function importSelectedSources(
+  projectPath: string,
+  taskId: string,
+  llmConfig: LlmConfig,
+): Promise<string[]> {
+  const task = useResearchStore.getState().tasks.find((t) => t.id === taskId)
+  if (!task) return []
+
+  const project = useWikiStore.getState().project
+  if (!project) return []
+
+  const pp = normalizePath(projectPath)
+  const selected = task.selectedUrls
+  if (selected.size === 0) return []
+
+  const pagesToImport = task.crawledPages.filter(
+    (p) => p.status === "success" && selected.has(p.url),
+  )
+  if (pagesToImport.length === 0) return []
+
+  const topicSlug = task.topic
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, "")
+    .trim()
+    .replace(/\s+/g, "-")
+    .slice(0, 50)
+  const sourcesDir = `${pp}/raw/sources/deep-research-${topicSlug}`
+
+  await createDirectory(sourcesDir)
+
+  const importedPaths: string[] = []
+
+  for (const page of pagesToImport) {
+    const urlSlug = page.url
+      .replace(/^https?:\/\//, "")
+      .replace(/[/?#:]/g, "-")
+      .replace(/-{2,}/g, "-")
+      .replace(/^-|-$/g, "")
+      .slice(0, 80)
+      .toLowerCase()
+
+    const html = `<!DOCTYPE html>
+<html><head>
+<meta charset="utf-8">
+<meta name="title" content="${escapeAttr(page.title)}">
+<meta name="source-url" content="${escapeAttr(page.url)}">
+<meta name="origin" content="deep-research">
+</head>
+<body>
+${page.content}
+</body></html>`
+
+    const filePath = `${sourcesDir}/${urlSlug}.html`
+    await writeFile(filePath, html)
+    importedPaths.push(filePath)
+  }
+
+  if (importedPaths.length > 0) {
+    await enqueueSourceIngest(
+      project,
+      importedPaths,
+      llmConfig,
+      { sourceRoot: sourcesDir, rootContext: `deep-research-${topicSlug}` },
+    )
+  }
+
+  // Clear selection after import
+  useResearchStore.getState().clearSelection(taskId)
+
+  return importedPaths
+}
+
+function escapeAttr(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
 }
 
 function onTaskFinished(

--- a/src/lib/file-types.ts
+++ b/src/lib/file-types.ts
@@ -2,6 +2,7 @@ export type FileCategory =
   | "markdown"
   | "text"
   | "code"
+  | "html"
   | "image"
   | "video"
   | "audio"
@@ -47,8 +48,8 @@ const EXT_MAP: Record<string, FileCategory> = {
   css: "code",
   scss: "code",
   less: "code",
-  html: "code",
-  htm: "code",
+  html: "html",
+  htm: "html",
   xml: "code",
   svg: "code",
   vue: "code",
@@ -127,7 +128,7 @@ export function getFileCategory(filePath: string): FileCategory {
 }
 
 export function isTextReadable(category: FileCategory): boolean {
-  return ["markdown", "text", "code", "data"].includes(category)
+  return ["markdown", "text", "code", "data", "html"].includes(category)
 }
 
 export const EXTRACTED_TEXT_PREVIEW_EXTENSIONS = new Set([

--- a/src/lib/web-crawler.test.ts
+++ b/src/lib/web-crawler.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest"
+import { extractContentFromHtml } from "./web-crawler"
+
+const FULL_HTML = `<!DOCTYPE html>
+<html><head>
+<meta property="og:title" content="Test Article">
+<style>body{color:red}</style>
+<script>console.log("hi")</script>
+</head><body>
+<header>Nav stuff</header>
+<article>
+  <h1>Test Article</h1>
+  <p>This is the main content with <b>bold</b> text.</p>
+  <p>Second paragraph.</p>
+</article>
+<footer>Footer links</footer>
+</body></html>`
+
+const MAIN_ONLY = `<!DOCTYPE html>
+<html><head><title>Main Page</title></head><body>
+<nav>Navigation</nav>
+<main>
+  <p>Main content here.</p>
+</main>
+<aside>Sidebar</aside>
+</body></html>`
+
+const BODY_ONLY = `<!DOCTYPE html>
+<html><head><title>Body Page</title></head><body>
+  <p>Just body content.</p>
+</body></html>`
+
+const NO_STRUCTURE = `Plain text without any HTML structure.`
+
+const TITLE_ENTITIES = `<!DOCTYPE html>
+<html><head><title>Tom &amp; Jerry &lt;Cartoon&gt;</title></head><body>
+<article>Content</article>
+</body></html>`
+
+describe("extractContentFromHtml", () => {
+  it("extracts article content and og:title", () => {
+    const result = extractContentFromHtml(FULL_HTML)
+    expect(result.title).toBe("Test Article")
+    expect(result.content).toContain("This is the main content with <b>bold</b> text.")
+    expect(result.content).toContain("Second paragraph.")
+    expect(result.content).not.toContain("Nav stuff")
+    expect(result.content).not.toContain("Footer links")
+  })
+
+  it("falls back to <main> when no <article>", () => {
+    const result = extractContentFromHtml(MAIN_ONLY)
+    expect(result.title).toBe("Main Page")
+    expect(result.content).toContain("Main content here.")
+    expect(result.content).not.toContain("Navigation")
+  })
+
+  it("falls back to <body> when no <article> or <main>", () => {
+    const result = extractContentFromHtml(BODY_ONLY)
+    expect(result.title).toBe("Body Page")
+    expect(result.content).toContain("Just body content.")
+  })
+
+  it("handles plain text with no HTML structure", () => {
+    const result = extractContentFromHtml(NO_STRUCTURE)
+    expect(result.content).toContain("Plain text")
+  })
+
+  it("unescapes HTML entities in title", () => {
+    const result = extractContentFromHtml(TITLE_ENTITIES)
+    expect(result.title).toBe("Tom & Jerry <Cartoon>")
+  })
+
+  it("removes script and style tags", () => {
+    const result = extractContentFromHtml(FULL_HTML)
+    expect(result.content).not.toContain("console.log")
+    expect(result.content).not.toContain("color:red")
+  })
+})

--- a/src/lib/web-crawler.ts
+++ b/src/lib/web-crawler.ts
@@ -1,0 +1,128 @@
+export interface CrawledPage {
+  url: string
+  title: string
+  content: string
+  status: "success" | "failed"
+  error?: string
+}
+
+const DEFAULT_CONCURRENCY = 4
+const DEFAULT_TIMEOUT_MS = 15_000
+
+function stripTags(html: string, tags: string[]): string {
+  return tags.reduce((s, tag) => {
+    const re = new RegExp(`<${tag}[^>]*>[\\s\\S]*?<\\/${tag}>`, "gi")
+    return s.replace(re, "")
+  }, html)
+}
+
+function extractBody(html: string): string {
+  // Prefer <article>, then <main>, then <body>
+  const article = /<article[^>]*>([\s\S]*?)<\/article>/i.exec(html)
+  if (article) return article[1]
+
+  const main = /<main[^>]*>([\s\S]*?)<\/main>/i.exec(html)
+  if (main) return main[1]
+
+  const body = /<body[^>]*>([\s\S]*?)<\/body>/i.exec(html)
+  if (body) return body[1]
+
+  return html
+}
+
+function extractTitle(html: string): string {
+  const og = /<meta[^>]*property="og:title"[^>]*content="([^"]*)"/i.exec(html)
+  if (og) return unescapeHtml(og[1])
+
+  const title = /<title[^>]*>([\s\S]*?)<\/title>/i.exec(html)
+  if (title) return unescapeHtml(title[1].trim())
+
+  const h1 = /<h1[^>]*>([\s\S]*?)<\/h1>/i.exec(html)
+  if (h1) return unescapeHtml(h1[1].replace(/<[^>]*>/g, "").trim())
+
+  return ""
+}
+
+function unescapeHtml(s: string): string {
+  return s
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&#x27;/g, "'")
+}
+
+const NOISE_TAGS = ["script", "style", "nav", "footer", "header", "aside", "noscript", "iframe"]
+
+export function extractContentFromHtml(html: string): { title: string; content: string } {
+  const title = extractTitle(html)
+  let body = extractBody(html)
+  body = stripTags(body, NOISE_TAGS)
+  // Collapse excessive whitespace
+  body = body.replace(/\n{3,}/g, "\n\n").trim()
+  return { title, content: body }
+}
+
+async function crawlSingle(
+  url: string,
+  httpFetch: (url: string, init?: RequestInit) => Promise<Response>,
+  timeoutMs: number,
+): Promise<CrawledPage> {
+  try {
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), timeoutMs)
+    const res = await httpFetch(url, {
+      method: "GET",
+      headers: {
+        Accept: "text/html,application/xhtml+xml,*/*",
+        "User-Agent": "Mozilla/5.0 (compatible; LLMWiki/1.0)",
+      },
+      signal: controller.signal,
+    })
+    clearTimeout(timer)
+
+    if (!res.ok) {
+      return { url, title: "", content: "", status: "failed", error: `HTTP ${res.status}` }
+    }
+
+    const ct = res.headers.get("content-type") || ""
+    if (!ct.includes("text/html") && !ct.includes("application/xhtml")) {
+      return { url, title: "", content: "", status: "failed", error: `Not HTML: ${ct}` }
+    }
+
+    const html = await res.text()
+    const { title, content } = extractContentFromHtml(html)
+    return { url, title, content, status: "success" }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    return { url, title: "", content: "", status: "failed", error: msg }
+  }
+}
+
+export async function crawlUrls(
+  urls: string[],
+  httpFetch: (url: string, init?: RequestInit) => Promise<Response>,
+  options?: { concurrency?: number; timeoutMs?: number; onProgress?: (done: number, total: number) => void },
+): Promise<CrawledPage[]> {
+  const concurrency = options?.concurrency ?? DEFAULT_CONCURRENCY
+  const timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS
+  const onProgress = options?.onProgress
+  const results: CrawledPage[] = new Array(urls.length)
+  let done = 0
+
+  // Process in batches of `concurrency`
+  for (let i = 0; i < urls.length; i += concurrency) {
+    const batch = urls.slice(i, i + concurrency)
+    const batchResults = await Promise.all(
+      batch.map((url) => crawlSingle(url, httpFetch, timeoutMs)),
+    )
+    batchResults.forEach((r, j) => {
+      results[i + j] = r
+    })
+    done += batch.length
+    onProgress?.(done, urls.length)
+  }
+
+  return results
+}

--- a/src/stores/research-store.ts
+++ b/src/stores/research-store.ts
@@ -1,16 +1,20 @@
 import { create } from "zustand"
 import type { WebSearchResult } from "@/lib/web-search"
+import type { CrawledPage } from "@/lib/web-crawler"
 
 export interface ResearchTask {
   id: string
   topic: string
   searchQueries?: string[]
-  status: "queued" | "searching" | "synthesizing" | "saving" | "done" | "error"
+  status: "queued" | "searching" | "crawling" | "synthesizing" | "saving" | "done" | "error"
   webResults: WebSearchResult[]
   synthesis: string
   savedPath: string | null
   error: string | null
   createdAt: number
+  crawledPages: CrawledPage[]
+  crawlProgress: { done: number; total: number } | null
+  selectedUrls: Set<string>
 }
 
 interface ResearchState {
@@ -24,6 +28,13 @@ interface ResearchState {
   setPanelOpen: (open: boolean) => void
   getRunningCount: () => number
   getNextQueued: () => ResearchTask | undefined
+
+  setCrawledPages: (id: string, pages: CrawledPage[]) => void
+  appendCrawledPages: (id: string, pages: CrawledPage[]) => void
+  updateCrawlProgress: (id: string, done: number, total: number) => void
+  toggleUrlSelection: (id: string, url: string) => void
+  selectAllSuccessful: (id: string) => void
+  clearSelection: (id: string) => void
 }
 
 let counter = 0
@@ -47,6 +58,9 @@ export const useResearchStore = create<ResearchState>((set, get) => ({
           savedPath: null,
           error: null,
           createdAt: Date.now(),
+          crawledPages: [],
+          crawlProgress: null,
+          selectedUrls: new Set(),
         },
       ],
       panelOpen: true,
@@ -69,7 +83,7 @@ export const useResearchStore = create<ResearchState>((set, get) => ({
   getRunningCount: () => {
     const { tasks } = get()
     return tasks.filter((t) =>
-      t.status === "searching" || t.status === "synthesizing" || t.status === "saving"
+      t.status === "searching" || t.status === "crawling" || t.status === "synthesizing" || t.status === "saving"
     ).length
   },
 
@@ -77,4 +91,50 @@ export const useResearchStore = create<ResearchState>((set, get) => ({
     const { tasks } = get()
     return tasks.find((t) => t.status === "queued")
   },
+
+  setCrawledPages: (id, pages) =>
+    set((state) => ({
+      tasks: state.tasks.map((t) => (t.id === id ? { ...t, crawledPages: pages } : t)),
+    })),
+
+  appendCrawledPages: (id, pages) =>
+    set((state) => ({
+      tasks: state.tasks.map((t) =>
+        t.id === id ? { ...t, crawledPages: [...t.crawledPages, ...pages] } : t
+      ),
+    })),
+
+  updateCrawlProgress: (id, done, total) =>
+    set((state) => ({
+      tasks: state.tasks.map((t) =>
+        t.id === id ? { ...t, crawlProgress: { done, total } } : t
+      ),
+    })),
+
+  toggleUrlSelection: (id, url) =>
+    set((state) => ({
+      tasks: state.tasks.map((t) => {
+        if (t.id !== id) return t
+        const next = new Set(t.selectedUrls)
+        if (next.has(url)) next.delete(url)
+        else next.add(url)
+        return { ...t, selectedUrls: next }
+      }),
+    })),
+
+  selectAllSuccessful: (id) =>
+    set((state) => ({
+      tasks: state.tasks.map((t) => {
+        if (t.id !== id) return t
+        const urls = t.crawledPages.filter((p) => p.status === "success").map((p) => p.url)
+        return { ...t, selectedUrls: new Set(urls) }
+      }),
+    })),
+
+  clearSelection: (id) =>
+    set((state) => ({
+      tasks: state.tasks.map((t) =>
+        t.id === id ? { ...t, selectedUrls: new Set() } : t
+      ),
+    })),
 }))


### PR DESCRIPTION
## Summary
- Auto-crawl full page content for all Deep Research search results in parallel with LLM synthesis
- Allow users to selectively import crawled pages as source files into raw/sources/ for standard LLM ingest
- Add HTML file preview via sandboxed iframe for .html source files

## Changes
- **web-crawler.ts**: URL crawler with concurrency=4, 15s timeout, regex-based article/main/body extraction
- **research-store**: Add crawledPages, crawlProgress, selectedUrls state and actions
- **deep-research.ts**: Auto-crawl after search + importSelectedSources() for selective import
- **research-panel.tsx**: Add checkboxes, crawl progress bar, select all/import button to Sources section
- **file-preview.tsx**: Add HtmlPreview component using sandboxed iframe
- **file-types.ts**: Add html file category
- **i18n**: Add crawl/import translations in en.json and zh.json

## Test plan
- [ ] Start a Deep Research task, verify crawl runs automatically after search with progress indicator
- [ ] After crawl completes, select sources and click Import Selected, verify files are written to raw/sources/ and enqueued for ingest
- [ ] Click an imported .html source file, verify rendered preview instead of raw code

🤖 Generated with [Claude Code](https://claude.com/claude-code)