### PR TITLE
feat: add finding, thesis, methodology types to Knowledge Tree sidebar

### DIFF
--- a/src/components/layout/knowledge-tree.tsx
+++ b/src/components/layout/knowledge-tree.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from "react"
 import {
-  FileText, Users, Lightbulb, BookOpen, HelpCircle, GitMerge, BarChart3, ChevronRight, ChevronDown, Layout, Globe, Trash2,
+  FileText, Users, Lightbulb, BookOpen, HelpCircle, GitMerge, BarChart3, TrendingUp, Target, ChevronRight, ChevronDown, Layout, Globe, Trash2,
 } from "lucide-react"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { Button } from "@/components/ui/button"
@@ -24,8 +24,11 @@ const TYPE_CONFIG: Record<string, { icon: typeof FileText; label: string; color:
   concept:     { icon: Lightbulb,   label: "Concepts",     color: "text-purple-500", order: 2 },
   source:      { icon: BookOpen,    label: "Sources",      color: "text-orange-500", order: 3 },
   synthesis:   { icon: GitMerge,    label: "Synthesis",    color: "text-red-500",    order: 4 },
-  comparison:  { icon: BarChart3,   label: "Comparisons",  color: "text-emerald-500",order: 5 },
-  query:       { icon: HelpCircle,  label: "Queries",      color: "text-green-500",  order: 6 },
+  finding:     { icon: TrendingUp,  label: "Findings",     color: "text-purple-500", order: 5 },
+  thesis:      { icon: Target,      label: "Theses",       color: "text-rose-500",   order: 6 },
+  methodology: { icon: BookOpen,    label: "Methodologies",color: "text-teal-500",   order: 7 },
+  comparison:  { icon: BarChart3,   label: "Comparisons",  color: "text-emerald-500",order: 8 },
+  query:       { icon: HelpCircle,  label: "Queries",      color: "text-green-500",  order: 9 },
 }
 
 const DEFAULT_CONFIG = { icon: FileText, label: "Other", color: "text-muted-foreground", order: 99 }
@@ -329,6 +332,9 @@ function parsePageInfo(path: string, fileName: string, content: string): WikiPag
     else if (path.includes("/queries/")) type = "query"
     else if (path.includes("/comparisons/")) type = "comparison"
     else if (path.includes("/synthesis/")) type = "synthesis"
+    else if (path.includes("/findings/")) type = "finding"
+    else if (path.includes("/thesis/")) type = "thesis"
+    else if (path.includes("/methodology/")) type = "methodology"
     else if (fileName === "overview.md") type = "overview"
   }
 


### PR DESCRIPTION
## Summary

The Knowledge Tree sidebar categorizes wiki pages by their `type` frontmatter field, but only recognizes a fixed set of types. Pages with `type: finding`, `type: thesis`, or `type: methodology` currently fall into the catch-all **"Other"** category despite these being common and semantically distinct node types in many wikis (they already have dedicated styling in `WIKI_TYPE_STYLES` for the graph view).

## Changes

### 1. `TYPE_CONFIG` — new entries (between synthesis and comparison, orders bumped accordingly)

| type | icon | label | color |
|------|------|-------|-------|
| `finding` | TrendingUp | Findings | purple-500 |
| `thesis` | Target | Theses | rose-500 |
| `methodology` | BookOpen | Methodologies | teal-500 |

### 2. `parsePageInfo` — path fallback rules
Added directory-based inference for `/findings/`, `/thesis/`, and `/methodology/` paths, matching the existing pattern for `/entities/`, `/concepts/`, `/sources/`, etc.

### 3. Imports
Added `TrendingUp` and `Target` from lucide-react (BookOpen already imported).

### Order rationale
- **Finding** (order 5) — sits after Synthesis (4), as findings are a post-synthesis deliverable
- **Thesis** (order 6) — follows finding, a higher-level synthesis of findings
- **Methodology** (order 7) — methodological documentation, before Comparison (8)