### PR TITLE
Add Azure OpenAI provider and normalize persisted LLM settings.

### DIFF
--- a/src/components/project/create-project-dialog.tsx
+++ b/src/components/project/create-project-dialog.tsx
@@ -94,11 +94,11 @@ export function CreateProjectDialog({ open: isOpen, onOpenChange, onCreated }: C
 
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-lg">
+      <DialogContent className="max-h-[calc(100vh-2rem)] max-w-lg grid-rows-[auto_minmax(0,1fr)_auto] overflow-hidden">
         <DialogHeader>
           <DialogTitle>{t("project.createTitle")}</DialogTitle>
         </DialogHeader>
-        <div className="flex flex-col gap-4 py-4">
+        <div className="flex flex-col gap-4 overflow-y-auto py-4 pr-1">
           <div className="flex flex-col gap-2">
             <Label htmlFor="name">{t("project.name")}</Label>
             <Input id="name" value={name} onChange={(e) => setName(e.target.value)} placeholder={t("project.namePlaceholder")} />

--- a/src/components/project/welcome-screen.tsx
+++ b/src/components/project/welcome-screen.tsx
@@ -31,8 +31,8 @@ export function WelcomeScreen({
   }
 
   return (
-    <div className="flex h-full items-center justify-center bg-background">
-      <div className="flex flex-col items-center gap-8 px-4">
+    <div className="flex min-h-screen overflow-y-auto bg-background px-4 py-8">
+      <div className="m-auto flex flex-col items-center gap-8">
         <div className="text-center">
           <h1 className="text-3xl font-bold">{t("app.title")}</h1>
           <p className="mt-2 text-muted-foreground">

--- a/src/components/settings/llm-presets.ts
+++ b/src/components/settings/llm-presets.ts
@@ -12,6 +12,7 @@ export type Provider =
   | "openai"
   | "anthropic"
   | "google"
+  | "azure"
   | "ollama"
   | "custom"
   | "minimax"
@@ -39,6 +40,8 @@ export interface LlmPreset {
   baseUrlByMode?: Partial<Record<CustomApiMode, string>>
   /** Suggested default model; user can override. */
   defaultModel?: string
+  /** Azure OpenAI api-version query parameter. Azure deployments vary by resource. */
+  azureApiVersion?: string
   /**
    * Curated list of model ids the UI shows as clickable chips above the
    * Model input. The user can still type a custom value — the input stays
@@ -146,6 +149,16 @@ export const LLM_PRESETS: LlmPreset[] = [
       "gemini-1.5-flash",
     ],
     suggestedContextSize: 1000000,
+  },
+  {
+    id: "azure",
+    label: "Azure OpenAI",
+    hint: "Azure OpenAI resource endpoint; Model field is the deployment name",
+    provider: "azure",
+    baseUrl: "https://your-resource.openai.azure.com",
+    defaultModel: "your-deployment-name",
+    azureApiVersion: "2024-10-21",
+    suggestedContextSize: 128000,
   },
   {
     id: "deepseek",

--- a/src/components/settings/preset-resolver.ts
+++ b/src/components/settings/preset-resolver.ts
@@ -44,6 +44,19 @@ export function resolveConfig(
     }
   }
 
+  if (preset.provider === "azure") {
+    return {
+      provider: "azure",
+      apiKey,
+      model,
+      ollamaUrl: fallback.ollamaUrl,
+      customEndpoint: ov.baseUrl ?? preset.baseUrl ?? "",
+      azureApiVersion: ov.azureApiVersion ?? preset.azureApiVersion ?? "2024-10-21",
+      maxContextSize,
+      reasoning,
+    }
+  }
+
   if (preset.provider === "claude-code" || preset.provider === "codex-cli") {
     // Subprocess transport — no apiKey, no endpoint URL. Model id is
     // passed straight to the local CLI's model flag.

--- a/src/components/settings/sections/llm-provider-section.tsx
+++ b/src/components/settings/sections/llm-provider-section.tsx
@@ -117,9 +117,10 @@ function PresetRow({
   const apiKey = ov.apiKey ?? ""
   const apiMode = ov.apiMode ?? preset.apiMode ?? "chat_completions"
   const baseUrl = ov.baseUrl ?? preset.baseUrl ?? ""
+  const azureApiVersion = ov.azureApiVersion ?? preset.azureApiVersion ?? "2024-10-21"
   const context = ov.maxContextSize ?? preset.suggestedContextSize ?? 131072
   const reasoning = ov.reasoning ?? { mode: "auto" as const }
-  const hasConfig = !!apiKey || !!ov.baseUrl || !!ov.model
+  const hasConfig = !!apiKey || !!ov.baseUrl || !!ov.model || !!ov.azureApiVersion
   // Local CLI providers authenticate via their own existing login state
   // (inherited by the spawned subprocess), so no API key field is shown.
   // Ollama ditto for its local-only model.
@@ -240,13 +241,27 @@ function PresetRow({
             </div>
           )}
 
-          {(preset.provider === "custom" || preset.provider === "ollama") && (
+          {(preset.provider === "custom" || preset.provider === "ollama" || preset.provider === "azure") && (
             <EndpointField
               value={baseUrl}
-              mode={apiMode}
+              mode={preset.provider === "azure" ? "azure" : apiMode}
               placeholder={preset.baseUrl ?? "https://your-api.example.com/v1"}
               onChange={(v) => onChange({ baseUrl: v })}
             />
+          )}
+
+          {preset.provider === "azure" && (
+            <div className="space-y-2">
+              <Label>Azure API version</Label>
+              <Input
+                value={azureApiVersion}
+                onChange={(e) => onChange({ azureApiVersion: e.target.value })}
+                placeholder="2024-10-21"
+              />
+              <p className="text-xs text-muted-foreground">
+                Sent as the Azure OpenAI <code className="font-mono">api-version</code> query parameter.
+              </p>
+            </div>
           )}
 
           {preset.provider === "claude-code" && <ClaudeCliStatusPill />}
@@ -269,7 +284,11 @@ function PresetRow({
           )}
 
           <div className="space-y-2">
-            <Label>{t("settings.model")}</Label>
+            <Label>
+              {preset.provider === "azure"
+                ? t("settings.sections.llm.deploymentName", "Deployment name")
+                : t("settings.model")}
+            </Label>
             <ModelPicker
               value={model}
               suggestions={preset.suggestedModels ?? []}
@@ -367,7 +386,7 @@ function ReasoningControls({
 
 interface EndpointFieldProps {
   value: string
-  mode: "chat_completions" | "anthropic_messages"
+  mode: "chat_completions" | "anthropic_messages" | "azure"
   placeholder: string
   onChange: (value: string) => void
 }

--- a/src/components/settings/sections/multimodal-section.tsx
+++ b/src/components/settings/sections/multimodal-section.tsx
@@ -13,6 +13,7 @@ const PROVIDER_OPTIONS: Array<{ value: SettingsDraft["multimodalProvider"]; labe
   { value: "openai", label: "OpenAI" },
   { value: "anthropic", label: "Anthropic" },
   { value: "google", label: "Google (Gemini)" },
+  { value: "azure", label: "Azure OpenAI" },
   { value: "ollama", label: "Ollama" },
 ]
 
@@ -174,18 +175,48 @@ export function MultimodalSection({ draft, setDraft }: Props) {
                 </div>
               )}
 
-              {draft.multimodalProvider === "custom" && (
+              {(draft.multimodalProvider === "custom" || draft.multimodalProvider === "azure") && (
                 <div className="space-y-2">
-                  <Label>{t("settings.sections.multimodal.customEndpoint", "Endpoint URL")}</Label>
+                  <Label>
+                    {draft.multimodalProvider === "azure"
+                      ? t("settings.sections.multimodal.azureEndpoint", "Azure endpoint")
+                      : t("settings.sections.multimodal.customEndpoint", "Endpoint URL")}
+                  </Label>
                   <Input
                     value={draft.multimodalCustomEndpoint}
                     onChange={(e) => setDraft("multimodalCustomEndpoint", e.target.value)}
-                    placeholder="http://localhost:1234/v1"
+                    placeholder={
+                      draft.multimodalProvider === "azure"
+                        ? "https://your-resource.openai.azure.com"
+                        : "http://localhost:1234/v1"
+                    }
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    {draft.multimodalProvider === "azure"
+                      ? t(
+                          "settings.sections.multimodal.azureEndpointHint",
+                          "Use your Azure OpenAI resource endpoint. The model field is the deployment name.",
+                        )
+                      : t(
+                          "settings.sections.multimodal.customEndpointHint",
+                          "OpenAI-compatible /v1 base. LM Studio, llama.cpp server, vLLM, LocalAI all work.",
+                        )}
+                  </p>
+                </div>
+              )}
+
+              {draft.multimodalProvider === "azure" && (
+                <div className="space-y-2">
+                  <Label>{t("settings.sections.multimodal.azureApiVersion", "Azure API version")}</Label>
+                  <Input
+                    value={draft.multimodalAzureApiVersion}
+                    onChange={(e) => setDraft("multimodalAzureApiVersion", e.target.value)}
+                    placeholder="2024-10-21"
                   />
                   <p className="text-xs text-muted-foreground">
                     {t(
-                      "settings.sections.multimodal.customEndpointHint",
-                      "OpenAI-compatible /v1 base. LM Studio, llama.cpp server, vLLM, LocalAI all work.",
+                      "settings.sections.multimodal.azureApiVersionHint",
+                      "Sent as the Azure OpenAI api-version query parameter.",
                     )}
                   </p>
                 </div>
@@ -205,7 +236,11 @@ export function MultimodalSection({ draft, setDraft }: Props) {
               </div>
 
               <div className="space-y-2">
-                <Label>{t("settings.sections.multimodal.model", "Model")}</Label>
+                <Label>
+                  {draft.multimodalProvider === "azure"
+                    ? t("settings.sections.multimodal.azureDeployment", "Deployment name")
+                    : t("settings.sections.multimodal.model", "Model")}
+                </Label>
                 <Input
                   value={draft.multimodalModel}
                   onChange={(e) => setDraft("multimodalModel", e.target.value)}

--- a/src/components/settings/settings-types.ts
+++ b/src/components/settings/settings-types.ts
@@ -9,11 +9,12 @@ import type { ReasoningConfig, SourceWatchConfig } from "@/stores/wiki-store"
  */
 export interface SettingsDraft {
   // LLM provider
-  provider: "openai" | "anthropic" | "google" | "ollama" | "custom" | "minimax" | "claude-code" | "codex-cli"
+  provider: "openai" | "anthropic" | "google" | "azure" | "ollama" | "custom" | "minimax" | "claude-code" | "codex-cli"
   apiKey: string
   model: string
   ollamaUrl: string
   customEndpoint: string
+  azureApiVersion: string
   maxContextSize: number
   apiMode: CustomApiMode | undefined
   reasoning: ReasoningConfig | undefined
@@ -33,11 +34,12 @@ export interface SettingsDraft {
   // Multimodal (image captioning at ingest time)
   multimodalEnabled: boolean
   multimodalUseMainLlm: boolean
-  multimodalProvider: "openai" | "anthropic" | "google" | "ollama" | "custom" | "minimax" | "claude-code" | "codex-cli"
+  multimodalProvider: "openai" | "anthropic" | "google" | "azure" | "ollama" | "custom" | "minimax" | "claude-code" | "codex-cli"
   multimodalApiKey: string
   multimodalModel: string
   multimodalOllamaUrl: string
   multimodalCustomEndpoint: string
+  multimodalAzureApiVersion: string
   multimodalApiMode: CustomApiMode | undefined
   multimodalConcurrency: number
 

--- a/src/components/settings/settings-view.tsx
+++ b/src/components/settings/settings-view.tsx
@@ -103,6 +103,7 @@ function initialDraft(
     model: llm.model,
     ollamaUrl: llm.ollamaUrl,
     customEndpoint: llm.customEndpoint,
+    azureApiVersion: llm.azureApiVersion ?? "2024-10-21",
     maxContextSize: llm.maxContextSize ?? 204800,
     apiMode: llm.apiMode,
     reasoning: llm.reasoning,
@@ -120,6 +121,7 @@ function initialDraft(
     multimodalModel: multimodal.model,
     multimodalOllamaUrl: multimodal.ollamaUrl,
     multimodalCustomEndpoint: multimodal.customEndpoint,
+    multimodalAzureApiVersion: multimodal.azureApiVersion ?? "2024-10-21",
     multimodalApiMode: multimodal.apiMode,
     multimodalConcurrency: multimodal.concurrency,
     outputLanguage,
@@ -255,6 +257,7 @@ export function SettingsView() {
       model: draft.model,
       ollamaUrl: draft.ollamaUrl,
       customEndpoint: draft.customEndpoint,
+      azureApiVersion: draft.provider === "azure" ? draft.azureApiVersion.trim() : undefined,
       maxContextSize: draft.maxContextSize,
       apiMode: draft.provider === "custom" ? draft.apiMode : undefined,
       reasoning: draft.reasoning,
@@ -276,6 +279,7 @@ export function SettingsView() {
       model: draft.multimodalModel,
       ollamaUrl: draft.multimodalOllamaUrl,
       customEndpoint: draft.multimodalCustomEndpoint,
+      azureApiVersion: draft.multimodalProvider === "azure" ? draft.multimodalAzureApiVersion.trim() : undefined,
       apiMode: draft.multimodalProvider === "custom" ? draft.multimodalApiMode : undefined,
       // Clamp at save time so a hand-edited persisted store with a
       // ridiculous concurrency value (e.g. someone setting 1000 in

--- a/src/lib/__tests__/llm-providers.test.ts
+++ b/src/lib/__tests__/llm-providers.test.ts
@@ -3,7 +3,7 @@ import { buildAnthropicUrl, parseGoogleLine, getProviderConfig } from "../llm-pr
 import type { LlmConfig as RealLlmConfig } from "@/stores/wiki-store"
 
 // Inline minimal types to avoid store/zustand dependencies in unit tests
-type Provider = "openai" | "anthropic" | "google" | "ollama" | "custom" | "minimax"
+type Provider = "openai" | "anthropic" | "google" | "azure" | "ollama" | "custom" | "minimax"
 
 interface LlmConfig {
   provider: Provider

--- a/src/lib/endpoint-normalizer.ts
+++ b/src/lib/endpoint-normalizer.ts
@@ -1,3 +1,5 @@
+import { isAzureOpenAiEndpoint } from "@/lib/llm-config-normalize"
+
 /**
  * Clean up user-entered LLM endpoint URLs. Catches the two most common
  * mistakes:
@@ -17,7 +19,7 @@
  * gateways really do mount the API at a bare host.
  */
 
-export type EndpointMode = "chat_completions" | "anthropic_messages"
+export type EndpointMode = "chat_completions" | "anthropic_messages" | "azure"
 
 export interface NormalizedEndpoint {
   /** The cleaned-up URL to store. Empty string for empty input. */
@@ -94,6 +96,37 @@ export function normalizeEndpoint(raw: string, mode: EndpointMode): NormalizedEn
 
   // Strip trailing slashes (cheap, always safe)
   url = url.replace(/\/+$/, "")
+
+  // Azure OpenAI: keep `/openai/deployments/{name}` on the stored base.
+  if (mode === "azure" || isAzureOpenAiEndpoint(url)) {
+    try {
+      const u = new URL(url.includes("://") ? url : `https://${url}`)
+      let pathname = u.pathname.replace(/\/+$/, "")
+      if (/\/chat\/completions\/?$/i.test(pathname)) {
+        pathname = pathname.replace(/\/chat\/completions\/?$/i, "")
+        notes.push(
+          'stripped trailing "chat/completions" — Azure appends this per request',
+        )
+      }
+      url = `${u.origin}${pathname}`
+      if (u.search) {
+        notes.push("stripped query string — api-version is configured separately")
+      }
+    } catch {
+      if (/\/chat\/completions\/?($|\?)/i.test(url)) {
+        url = url.replace(/\/chat\/completions\/?(?=$|\?)/i, "")
+        notes.push(
+          'stripped trailing "chat/completions" — Azure appends this per request',
+        )
+      }
+    }
+    const changed = url !== trimmed
+    return {
+      normalized: url,
+      changed,
+      warning: notes.length ? notes.join(" ") : undefined,
+    }
+  }
 
   // Strip request-path tails users paste by accident. Works in both
   // modes for /chat/completions and /embeddings (wrong shape for either

--- a/src/lib/has-usable-llm.test.ts
+++ b/src/lib/has-usable-llm.test.ts
@@ -15,6 +15,7 @@ const KNOWN_PROVIDERS_WITH_KEY: ReadonlySet<LlmProvider> = new Set([
   "openai",
   "anthropic",
   "google",
+  "azure",
   "minimax",
 ])
 
@@ -76,6 +77,12 @@ describe("hasUsableLlm", () => {
     ).toBe(false)
   })
 
+  it("returns false instead of throwing when a key-required provider has a missing legacy key field", () => {
+    expect(
+      hasUsableLlm({ provider: "azure", apiKey: undefined as unknown as string }),
+    ).toBe(false)
+  })
+
   it("PROVIDERS_WITHOUT_KEY covers the locally-running / CLI-auth providers", () => {
     expect(PROVIDERS_WITHOUT_KEY.has("ollama")).toBe(true)
     expect(PROVIDERS_WITHOUT_KEY.has("custom")).toBe(true)
@@ -87,6 +94,7 @@ describe("hasUsableLlm", () => {
     expect(PROVIDERS_WITHOUT_KEY.has("openai")).toBe(false)
     expect(PROVIDERS_WITHOUT_KEY.has("anthropic")).toBe(false)
     expect(PROVIDERS_WITHOUT_KEY.has("google")).toBe(false)
+    expect(PROVIDERS_WITHOUT_KEY.has("azure")).toBe(false)
     expect(PROVIDERS_WITHOUT_KEY.has("minimax")).toBe(false)
   })
 
@@ -99,6 +107,7 @@ describe("hasUsableLlm", () => {
       "openai",
       "anthropic",
       "google",
+      "azure",
       "ollama",
       "custom",
       "minimax",

--- a/src/lib/has-usable-llm.ts
+++ b/src/lib/has-usable-llm.ts
@@ -15,7 +15,7 @@ export type LlmProvider = LlmConfig["provider"]
  *   - `codex-cli` spawns the Codex CLI subprocess, which authenticates
  *     via the user's existing Codex/ChatGPT login.
  *
- * Hosted providers (openai, anthropic, google, minimax) require a
+ * Hosted providers (openai, anthropic, google, azure, minimax) require a
  * key from the user.
  */
 export const PROVIDERS_WITHOUT_KEY: ReadonlySet<LlmProvider> = new Set<LlmProvider>([
@@ -43,5 +43,5 @@ export function hasUsableLlm(
   cfg: Pick<LlmConfig, "provider" | "apiKey">,
 ): boolean {
   if (PROVIDERS_WITHOUT_KEY.has(cfg.provider)) return true
-  return cfg.apiKey.trim().length > 0
+  return (cfg.apiKey ?? "").trim().length > 0
 }

--- a/src/lib/llm-client.ts
+++ b/src/lib/llm-client.ts
@@ -1,4 +1,5 @@
 import type { LlmConfig } from "@/stores/wiki-store"
+import { isAzureOpenAiEndpoint } from "@/lib/llm-config-normalize"
 import { getProviderConfig, type RequestOverrides } from "./llm-providers"
 import { getHttpFetch, isFetchNetworkError } from "./tauri-fetch"
 import { countReasoningCharsInLine, extractReasoningTextFromLine } from "./reasoning-detector"
@@ -151,6 +152,21 @@ export async function streamChat(
       if (body) errorDetail += ` — ${body}`
     } catch {
       // ignore body read failure
+    }
+    if (
+      response.status === 404 &&
+      (config.provider === "azure" ||
+        (config.provider === "custom" && isAzureOpenAiEndpoint(config.customEndpoint)))
+    ) {
+      onError(
+        new Error(
+          `${errorDetail} — Azure 404 usually means the deployment name is wrong. ` +
+            `Set Model to your Azure deployment name (not the model SKU), ` +
+            `and Endpoint to https://<resource>.openai.azure.com ` +
+            `or .../openai/deployments/<deployment-name>.`,
+        ),
+      )
+      return
     }
     onError(new Error(errorDetail))
     return

--- a/src/lib/llm-config-normalize.test.ts
+++ b/src/lib/llm-config-normalize.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest"
+import {
+  buildAzureOpenAiUrl,
+  normalizeActivePresetId,
+} from "./llm-config-normalize"
+
+describe("buildAzureOpenAiUrl", () => {
+  it("builds deployment chat URL with api-version", () => {
+    expect(
+      buildAzureOpenAiUrl(
+        "https://my-resource.openai.azure.com",
+        "gpt-5",
+        "2024-10-21",
+      ),
+    ).toBe(
+      "https://my-resource.openai.azure.com/openai/deployments/gpt-5/chat/completions?api-version=2024-10-21",
+    )
+  })
+
+  it("reuses deployment embedded in the stored endpoint path", () => {
+    expect(
+      buildAzureOpenAiUrl(
+        "https://my-resource.openai.azure.com/openai/deployments/my-gpt5",
+        "wrong-model",
+        "2024-10-21",
+      ),
+    ).toBe(
+      "https://my-resource.openai.azure.com/openai/deployments/my-gpt5/chat/completions?api-version=2024-10-21",
+    )
+  })
+})
+
+describe("normalizeActivePresetId", () => {
+  it("maps legacy azure-openai preset id to azure", () => {
+    expect(normalizeActivePresetId("azure-openai")).toBe("azure")
+  })
+})

--- a/src/lib/llm-config-normalize.ts
+++ b/src/lib/llm-config-normalize.ts
@@ -1,0 +1,77 @@
+export const AZURE_OPENAI_API_VERSION = "2024-10-21"
+
+export function isAzureOpenAiEndpoint(endpoint: string): boolean {
+  return /\.openai\.azure\.com/i.test(endpoint)
+}
+
+export interface AzureParsedEndpoint {
+  resourceBase: string
+  deployment: string
+  apiVersion: string
+}
+
+/**
+ * Parse an Azure resource URL the user may have pasted in any of the
+ * common shapes (bare host, host + deployment path, full chat URL).
+ * The deployment embedded in the path wins over `fallbackDeployment`.
+ */
+export function parseAzureOpenAiEndpoint(
+  endpoint: string,
+  fallbackDeployment: string,
+  fallbackApiVersion: string,
+): AzureParsedEndpoint | null {
+  const trimmed = endpoint.trim()
+  if (!isAzureOpenAiEndpoint(trimmed)) return null
+
+  let apiVersion = (fallbackApiVersion.trim() || AZURE_OPENAI_API_VERSION)
+  const qMatch = trimmed.match(/[?&]api-version=([^&]+)/i)
+  if (qMatch) apiVersion = decodeURIComponent(qMatch[1])
+
+  const withoutQuery = trimmed.split("?")[0].replace(/\/+$/, "")
+
+  const withDeployment = withoutQuery.match(
+    /^(https?:\/\/[^/]+\.openai\.azure\.com)\/openai\/deployments\/([^/]+)(?:\/chat\/completions)?$/i,
+  )
+  if (withDeployment) {
+    return {
+      resourceBase: withDeployment[1],
+      deployment: decodeURIComponent(withDeployment[2]),
+      apiVersion,
+    }
+  }
+
+  const resourceOnly = withoutQuery.match(/^(https?:\/\/[^/]+\.openai\.azure\.com)(?:\/openai)?$/i)
+  if (resourceOnly) {
+    const deployment = fallbackDeployment.trim()
+    if (!deployment) return null
+    return {
+      resourceBase: resourceOnly[1],
+      deployment,
+      apiVersion,
+    }
+  }
+
+  return null
+}
+
+export function buildAzureOpenAiUrl(
+  endpoint: string,
+  deployment: string,
+  apiVersion: string,
+): string {
+  const parsed = parseAzureOpenAiEndpoint(endpoint, deployment, apiVersion)
+  if (!parsed) {
+    const trimmed = endpoint.replace(/\/+$/, "")
+    const version = encodeURIComponent(apiVersion.trim() || AZURE_OPENAI_API_VERSION)
+    const deploymentPath = `/openai/deployments/${encodeURIComponent(deployment)}/chat/completions`
+    return `${trimmed}${deploymentPath}?api-version=${version}`
+  }
+  const version = encodeURIComponent(parsed.apiVersion)
+  const dep = encodeURIComponent(parsed.deployment)
+  return `${parsed.resourceBase}/openai/deployments/${dep}/chat/completions?api-version=${version}`
+}
+
+export function normalizeActivePresetId(id: string | null): string | null {
+  if (id === "azure-openai") return "azure"
+  return id
+}

--- a/src/lib/llm-providers.test.ts
+++ b/src/lib/llm-providers.test.ts
@@ -126,6 +126,75 @@ describe("Google buildBody — vision content", () => {
   })
 })
 
+describe("Azure OpenAI provider", () => {
+  it("uses Azure deployment URL and api-key auth", () => {
+    const cfg = getProviderConfig(mkConfig({
+      provider: "azure",
+      apiKey: "azure-key",
+      model: "my-gpt-4o-deployment",
+      customEndpoint: "https://example-resource.openai.azure.com",
+    }))
+
+    expect(cfg.url).toBe(
+      "https://example-resource.openai.azure.com/openai/deployments/my-gpt-4o-deployment/chat/completions?api-version=2024-10-21",
+    )
+    expect(cfg.headers["api-key"]).toBe("azure-key")
+    expect(cfg.headers.Authorization).toBeUndefined()
+  })
+
+  it("omits model from the request body because the deployment is in the URL", () => {
+    const cfg = getProviderConfig(mkConfig({
+      provider: "azure",
+      model: "deployment-a",
+      customEndpoint: "https://example-resource.openai.azure.com",
+    }))
+    const body = cfg.buildBody([{ role: "user", content: "hi" }]) as Record<string, unknown>
+
+    expect(body.model).toBeUndefined()
+    expect(body.messages).toEqual([{ role: "user", content: "hi" }])
+  })
+
+  it("uses the configured Azure API version", () => {
+    const cfg = getProviderConfig(mkConfig({
+      provider: "azure",
+      model: "deployment-a",
+      customEndpoint: "https://example-resource.openai.azure.com",
+      azureApiVersion: "2025-01-01-preview",
+    }))
+
+    expect(cfg.url).toContain("api-version=2025-01-01-preview")
+  })
+
+  it("maps max_tokens to max_completion_tokens for Azure GPT-5 deployments", () => {
+    const cfg = getProviderConfig(mkConfig({
+      provider: "azure",
+      model: "gpt-5-nano",
+      customEndpoint: "https://example-resource.openai.azure.com",
+    }))
+    const body = cfg.buildBody(
+      [{ role: "user", content: "hi" }],
+      { max_tokens: 4096 },
+    ) as Record<string, unknown>
+
+    expect(body.max_tokens).toBeUndefined()
+    expect(body.max_completion_tokens).toBe(4096)
+  })
+
+  it("omits unsupported non-default temperature for Azure GPT-5 deployments", () => {
+    const cfg = getProviderConfig(mkConfig({
+      provider: "azure",
+      model: "gpt-5-nano",
+      customEndpoint: "https://example-resource.openai.azure.com",
+    }))
+    const body = cfg.buildBody(
+      [{ role: "user", content: "hi" }],
+      { temperature: 0.1 },
+    ) as Record<string, unknown>
+
+    expect(body.temperature).toBeUndefined()
+  })
+})
+
 describe("Ollama / custom (chat_completions) — vision content", () => {
   it("ollama uses OpenAI-shaped image_url block (works on /v1/chat/completions for vision-capable models)", () => {
     const cfg = mkConfig({

--- a/src/lib/llm-providers.ts
+++ b/src/lib/llm-providers.ts
@@ -1,4 +1,9 @@
 import type { LlmConfig, ReasoningConfig } from "@/stores/wiki-store"
+import {
+  AZURE_OPENAI_API_VERSION,
+  buildAzureOpenAiUrl,
+  isAzureOpenAiEndpoint,
+} from "@/lib/llm-config-normalize"
 
 /**
  * One piece of a multimodal message body. Text + image is the only
@@ -246,9 +251,12 @@ function isKimiEndpoint(config: LlmConfig): boolean {
 }
 
 function isOpenAiStrictCompletionModel(config: LlmConfig): boolean {
-  if (config.provider !== "openai") return false
   const model = config.model.trim().toLowerCase()
-  return /^gpt-5(?:[.\-_]|$)/.test(model) || /^o\d+(?:[.\-_]|$)/.test(model)
+  const strictModel =
+    /^gpt-5(?:[.\-_]|$)/.test(model) || /^o\d+(?:[.\-_]|$)/.test(model)
+  if (!strictModel) return false
+  if (config.provider === "openai" || config.provider === "azure") return true
+  return config.provider === "custom" && isAzureOpenAiEndpoint(config.customEndpoint)
 }
 
 function adaptOpenAiStrictCompletionBody(config: LlmConfig, body: Record<string, unknown>): void {
@@ -613,6 +621,23 @@ export function getProviderConfig(config: LlmConfig): ProviderConfig {
       }
     }
 
+    case "azure": {
+      return {
+        url: buildAzureOpenAiUrl(
+          customEndpoint,
+          model,
+          config.azureApiVersion ?? AZURE_OPENAI_API_VERSION,
+        ),
+        headers: {
+          "Content-Type": JSON_CONTENT_TYPE,
+          "api-key": apiKey,
+        },
+        buildBody: (messages, overrides) =>
+          buildOpenAiCompatibleBody(config, messages, overrides),
+        parseStream: parseOpenAiLine,
+      }
+    }
+
     case "ollama": {
       // Defense-in-depth for the same reason as the custom branch: if a
       // user pasted the full path as their Ollama URL, don't tack on
@@ -689,23 +714,35 @@ export function getProviderConfig(config: LlmConfig): ProviderConfig {
       // a pasted "/chat/completions" tail. Don't double-append in that
       // case, or we'd POST to ".../chat/completions/chat/completions".
       const base = customEndpoint.replace(/\/+$/, "")
-      const url = /\/chat\/completions$/i.test(base)
-        ? base
-        : `${base}/chat/completions`
+      const url = isAzureOpenAiEndpoint(base)
+        ? buildAzureOpenAiUrl(
+            base,
+            model,
+            config.azureApiVersion ?? AZURE_OPENAI_API_VERSION,
+          )
+        : /\/chat\/completions$/i.test(base)
+          ? base
+          : `${base}/chat/completions`
+      const azure = isAzureOpenAiEndpoint(url)
       return {
         url,
         headers: {
           "Content-Type": JSON_CONTENT_TYPE,
-          ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
+          ...(apiKey
+            ? azure
+              ? { "api-key": apiKey }
+              : { Authorization: `Bearer ${apiKey}` }
+            : {}),
           // Local OpenAI-compatible servers (LM Studio, llama.cpp,
           // vLLM, LocalAI) often share Ollama's CORS sensitivity.
           // Same rationale as the `ollama` branch above.
-          ...localLlmOriginHeader(),
+          ...(azure ? {} : localLlmOriginHeader()),
         },
-        buildBody: (messages, overrides) => ({
-          ...buildOpenAiCompatibleBody(config, messages, overrides),
-          model,
-        }),
+        buildBody: (messages, overrides) => {
+          const body = buildOpenAiCompatibleBody(config, messages, overrides)
+          if (!azure) body.model = model
+          return body
+        },
         parseStream: parseOpenAiLine,
       }
     }

--- a/src/lib/project-store.ts
+++ b/src/lib/project-store.ts
@@ -1,6 +1,6 @@
 import { load } from "@tauri-apps/plugin-store"
 import type { WikiProject } from "@/types/wiki"
-import type { LlmConfig, SearchApiConfig, EmbeddingConfig, MultimodalConfig, OutputLanguage, ProviderConfigs, ProxyConfig, ScheduledImportConfig, SourceWatchConfig } from "@/stores/wiki-store"
+import type { LlmConfig, SearchApiConfig, EmbeddingConfig, MultimodalConfig, OutputLanguage, ProviderConfigs, ProviderOverride, ProxyConfig, ScheduledImportConfig, SourceWatchConfig } from "@/stores/wiki-store"
 import { normalizeSourceWatchConfig } from "@/lib/source-watch-config"
 import { normalizePath } from "@/lib/path-utils"
 
@@ -44,6 +44,122 @@ const LLM_CONFIG_KEY = "llmConfig"
 const PROVIDER_CONFIGS_KEY = "providerConfigs"
 const ACTIVE_PRESET_KEY = "activePresetId"
 
+const PROVIDERS = new Set<LlmConfig["provider"]>([
+  "openai",
+  "anthropic",
+  "google",
+  "azure",
+  "ollama",
+  "custom",
+  "minimax",
+  "claude-code",
+  "codex-cli",
+])
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function stringValue(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value : fallback
+}
+
+function numberValue(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback
+}
+
+function normalizeProvider(value: unknown): LlmConfig["provider"] {
+  return typeof value === "string" && PROVIDERS.has(value as LlmConfig["provider"])
+    ? (value as LlmConfig["provider"])
+    : "openai"
+}
+
+function normalizeReasoning(value: unknown): LlmConfig["reasoning"] {
+  if (!isRecord(value) || typeof value.mode !== "string") return { mode: "auto" }
+  const modes = new Set(["auto", "off", "low", "medium", "high", "max", "custom"])
+  if (!modes.has(value.mode)) return { mode: "auto" }
+  return {
+    mode: value.mode as NonNullable<LlmConfig["reasoning"]>["mode"],
+    ...(typeof value.budgetTokens === "number" && Number.isFinite(value.budgetTokens)
+      ? { budgetTokens: value.budgetTokens }
+      : {}),
+  }
+}
+
+function normalizeApiMode(value: unknown): LlmConfig["apiMode"] {
+  return value === "anthropic_messages" ? "anthropic_messages" : "chat_completions"
+}
+
+function normalizeLlmConfig(raw: unknown): LlmConfig | null {
+  if (!isRecord(raw)) return null
+  const provider = normalizeProvider(raw.provider)
+  return {
+    provider,
+    apiKey: stringValue(raw.apiKey),
+    model: stringValue(raw.model),
+    ollamaUrl: stringValue(raw.ollamaUrl, "http://localhost:11434"),
+    customEndpoint: stringValue(raw.customEndpoint),
+    azureApiVersion: provider === "azure" ? stringValue(raw.azureApiVersion, "2024-10-21") : undefined,
+    maxContextSize: numberValue(raw.maxContextSize, 204800),
+    apiMode: provider === "custom" ? normalizeApiMode(raw.apiMode) : undefined,
+    reasoning: normalizeReasoning(raw.reasoning),
+  }
+}
+
+function normalizeProviderOverride(raw: unknown): ProviderOverride {
+  if (!isRecord(raw)) return {}
+  return {
+    ...(typeof raw.apiKey === "string" ? { apiKey: raw.apiKey } : {}),
+    ...(typeof raw.model === "string" ? { model: raw.model } : {}),
+    ...(typeof raw.baseUrl === "string" ? { baseUrl: raw.baseUrl } : {}),
+    ...(typeof raw.azureApiVersion === "string" ? { azureApiVersion: raw.azureApiVersion } : {}),
+    ...(raw.apiMode === "anthropic_messages" || raw.apiMode === "chat_completions"
+      ? { apiMode: raw.apiMode }
+      : {}),
+    ...(typeof raw.maxContextSize === "number" && Number.isFinite(raw.maxContextSize)
+      ? { maxContextSize: raw.maxContextSize }
+      : {}),
+    reasoning: normalizeReasoning(raw.reasoning),
+  }
+}
+
+function normalizeProviderConfigs(raw: unknown): ProviderConfigs | null {
+  if (!isRecord(raw)) return null
+  const next: ProviderConfigs = {}
+  for (const [rawId, value] of Object.entries(raw)) {
+    const id = rawId === "azure-openai" ? "azure" : rawId
+    next[id] = { ...(next[id] ?? {}), ...normalizeProviderOverride(value) }
+  }
+  return next
+}
+
+function normalizeActivePresetId(raw: unknown): string | null {
+  if (raw === null || raw === undefined) return null
+  if (typeof raw !== "string") return null
+  return raw === "azure-openai" ? "azure" : raw
+}
+
+function normalizeMultimodalConfig(raw: unknown): MultimodalConfig | null {
+  if (!isRecord(raw)) return null
+  const provider = normalizeProvider(raw.provider)
+  return {
+    enabled: raw.enabled === true,
+    useMainLlm: raw.useMainLlm !== false,
+    provider,
+    apiKey: stringValue(raw.apiKey),
+    model: stringValue(raw.model),
+    ollamaUrl: stringValue(raw.ollamaUrl, "http://localhost:11434"),
+    customEndpoint: stringValue(raw.customEndpoint),
+    azureApiVersion: provider === "azure" ? stringValue(raw.azureApiVersion, "2024-10-21") : undefined,
+    apiMode: provider === "custom" ? normalizeApiMode(raw.apiMode) : undefined,
+    concurrency: Math.max(1, Math.min(16, numberValue(raw.concurrency, 4))),
+  }
+}
+
+function changed(raw: unknown, normalized: unknown): boolean {
+  return JSON.stringify(raw) !== JSON.stringify(normalized)
+}
+
 export async function saveLlmConfig(config: LlmConfig): Promise<void> {
   const store = await getStore()
   await store.set(LLM_CONFIG_KEY, config)
@@ -51,7 +167,12 @@ export async function saveLlmConfig(config: LlmConfig): Promise<void> {
 
 export async function loadLlmConfig(): Promise<LlmConfig | null> {
   const store = await getStore()
-  return (await store.get<LlmConfig>(LLM_CONFIG_KEY)) ?? null
+  const raw = await store.get<unknown>(LLM_CONFIG_KEY)
+  const normalized = normalizeLlmConfig(raw)
+  if (normalized && changed(raw, normalized)) {
+    await store.set(LLM_CONFIG_KEY, normalized)
+  }
+  return normalized
 }
 
 export async function saveProviderConfigs(configs: ProviderConfigs): Promise<void> {
@@ -61,7 +182,12 @@ export async function saveProviderConfigs(configs: ProviderConfigs): Promise<voi
 
 export async function loadProviderConfigs(): Promise<ProviderConfigs | null> {
   const store = await getStore()
-  return (await store.get<ProviderConfigs>(PROVIDER_CONFIGS_KEY)) ?? null
+  const raw = await store.get<unknown>(PROVIDER_CONFIGS_KEY)
+  const normalized = normalizeProviderConfigs(raw)
+  if (normalized && changed(raw, normalized)) {
+    await store.set(PROVIDER_CONFIGS_KEY, normalized)
+  }
+  return normalized
 }
 
 export async function saveActivePresetId(id: string | null): Promise<void> {
@@ -71,7 +197,12 @@ export async function saveActivePresetId(id: string | null): Promise<void> {
 
 export async function loadActivePresetId(): Promise<string | null> {
   const store = await getStore()
-  return (await store.get<string | null>(ACTIVE_PRESET_KEY)) ?? null
+  const raw = await store.get<unknown>(ACTIVE_PRESET_KEY)
+  const normalized = normalizeActivePresetId(raw)
+  if (changed(raw, normalized)) {
+    await store.set(ACTIVE_PRESET_KEY, normalized)
+  }
+  return normalized
 }
 
 const SEARCH_API_KEY = "searchApiConfig"
@@ -107,7 +238,12 @@ export async function saveMultimodalConfig(config: MultimodalConfig): Promise<vo
 
 export async function loadMultimodalConfig(): Promise<MultimodalConfig | null> {
   const store = await getStore()
-  return (await store.get<MultimodalConfig>(MULTIMODAL_KEY)) ?? null
+  const raw = await store.get<unknown>(MULTIMODAL_KEY)
+  const normalized = normalizeMultimodalConfig(raw)
+  if (normalized && changed(raw, normalized)) {
+    await store.set(MULTIMODAL_KEY, normalized)
+  }
+  return normalized
 }
 
 // IMPORTANT: Keep this key in sync with the Rust setup hook

--- a/src/stores/wiki-store.ts
+++ b/src/stores/wiki-store.ts
@@ -17,11 +17,12 @@ export interface ReasoningConfig {
 }
 
 interface LlmConfig {
-  provider: "openai" | "anthropic" | "google" | "ollama" | "custom" | "minimax" | "claude-code" | "codex-cli"
+  provider: "openai" | "anthropic" | "google" | "azure" | "ollama" | "custom" | "minimax" | "claude-code" | "codex-cli"
   apiKey: string
   model: string
   ollamaUrl: string
   customEndpoint: string
+  azureApiVersion?: string
   maxContextSize: number // max context window in characters
   apiMode?: CustomApiMode
   reasoning?: ReasoningConfig
@@ -162,6 +163,7 @@ interface MultimodalConfig {
   model: string
   ollamaUrl: string
   customEndpoint: string
+  azureApiVersion?: string
   apiMode?: CustomApiMode
   /** Max parallel caption requests during ingest. >=1. */
   concurrency: number
@@ -206,6 +208,7 @@ export interface ProviderOverride {
   apiKey?: string
   model?: string
   baseUrl?: string           // customEndpoint for custom presets, ollamaUrl for ollama
+  azureApiVersion?: string
   apiMode?: CustomApiMode
   maxContextSize?: number
   reasoning?: ReasoningConfig
@@ -284,6 +287,7 @@ export const useWikiStore = create<WikiState>((set) => ({
     model: "",
     ollamaUrl: "http://localhost:11434",
     customEndpoint: "",
+    azureApiVersion: "2024-10-21",
     reasoning: { mode: "auto" },
   },
   providerConfigs: {},
@@ -327,6 +331,7 @@ export const useWikiStore = create<WikiState>((set) => ({
     model: "",
     ollamaUrl: "http://localhost:11434",
     customEndpoint: "",
+    azureApiVersion: "2024-10-21",
     apiMode: "chat_completions",
     concurrency: 4,
   },


### PR DESCRIPTION
Support Azure deployments in presets, multimodal, and request wiring; migrate legacy azure-openai ids on load; fix welcome/create-project scrolling on small viewports.