### PR TITLE
fix: allow SearXNG web search without an API key

### DIFF
--- a/src/components/layout/research-panel.tsx
+++ b/src/components/layout/research-panel.tsx
@@ -14,6 +14,7 @@ import { useWikiStore } from "@/stores/wiki-store"
 import { readFile } from "@/commands/fs"
 import { queueResearch } from "@/lib/deep-research"
 import { normalizePath } from "@/lib/path-utils"
+import { hasConfiguredSearchProvider } from "@/lib/web-search"
 import { isImeComposing } from "@/lib/keyboard-utils"
 import { detectLanguage } from "@/lib/detect-language"
 import { getHtmlLang, getTextDirection } from "@/lib/language-metadata"
@@ -35,8 +36,8 @@ export function ResearchPanel() {
   function handleStartResearch() {
     const topic = inputValue.trim()
     if (!topic || !project) return
-    if (searchApiConfig.provider === "none" || !searchApiConfig.apiKey) {
-      window.alert("Web Search not configured. Go to Settings → Web Search to add a Tavily or SerpApi API key.")
+    if (!hasConfiguredSearchProvider(searchApiConfig)) {
+      window.alert("Web Search not configured. Go to Settings → Web Search to configure a provider.")
       return
     }
     queueResearch(normalizePath(project.path), topic, llmConfig, searchApiConfig)

--- a/src/components/review/review-view.tsx
+++ b/src/components/review/review-view.tsx
@@ -16,6 +16,7 @@ import { useReviewStore, type ReviewItem } from "@/stores/review-store"
 import { useWikiStore } from "@/stores/wiki-store"
 import { writeFile, readFile, listDirectory, deleteFile } from "@/commands/fs"
 import { normalizePath } from "@/lib/path-utils"
+import { hasConfiguredSearchProvider } from "@/lib/web-search"
 
 const typeConfig: Record<ReviewItem["type"], { icon: typeof AlertTriangle; label: string; color: string }> = {
   contradiction: { icon: AlertTriangle, label: "Contradiction", color: "text-amber-500" },
@@ -38,8 +39,8 @@ export function ReviewView() {
     // Deep Research — must be checked FIRST before any fuzzy matching
     if (action === "__deep_research__" && project) {
       const searchConfig = useWikiStore.getState().searchApiConfig
-      if (searchConfig.provider === "none" || !searchConfig.apiKey) {
-        window.alert("Web Search not configured. Go to Settings → Web Search to add a Tavily or SerpApi API key first.")
+      if (!hasConfiguredSearchProvider(searchConfig)) {
+        window.alert("Web Search not configured. Go to Settings → Web Search to configure a provider first.")
         return
       }
       const item = items.find((i) => i.id === id)
@@ -139,7 +140,7 @@ export function ReviewView() {
     } else if (actionLooksLikeResearch(action) && project) {
       // Actions with "research" trigger deep research, not just page creation
       const searchConfig = useWikiStore.getState().searchApiConfig
-      if (searchConfig.provider === "none" || !searchConfig.apiKey) {
+      if (!hasConfiguredSearchProvider(searchConfig)) {
         // No search API — fall through to create a page instead
         const item = items.find((i) => i.id === id)
         if (item) {

--- a/src/lib/web-search.test.ts
+++ b/src/lib/web-search.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
-import { webSearch } from "./web-search"
+import { hasConfiguredSearchProvider, webSearch } from "./web-search"
 
 const fetchMock = vi.fn<typeof fetch>()
 
@@ -158,5 +158,21 @@ describe("webSearch", () => {
       .rejects.toThrow("Tavily or SerpApi API key")
     await expect(webSearch("x", { provider: "searxng", apiKey: "" }, 5))
       .rejects.toThrow("SearXNG instance URL")
+  })
+
+  it("treats SearXNG instance URLs as configured without an API key", () => {
+    expect(hasConfiguredSearchProvider({
+      provider: "searxng",
+      apiKey: "",
+      providerConfigs: {
+        searxng: {
+          searXngUrl: "http://127.0.0.1:8080",
+          searXngCategories: ["general", "science", "it"],
+        },
+      },
+      searXngUrl: "http://127.0.0.1:8080",
+      searXngCategories: ["general", "science", "it"],
+      serpApiEngine: "google",
+    })).toBe(true)
   })
 })

--- a/src/lib/web-search.ts
+++ b/src/lib/web-search.ts
@@ -86,6 +86,15 @@ export function resolveSearchConfig(config: SearchApiConfig): SearchApiConfig {
   }
 }
 
+export function hasConfiguredSearchProvider(config: SearchApiConfig): boolean {
+  const resolved = resolveSearchConfig(config)
+  if (resolved.provider === "none") return false
+  if (resolved.provider === "searxng") {
+    return Boolean(resolved.searXngUrl?.trim())
+  }
+  return Boolean(resolved.apiKey?.trim())
+}
+
 export async function webSearch(
   query: string,
   config: SearchApiConfig,


### PR DESCRIPTION
Summary
- Add a shared web-search configuration helper.
- Treat SearXNG as configured when an instance URL is present.
- Keep Tavily and SerpApi configured only when their API keys are present.

Testing
- npx vitest run src/lib/web-search.test.ts
- npm run typecheck
- git diff --check

Fixes #190