### PR TITLE
Fix nested source identity handling

### DIFF
--- a/src/lib/extract-source-images.ts
+++ b/src/lib/extract-source-images.ts
@@ -51,12 +51,14 @@ const SUPPORTED_OFFICE_EXTS = ["pptx", "docx", "ppt", "doc"] as const
  * as an empty array — image extraction failure must NEVER abort the
  * ingest pipeline (which is why this isn't `throws`).
  *
- * `slug` is the basename of the source file without extension. Same
- * convention the rest of ingest uses (see `wiki/sources/<slug>.md`).
+ * By default, `slug` is the basename of the source file without extension.
+ * Callers can pass a slug that includes source-folder context so same-named
+ * files from different `raw/sources` subdirectories do not collide.
  */
 export async function extractAndSaveSourceImages(
   projectPath: string,
   sourcePath: string,
+  slugOverride?: string,
 ): Promise<SavedImage[]> {
   const pp = normalizePath(projectPath)
   const sp = normalizePath(sourcePath)
@@ -67,7 +69,7 @@ export async function extractAndSaveSourceImages(
   const isOffice = (SUPPORTED_OFFICE_EXTS as readonly string[]).includes(ext)
   if (!isPdf && !isOffice) return []
 
-  const slug = fileName.replace(/\.[^.]+$/, "")
+  const slug = slugOverride ?? fileName.replace(/\.[^.]+$/, "")
   const destDir = `${pp}/wiki/media/${slug}`
   const relTo = `${pp}/wiki`
 

--- a/src/lib/ingest-source-path-collision.test.ts
+++ b/src/lib/ingest-source-path-collision.test.ts
@@ -1,0 +1,218 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import fs from "node:fs/promises"
+import path from "node:path"
+import { createTempProject, realFs, writeFileRaw } from "@/test-helpers/fs-temp"
+import { useActivityStore } from "@/stores/activity-store"
+import { useChatStore } from "@/stores/chat-store"
+import { useReviewStore } from "@/stores/review-store"
+import { useWikiStore } from "@/stores/wiki-store"
+import { sourceSummarySlugFromIdentity } from "./source-identity"
+
+vi.mock("@/commands/fs", () => realFs)
+
+let sourceMarkers: string[] = []
+
+vi.mock("./llm-client", () => ({
+  streamChat: vi.fn(async (_cfg, messages, cb) => {
+    const systemPrompt = String(messages?.[0]?.content ?? "")
+    const userPrompt = String(messages?.[1]?.content ?? "")
+
+    if (systemPrompt.startsWith("You are merging two versions")) {
+      const incoming = userPrompt.split("## Newly generated version")[1]?.split("---")[2]
+      cb.onToken(incoming?.trim() || "---\ntitle: merged\n---\n\n# merged")
+      cb.onDone()
+      return
+    }
+
+    if (systemPrompt.startsWith("You are a wiki generation assistant")) {
+      cb.onToken([
+        "---FILE: wiki/sources/config.md---",
+        "---",
+        'type: "source"',
+        'title: "Source: config.yaml"',
+        'sources: ["config.yaml"]',
+        "tags: []",
+        "related: []",
+        "---",
+        "",
+        "# Source: config.yaml",
+        "",
+        "Configuration source generated from the chat handoff.",
+        "---END FILE---",
+      ].join("\n"))
+      cb.onDone()
+      return
+    }
+
+    const targetMatch = systemPrompt.match(
+      /source summary page at \*\*(wiki\/sources\/[^*]+)\*\*/,
+    )
+    if (!targetMatch) {
+      cb.onToken("## Analysis\nConfiguration source.")
+      cb.onDone()
+      return
+    }
+
+    const marker = sourceMarkers.shift() ?? "unknown project"
+    const targetPath = targetMatch[1]
+    const sourceIdentity =
+      systemPrompt.match(/original source file is:\s*\*\*([^*]+)\*\*/i)?.[1] ?? "config.yaml"
+    cb.onToken([
+      `---FILE: ${targetPath}---`,
+      "---",
+      `title: "Source: ${sourceIdentity}"`,
+      `sources: ["${sourceIdentity}"]`,
+      "---",
+      "",
+      `# ${marker}`,
+      "",
+      `Configuration details for ${marker}.`,
+      "---END FILE---",
+    ].join("\n"))
+    cb.onDone()
+  }),
+}))
+
+import { autoIngest, executeIngestWrites } from "./ingest"
+
+describe("autoIngest source summary paths", () => {
+  let tmp: { path: string; cleanup: () => Promise<void> } | undefined
+
+  beforeEach(async () => {
+    sourceMarkers = []
+    tmp = await createTempProject("same-basename-sources")
+
+    await writeFileRaw(`${tmp.path}/purpose.md`, "# Purpose\n\nTrack project config files.\n")
+    await writeFileRaw(
+      `${tmp.path}/schema.md`,
+      "# Schema\n\nEach source needs its own source summary page.\n",
+    )
+    await writeFileRaw(`${tmp.path}/wiki/index.md`, "# Index\n")
+    await writeFileRaw(`${tmp.path}/wiki/overview.md`, "# Overview\n")
+    await writeFileRaw(`${tmp.path}/raw/sources/project-a/config.yaml`, "name: alpha\n")
+    await writeFileRaw(`${tmp.path}/raw/sources/project-b/config.yaml`, "name: beta\n")
+
+    useReviewStore.setState({ items: [] })
+    useActivityStore.setState({ items: [] })
+    useChatStore.setState({
+      conversations: [],
+      messages: [],
+      activeConversationId: null,
+      mode: "chat",
+      ingestSource: null,
+      isStreaming: false,
+      streamingContent: "",
+    })
+    useWikiStore.setState({
+      project: {
+        id: "same-basename-sources",
+        name: "same-basename-sources",
+        path: tmp.path,
+      },
+      fileTree: [],
+      outputLanguage: "auto",
+      multimodalConfig: {
+        enabled: false,
+        useMainLlm: true,
+        provider: "openai",
+        apiKey: "",
+        model: "",
+        ollamaUrl: "",
+        customEndpoint: "",
+        concurrency: 1,
+      },
+      embeddingConfig: {
+        enabled: false,
+        endpoint: "",
+        apiKey: "",
+        model: "",
+      },
+    })
+  })
+
+  afterEach(async () => {
+    await tmp?.cleanup()
+    tmp = undefined
+  })
+
+  it("keeps distinct source summaries for same-basename files in different source subdirectories", async () => {
+    if (!tmp) throw new Error("missing temp project")
+    sourceMarkers = ["project-a config", "project-b config"]
+
+    await autoIngest(
+      tmp.path,
+      `${tmp.path}/raw/sources/project-a/config.yaml`,
+      useWikiStore.getState().llmConfig,
+      undefined,
+      "project-a",
+    )
+    await autoIngest(
+      tmp.path,
+      `${tmp.path}/raw/sources/project-b/config.yaml`,
+      useWikiStore.getState().llmConfig,
+      undefined,
+      "project-b",
+    )
+
+    const sourcesDir = path.join(tmp.path, "wiki", "sources")
+    const summaryFiles = (await fs.readdir(sourcesDir))
+      .filter((name) => name.endsWith(".md"))
+      .sort()
+    const summaryContents = await Promise.all(
+      summaryFiles.map((name) => fs.readFile(path.join(sourcesDir, name), "utf8")),
+    )
+    const allSummaries = summaryContents.join("\n\n--- summary boundary ---\n\n")
+
+    expect(summaryFiles).toHaveLength(2)
+    expect(allSummaries).toContain("project-a/config.yaml")
+    expect(allSummaries).toContain("project-b/config.yaml")
+  })
+
+  it("canonicalizes interactive source summary paths and sources frontmatter", async () => {
+    if (!tmp) throw new Error("missing temp project")
+
+    const conversationId = "conv-interactive-source"
+    useChatStore.setState({
+      activeConversationId: conversationId,
+      conversations: [
+        {
+          id: conversationId,
+          title: "Interactive source summary",
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        },
+      ],
+      ingestSource: `${tmp.path}/raw/sources/project-a/config.yaml`,
+      messages: [
+        {
+          id: "user-1",
+          role: "user",
+          content: "Please save the source summary.",
+          timestamp: Date.now(),
+          conversationId,
+        },
+        {
+          id: "assistant-1",
+          role: "assistant",
+          content: "Ready to create the source summary.",
+          timestamp: Date.now(),
+          conversationId,
+        },
+      ],
+    })
+
+    const writtenPaths = await executeIngestWrites(
+      tmp.path,
+      useWikiStore.getState().llmConfig,
+    )
+
+    const canonicalSummary = `wiki/sources/${sourceSummarySlugFromIdentity("project-a/config.yaml")}.md`
+    const canonicalSummaryPath = path.join(tmp.path, canonicalSummary)
+    const staleSummaryPath = path.join(tmp.path, "wiki", "sources", "config.md")
+    const content = await fs.readFile(canonicalSummaryPath, "utf8")
+
+    expect(writtenPaths).toEqual([canonicalSummaryPath])
+    await expect(fs.access(staleSummaryPath)).rejects.toThrow()
+    expect(content).toContain('sources: ["project-a/config.yaml"]')
+  })
+})

--- a/src/lib/ingest.scenarios.test.ts
+++ b/src/lib/ingest.scenarios.test.ts
@@ -12,7 +12,7 @@
 import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from "vitest"
 import path from "node:path"
 import fs from "node:fs/promises"
-import { realFs, createTempProject, readFileRaw, fileExists } from "@/test-helpers/fs-temp"
+import { realFs, createTempProject, readFileRaw, writeFileRaw, fileExists } from "@/test-helpers/fs-temp"
 import { materializeScenario, copyDir } from "@/test-helpers/scenarios/materialize"
 import { ingestScenarios } from "@/test-helpers/scenarios/ingest-scenarios"
 import type { IngestScenario } from "@/test-helpers/scenarios/types"
@@ -195,4 +195,92 @@ describe("ingest scenarios (fixture-driven)", () => {
       await assertOutcome(scenario, ctx.tmp.path)
     },
   )
+
+  it("keeps source summaries distinct for same basenames in different source folders", async () => {
+    ctx = { tmp: await createTempProject("ingest-duplicate-source-basenames") }
+    const projectPath = ctx.tmp.path
+
+    await writeFileRaw(`${projectPath}/schema.md`, "")
+    await writeFileRaw(`${projectPath}/purpose.md`, "")
+    await writeFileRaw(`${projectPath}/wiki/index.md`, "# Index\n")
+    await writeFileRaw(`${projectPath}/wiki/overview.md`, "")
+    await writeFileRaw(`${projectPath}/raw/sources/project-a/config.yaml`, "name: project-a\n")
+    await writeFileRaw(`${projectPath}/raw/sources/project-b/config.yaml`, "name: project-b\n")
+
+    useWikiStore.setState({
+      project: {
+        name: "t",
+        path: projectPath,
+        createdAt: 0,
+        purposeText: "",
+        fileTree: [],
+      } as unknown as ReturnType<typeof useWikiStore.getState>["project"],
+    })
+    useWikiStore.getState().setLlmConfig({
+      provider: "openai",
+      apiKey: "test-key",
+      model: "gpt-4",
+      ollamaUrl: "",
+      customEndpoint: "",
+      maxContextSize: 128000,
+    })
+
+    pendingResponses = [
+      "analysis for project A",
+      [
+        "---FILE: wiki/sources/config.md---",
+        "---",
+        'type: "source"',
+        'title: "Source: config.yaml"',
+        'sources: ["config.yaml"]',
+        "tags: []",
+        "related: []",
+        "---",
+        "",
+        "# Project A",
+        "",
+        "analysis for project A",
+        "---END FILE---",
+      ].join("\n"),
+      "analysis for project B",
+      [
+        "---FILE: wiki/sources/config.md---",
+        "---",
+        'type: "source"',
+        'title: "Source: config.yaml"',
+        'sources: ["config.yaml"]',
+        "tags: []",
+        "related: []",
+        "---",
+        "",
+        "# Project B",
+        "",
+        "analysis for project B",
+        "---END FILE---",
+      ].join("\n"),
+    ]
+
+    const cfg = useWikiStore.getState().llmConfig
+    const firstWritten = await autoIngest(
+      projectPath,
+      `${projectPath}/raw/sources/project-a/config.yaml`,
+      cfg,
+    )
+    const secondWritten = await autoIngest(
+      projectPath,
+      `${projectPath}/raw/sources/project-b/config.yaml`,
+      cfg,
+    )
+
+    expect(firstWritten).toContain("wiki/sources/9-project-a--6-config--3eym4.md")
+    expect(secondWritten).toContain("wiki/sources/9-project-b--6-config--177z4nx.md")
+    expect(await fileExists(`${projectPath}/wiki/sources/config.md`)).toBe(false)
+
+    const projectA = await readFileRaw(`${projectPath}/wiki/sources/9-project-a--6-config--3eym4.md`)
+    const projectB = await readFileRaw(`${projectPath}/wiki/sources/9-project-b--6-config--177z4nx.md`)
+    expect(projectA).toContain('sources: ["project-a/config.yaml"]')
+    expect(projectA).toContain("analysis for project A")
+    expect(projectB).toContain('sources: ["project-b/config.yaml"]')
+    expect(projectB).toContain("analysis for project B")
+  })
 })

--- a/src/lib/ingest.ts
+++ b/src/lib/ingest.ts
@@ -6,6 +6,11 @@ import { useChatStore } from "@/stores/chat-store"
 import { useActivityStore } from "@/stores/activity-store"
 import { useReviewStore, type ReviewItem } from "@/stores/review-store"
 import { getFileName, normalizePath } from "@/lib/path-utils"
+import {
+  sourceIdentityForPath,
+  sourceSummarySlugFromIdentity,
+} from "@/lib/source-identity"
+import { parseSources, writeSources } from "@/lib/sources-merge"
 import { checkIngestCache, saveIngestCache } from "@/lib/ingest-cache"
 import { sanitizeIngestedFileContent } from "@/lib/ingest-sanitize"
 import { mergePageContent, type MergeFn } from "@/lib/page-merge"
@@ -307,6 +312,9 @@ async function autoIngestImpl(
   const sp = normalizePath(sourcePath)
   const activity = useActivityStore.getState()
   const fileName = getFileName(sp)
+  const sourceIdentity = sourceIdentityForPath(pp, sp)
+  const sourceSummarySlug = sourceSummarySlugFromIdentity(sourceIdentity)
+  const sourceSummaryPath = `wiki/sources/${sourceSummarySlug}.md`
   console.log(`[ingest:diag] autoIngestImpl ENTRY for "${fileName}" (project="${pp}", source="${sp}")`)
   const activityId = activity.addItem({
     type: "ingest",
@@ -334,12 +342,12 @@ async function autoIngestImpl(
   // re-running them costs only the extraction time and converges the
   // source-summary page on the current pipeline's contract regardless
   // of when the file was first ingested.
-  const cachedFiles = await checkIngestCache(pp, fileName, sourceContent)
-  console.log(`[ingest:diag] cache check for "${fileName}":`, cachedFiles === null ? "MISS (full pipeline)" : `HIT (${cachedFiles.length} cached files)`)
+  const cachedFiles = await checkIngestCache(pp, sourceIdentity, sourceContent)
+  console.log(`[ingest:diag] cache check for "${sourceIdentity}":`, cachedFiles === null ? "MISS (full pipeline)" : `HIT (${cachedFiles.length} cached files)`)
   if (cachedFiles !== null) {
     try {
       console.log(`[ingest:diag] cache-hit branch: starting image extraction for ${sp}`)
-      const savedImages = await extractAndSaveSourceImages(pp, sp)
+      const savedImages = await extractAndSaveSourceImages(pp, sp, sourceSummarySlug)
       console.log(`[ingest:diag] cache-hit branch: got ${savedImages.length} image(s)`)
       if (savedImages.length > 0) {
         // Caption first (populates the cache), THEN inject — the
@@ -370,7 +378,7 @@ async function autoIngestImpl(
               await captionMarkdownImages(pp, sourceContent, captionLlm, {
                 signal,
                 shouldCaption: (url) =>
-                  url.startsWith(`${pp}/wiki/media/${fileName.replace(/\.[^.]+$/, "")}/`),
+                  url.startsWith(`${pp}/wiki/media/${sourceSummarySlug}/`),
                 urlToAbsPath: (url) => url,
                 concurrency: mmCfg.concurrency,
                 onProgress: (done, total) =>
@@ -385,14 +393,14 @@ async function autoIngestImpl(
               )
             }
           }
-          await injectImagesIntoSourceSummary(pp, fileName, savedImages)
+          await injectImagesIntoSourceSummary(pp, sourceIdentity, sourceSummarySlug, savedImages)
           // Re-embed the source-summary page so caption text lands
           // in the search index. Without this step, search by image
           // content stays empty for files ingested before captioning
           // was added — the safety-net section was just rewritten
           // with captions, but the embeddings still reflect the old
           // empty-alt content.
-          await reembedSourceSummary(pp, fileName)
+          await reembedSourceSummary(pp, sourceIdentity, sourceSummarySlug)
         }
       } else {
         console.log(`[ingest:diag] cache-hit branch: skipping injection (no images returned from extraction)`)
@@ -430,11 +438,11 @@ async function autoIngestImpl(
   // and returns [] on any error.
   activity.updateItem(activityId, { detail: "Extracting embedded images..." })
   console.log(`[ingest:diag] full-pipeline branch: starting image extraction for ${sp}`)
-  const savedImages = await extractAndSaveSourceImages(pp, sp)
+  const savedImages = await extractAndSaveSourceImages(pp, sp, sourceSummarySlug)
   console.log(`[ingest:diag] full-pipeline branch: got ${savedImages.length} image(s)`)
   if (savedImages.length > 0) {
     console.log(
-      `[ingest:images] saved ${savedImages.length} image(s) for "${fileName}" → wiki/media/${fileName.replace(/\.[^.]+$/, "")}/`,
+      `[ingest:images] saved ${savedImages.length} image(s) for "${sourceIdentity}" → wiki/media/${sourceSummarySlug}/`,
     )
   }
 
@@ -497,8 +505,7 @@ async function autoIngestImpl(
     /!\[\]\(/.test(sourceContent)
   ) {
     activity.updateItem(activityId, { detail: "Captioning images..." })
-    const sourceSlug = fileName.replace(/\.[^.]+$/, "")
-    const ourMediaPrefix = `${pp}/wiki/media/${sourceSlug}/`
+    const ourMediaPrefix = `${pp}/wiki/media/${sourceSummarySlug}/`
     try {
       const result = await captionMarkdownImages(pp, sourceContent, captionLlm, {
         signal,
@@ -544,7 +551,7 @@ async function autoIngestImpl(
     llmConfig,
     [
       { role: "system", content: buildAnalysisPrompt(purpose, index, truncatedContent) },
-      { role: "user", content: `Analyze this source document:\n\n**File:** ${fileName}${folderContext ? `\n**Folder context:** ${folderContext}` : ""}\n\n---\n\n${truncatedContent}` },
+      { role: "user", content: `Analyze this source document:\n\n**File:** ${sourceIdentity}${folderContext ? `\n**Folder context:** ${folderContext}` : ""}\n\n---\n\n${truncatedContent}` },
     ],
     {
       onToken: (token) => { analysis += token },
@@ -574,11 +581,11 @@ async function autoIngestImpl(
   await streamChat(
     llmConfig,
     [
-      { role: "system", content: buildGenerationPrompt(schema, purpose, index, fileName, overview, truncatedContent) },
+      { role: "system", content: buildGenerationPrompt(schema, purpose, index, sourceIdentity, overview, truncatedContent, sourceSummaryPath) },
       {
         role: "user",
         content: [
-          `Source document to process: **${fileName}**`,
+          `Source document to process: **${sourceIdentity}**`,
           "",
           "The Stage 1 analysis below is CONTEXT to inform your output. Do NOT echo",
           "its tables, bullet points, or prose. Your output must be FILE/REVIEW",
@@ -594,7 +601,7 @@ async function autoIngestImpl(
           "",
           "---",
           "",
-          `Now emit the FILE blocks for the wiki files derived from **${fileName}**.`,
+          `Now emit the FILE blocks for the wiki files derived from **${sourceIdentity}**.`,
           "Your response MUST begin with `---FILE:` as the very first characters.",
           "No preamble. No analysis prose. Start immediately.",
         ].join("\n"),
@@ -622,7 +629,8 @@ async function autoIngestImpl(
     pp,
     generation,
     llmConfig,
-    fileName,
+    sourceIdentity,
+    sourceSummaryPath,
     signal,
   )
 
@@ -638,10 +646,8 @@ async function autoIngestImpl(
   }
 
   // Ensure source summary page exists (LLM may not have generated it correctly)
-  const sourceBaseName = fileName.replace(/\.[^.]+$/, "")
-  const sourceSummaryPath = `wiki/sources/${sourceBaseName}.md`
   const sourceSummaryFullPath = `${pp}/${sourceSummaryPath}`
-  const hasSourceSummary = writtenPaths.some((p) => p.startsWith("wiki/sources/"))
+  const hasSourceSummary = writtenPaths.some((p) => normalizePath(p) === sourceSummaryPath)
 
   // If the signal was aborted (e.g. user switched projects / cancelled),
   // skip the fallback summary write — the LLM streams returned empty
@@ -654,15 +660,15 @@ async function autoIngestImpl(
     const fallbackContent = [
       "---",
       `type: source`,
-      `title: "Source: ${fileName}"`,
+      `title: "Source: ${sourceIdentity}"`,
       `created: ${date}`,
       `updated: ${date}`,
-      `sources: ["${fileName}"]`,
+      `sources: ["${sourceIdentity}"]`,
       `tags: []`,
       `related: []`,
       "---",
       "",
-      `# Source: ${fileName}`,
+      `# Source: ${sourceIdentity}`,
       "",
       analysis ? analysis.slice(0, 3000) : "(Analysis not available)",
       "",
@@ -681,7 +687,7 @@ async function autoIngestImpl(
   // want the safety-net section to slip image refs into the wiki
   // through the back door.
   if (mmCfg.enabled && savedImages.length > 0 && !signal?.aborted) {
-    await injectImagesIntoSourceSummary(pp, fileName, savedImages)
+    await injectImagesIntoSourceSummary(pp, sourceIdentity, sourceSummarySlug, savedImages)
   }
 
   if (writtenPaths.length > 0) {
@@ -710,10 +716,10 @@ async function autoIngestImpl(
   // — they represent deterministic decisions and caching them is
   // safe.
   if (writtenPaths.length > 0 && hardFailures.length === 0) {
-    await saveIngestCache(pp, fileName, sourceContent, writtenPaths)
+    await saveIngestCache(pp, sourceIdentity, sourceContent, writtenPaths)
   } else if (hardFailures.length > 0) {
     console.warn(
-      `[ingest] Skipping cache save for "${fileName}" — ${hardFailures.length} block(s) failed to write: ${hardFailures.join(", ")}`,
+      `[ingest] Skipping cache save for "${sourceIdentity}" — ${hardFailures.length} block(s) failed to write: ${hardFailures.join(", ")}`,
     )
   }
 
@@ -786,11 +792,53 @@ function contentMatchesTargetLanguage(content: string, target: string): boolean 
   return !detectedIsCjk
 }
 
+function isLogPath(relativePath: string): boolean {
+  return relativePath === "wiki/log.md" || relativePath.endsWith("/log.md")
+}
+
+function isListingPath(relativePath: string): boolean {
+  return (
+    relativePath === "wiki/index.md" ||
+    relativePath.endsWith("/index.md") ||
+    relativePath === "wiki/overview.md" ||
+    relativePath.endsWith("/overview.md")
+  )
+}
+
+function canonicalizeSourcesField(content: string, sourceIdentity: string): string {
+  if (!/^---\n/.test(content)) return content
+
+  const identityKey = normalizePath(sourceIdentity).toLowerCase()
+  const identityBaseName = getFileName(sourceIdentity).toLowerCase()
+  const sourceValues = parseSources(content)
+  const canonicalValues = sourceValues.map((source) => {
+    const normalized = normalizePath(source)
+    const key = normalized.toLowerCase()
+    if (key === identityKey) return sourceIdentity
+    if (!normalized.includes("/") && key === identityBaseName) return sourceIdentity
+    return source
+  })
+  if (!canonicalValues.some((source) => normalizePath(source).toLowerCase() === identityKey)) {
+    canonicalValues.push(sourceIdentity)
+  }
+
+  const seen = new Set<string>()
+  const deduped = canonicalValues.filter((source) => {
+    const key = normalizePath(source).toLowerCase()
+    if (seen.has(key)) return false
+    seen.add(key)
+    return true
+  })
+
+  return writeSources(content, deduped)
+}
+
 async function writeFileBlocks(
   projectPath: string,
   text: string,
   llmConfig: LlmConfig,
   sourceFileName: string,
+  sourceSummaryPath?: string,
   signal?: AbortSignal,
 ): Promise<{ writtenPaths: string[]; warnings: string[]; hardFailures: string[] }> {
   const { blocks, warnings: parseWarnings } = parseFileBlocks(text)
@@ -808,7 +856,12 @@ async function writeFileBlocks(
 
   const targetLang = useWikiStore.getState().outputLanguage
 
-  for (const { path: relativePath, content: rawContent } of blocks) {
+  for (const { path: rawRelativePath, content: rawContent } of blocks) {
+    let relativePath = rawRelativePath
+    if (sourceSummaryPath && relativePath.startsWith("wiki/sources/")) {
+      relativePath = sourceSummaryPath
+    }
+
     // Sanitize at the boundary — strip stray code-fence wrappers,
     // `frontmatter:` prefixes, and repair invalid wikilink-list
     // YAML lines so the file we write is canonical regardless of
@@ -817,7 +870,10 @@ async function writeFileBlocks(
     // step ~45% of generated entity pages went to disk with
     // unparseable frontmatter and the read-time fallback had to
     // paper over it forever.
-    const content = sanitizeIngestedFileContent(rawContent)
+    let content = sanitizeIngestedFileContent(rawContent)
+    if (!isLogPath(relativePath) && !isListingPath(relativePath)) {
+      content = canonicalizeSourcesField(content, sourceFileName)
+    }
 
     // Language guard: reject individual FILE blocks whose body contradicts
     // the user-set target language. Skip:
@@ -827,8 +883,7 @@ async function writeFileBlocks(
     //   quotes Russian philosophers) which confuses naive script-based
     //   detection. Keep the check for /concepts/ pages, which should be
     //   authoritative content in the target language.
-    const isLog =
-      relativePath.endsWith("/log.md") || relativePath === "wiki/log.md"
+    const isLog = isLogPath(relativePath)
     const isEntityOrSource =
       relativePath.startsWith("wiki/entities/") ||
       relativePath.includes("/entities/") ||
@@ -849,15 +904,12 @@ async function writeFileBlocks(
 
     const fullPath = `${projectPath}/${relativePath}`
     try {
-      if (relativePath === "wiki/log.md" || relativePath.endsWith("/log.md")) {
+      if (isLogPath(relativePath)) {
         const existing = await tryReadFile(fullPath)
         const appended = existing ? `${existing}\n\n${content.trim()}` : content.trim()
         await writeFile(fullPath, appended)
       } else if (
-        relativePath === "wiki/index.md" ||
-        relativePath.endsWith("/index.md") ||
-        relativePath === "wiki/overview.md" ||
-        relativePath.endsWith("/overview.md")
+        isListingPath(relativePath)
       ) {
         // Listing pages (index / overview) are always overwritten
         // wholesale — their sources field is incidental and merging
@@ -1026,9 +1078,18 @@ export function buildAnalysisPrompt(purpose: string, index: string, sourceConten
 /**
  * Step 2 prompt: AI takes its own analysis and generates wiki files + review items.
  */
-export function buildGenerationPrompt(schema: string, purpose: string, index: string, sourceFileName: string, overview?: string, sourceContent: string = ""): string {
+export function buildGenerationPrompt(
+  schema: string,
+  purpose: string,
+  index: string,
+  sourceFileName: string,
+  overview?: string,
+  sourceContent: string = "",
+  sourceSummaryPath?: string,
+): string {
   // Use original filename (without extension) as the source summary page name
   const sourceBaseName = sourceFileName.replace(/\.[^.]+$/, "")
+  const summaryPath = sourceSummaryPath ?? `wiki/sources/${sourceBaseName}.md`
 
   return [
     "You are a wiki maintainer. Based on the analysis provided, generate wiki files.",
@@ -1042,7 +1103,7 @@ export function buildGenerationPrompt(schema: string, purpose: string, index: st
     "",
     "## What to generate",
     "",
-    `1. A source summary page at **wiki/sources/${sourceBaseName}.md** (MUST use this exact path)`,
+    `1. A source summary page at **${summaryPath}** (MUST use this exact path)`,
     "2. Entity pages in wiki/entities/ for key entities identified in the analysis",
     "3. Concept pages in wiki/concepts/ for key concepts identified in the analysis",
     "4. An updated wiki/index.md — add new entries to existing categories, preserve all existing entries",
@@ -1292,12 +1353,12 @@ async function backupExistingPage(
  */
 async function injectImagesIntoSourceSummary(
   pp: string,
-  fileName: string,
+  sourceIdentity: string,
+  sourceSummarySlug: string,
   savedImages: { relPath: string; page: number | null; sha256?: string }[],
 ): Promise<void> {
   if (savedImages.length === 0) return
-  const sourceBaseName = fileName.replace(/\.[^.]+$/, "")
-  const sourceSummaryPath = `wiki/sources/${sourceBaseName}.md`
+  const sourceSummaryPath = `wiki/sources/${sourceSummarySlug}.md`
   const sourceSummaryFullPath = `${pp}/${sourceSummaryPath}`
   console.log(`[ingest:diag] injectImagesIntoSourceSummary: target=${sourceSummaryFullPath}, images=${savedImages.length}`)
   try {
@@ -1331,15 +1392,15 @@ async function injectImagesIntoSourceSummary(
       const stubFrontmatter = [
         "---",
         "type: source",
-        `title: "Source: ${fileName}"`,
+        `title: "Source: ${sourceIdentity}"`,
         `created: ${date}`,
         `updated: ${date}`,
-        `sources: ["${fileName}"]`,
+        `sources: ["${sourceIdentity}"]`,
         "tags: []",
         "related: []",
         "---",
         "",
-        `# Source: ${fileName}`,
+        `# Source: ${sourceIdentity}`,
         "",
       ].join("\n")
       await writeFile(sourceSummaryFullPath, stubFrontmatter + wrapped)
@@ -1369,23 +1430,26 @@ async function injectImagesIntoSourceSummary(
  * already exist in the step-6 logic. Wrapping them once here
  * avoids drift between the two paths if either side changes.
  */
-async function reembedSourceSummary(pp: string, fileName: string): Promise<void> {
+async function reembedSourceSummary(
+  pp: string,
+  sourceIdentity: string,
+  sourceSummarySlug: string,
+): Promise<void> {
   const embCfg = useWikiStore.getState().embeddingConfig
   if (!embCfg.enabled || !embCfg.model) return
-  const sourceBaseName = fileName.replace(/\.[^.]+$/, "")
-  const sourceSummaryFullPath = `${pp}/wiki/sources/${sourceBaseName}.md`
+  const sourceSummaryFullPath = `${pp}/wiki/sources/${sourceSummarySlug}.md`
   try {
     const content = await readFile(sourceSummaryFullPath)
     const titleMatch = content.match(
       /^---\n[\s\S]*?^title:\s*["']?(.+?)["']?\s*$/m,
     )
-    const title = titleMatch ? titleMatch[1].trim() : sourceBaseName
+    const title = titleMatch ? titleMatch[1].trim() : sourceIdentity
     const { embedPage } = await import("@/lib/embedding")
-    await embedPage(pp, sourceBaseName, title, content, embCfg)
-    console.log(`[ingest:caption] re-embedded ${sourceBaseName} with captioned alt text`)
+    await embedPage(pp, sourceSummarySlug, title, content, embCfg)
+    console.log(`[ingest:caption] re-embedded ${sourceSummarySlug} with captioned alt text`)
   } catch (err) {
     console.warn(
-      `[ingest:caption] re-embed failed for ${sourceBaseName}:`,
+      `[ingest:caption] re-embed failed for ${sourceSummarySlug}:`,
       err instanceof Error ? err.message : err,
     )
   }
@@ -1399,6 +1463,8 @@ export async function startIngest(
 ): Promise<void> {
   const pp = normalizePath(projectPath)
   const sp = normalizePath(sourcePath)
+  const sourceIdentity = sourceIdentityForPath(pp, sp)
+  const sourceSummarySlug = sourceSummarySlugFromIdentity(sourceIdentity)
   const store = getStore()
   store.setMode("ingest")
   store.setIngestSource(sp)
@@ -1414,7 +1480,7 @@ export async function startIngest(
   // Failure-tolerant — `extractAndSaveSourceImages` returns [] on
   // any error and logs internally; we never want image extraction
   // to break the ingest chat flow.
-  void extractAndSaveSourceImages(pp, sp).catch((err) => {
+  void extractAndSaveSourceImages(pp, sp, sourceSummarySlug).catch((err) => {
     console.warn(
       `[startIngest:images] eager extraction failed for "${getFileName(sp)}":`,
       err instanceof Error ? err.message : err,
@@ -1427,8 +1493,6 @@ export async function startIngest(
     tryReadFile(`${pp}/wiki/purpose.md`),
     tryReadFile(`${pp}/wiki/index.md`),
   ])
-
-  const fileName = getFileName(sp)
 
   const systemPrompt = [
     "You are a knowledgeable assistant helping to build a wiki from source documents.",
@@ -1443,12 +1507,12 @@ export async function startIngest(
     .join("\n\n")
 
   const userMessage = [
-    `I'm ingesting the following source file into my wiki: **${fileName}**`,
+    `I'm ingesting the following source file into my wiki: **${sourceIdentity}**`,
     "",
     "Please read it carefully and present the key takeaways, important concepts, and information that would be valuable to capture in the wiki. Highlight anything that relates to the wiki's purpose and schema.",
     "",
     "---",
-    `**File: ${fileName}**`,
+    `**File: ${sourceIdentity}**`,
     "```",
     sourceContent || "(empty file)",
     "```",
@@ -1489,6 +1553,16 @@ export async function executeIngestWrites(
 ): Promise<string[]> {
   const pp = normalizePath(projectPath)
   const store = getStore()
+  const ingestSource = store.ingestSource
+  const activeSourceIdentity = ingestSource
+    ? sourceIdentityForPath(pp, ingestSource)
+    : null
+  const activeSourceSummarySlug = activeSourceIdentity
+    ? sourceSummarySlugFromIdentity(activeSourceIdentity)
+    : null
+  const activeSourceSummaryPath = activeSourceSummarySlug
+    ? `wiki/sources/${activeSourceSummarySlug}.md`
+    : null
 
   const [schema, index] = await Promise.all([
     tryReadFile(`${pp}/wiki/schema.md`),
@@ -1506,6 +1580,14 @@ export async function executeIngestWrites(
     "",
     schema ? `## Wiki Schema\n${schema}` : "",
     index ? `## Current Wiki Index\n${index}` : "",
+    activeSourceIdentity && activeSourceSummaryPath
+      ? [
+          `## Source File`,
+          `The original source file is: **${activeSourceIdentity}**`,
+          `If you generate a source summary page, it MUST use this exact path: **${activeSourceSummaryPath}**.`,
+          `Every page generated from this source MUST include "${activeSourceIdentity}" in its frontmatter \`sources\` field.`,
+        ].join("\n")
+      : "",
     "",
     "Output ONLY the file contents in this exact format for each file:",
     "```",
@@ -1567,15 +1649,29 @@ export async function executeIngestWrites(
   const matches = accumulated.matchAll(FILE_BLOCK_REGEX)
 
   for (const match of matches) {
-    const relativePath = match[1].trim()
-    const content = match[2]
+    let relativePath = match[1].trim()
+    let content = match[2]
 
     if (!relativePath) continue
+    if (
+      activeSourceSummaryPath &&
+      relativePath.startsWith("wiki/sources/")
+    ) {
+      relativePath = activeSourceSummaryPath
+    }
+
+    if (
+      activeSourceIdentity &&
+      !isLogPath(relativePath) &&
+      !isListingPath(relativePath)
+    ) {
+      content = canonicalizeSourcesField(content, activeSourceIdentity)
+    }
 
     const fullPath = `${pp}/${relativePath}`
 
     try {
-      if (relativePath === "wiki/log.md" || relativePath.endsWith("/log.md")) {
+      if (isLogPath(relativePath)) {
         const existing = await tryReadFile(fullPath)
         const appended = existing
           ? `${existing}\n\n${content.trim()}`
@@ -1612,7 +1708,6 @@ export async function executeIngestWrites(
   // parameter (the chat-panel "Save to Wiki" button only passes
   // projectPath). Skipped silently when there's no ingestSource
   // (e.g. user manually entered chat mode and called this).
-  const ingestSource = getStore().ingestSource
   // Master toggle gate — see autoIngestImpl Step 0.6 / 3.5 for
   // the full rationale. When captioning is disabled, we skip the
   // safety-net inject here too so the executeIngestWrites path
@@ -1620,10 +1715,11 @@ export async function executeIngestWrites(
   const mmCfgWrites = useWikiStore.getState().multimodalConfig
   if (ingestSource && mmCfgWrites.enabled) {
     try {
-      const savedImages = await extractAndSaveSourceImages(pp, ingestSource)
+      const sourceIdentity = sourceIdentityForPath(pp, ingestSource)
+      const sourceSummarySlug = sourceSummarySlugFromIdentity(sourceIdentity)
+      const savedImages = await extractAndSaveSourceImages(pp, ingestSource, sourceSummarySlug)
       if (savedImages.length > 0) {
-        const fileName = getFileName(ingestSource)
-        await injectImagesIntoSourceSummary(pp, fileName, savedImages)
+        await injectImagesIntoSourceSummary(pp, sourceIdentity, sourceSummarySlug, savedImages)
       }
     } catch (err) {
       console.warn(

--- a/src/lib/raw-source-resolver.test.ts
+++ b/src/lib/raw-source-resolver.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { createTempProject, realFs, writeFileRaw } from "@/test-helpers/fs-temp"
+import { findRawSourceForImage, imageUrlToAbsolute } from "./raw-source-resolver"
+import { sourceSummarySlugFromIdentity } from "./source-identity"
+
+vi.mock("@/commands/fs", () => realFs)
+
+describe("raw source image resolver", () => {
+  let tmp: { path: string; cleanup: () => Promise<void> } | undefined
+
+  beforeEach(async () => {
+    tmp = await createTempProject("raw-source-resolver")
+    await writeFileRaw(`${tmp.path}/raw/sources/report.pdf`, "root source\n")
+    await writeFileRaw(`${tmp.path}/raw/sources/project-a/config.pdf`, "nested source\n")
+  })
+
+  afterEach(async () => {
+    await tmp?.cleanup()
+    tmp = undefined
+  })
+
+  it("resolves legacy root-level media slugs by raw source stem", async () => {
+    if (!tmp) throw new Error("missing temp project")
+
+    await expect(
+      findRawSourceForImage(`${tmp.path}/wiki/media/report/img-1.png`, tmp.path),
+    ).resolves.toBe(`${tmp.path}/raw/sources/report.pdf`)
+  })
+
+  it("resolves nested source media slugs by source-summary slug", async () => {
+    if (!tmp) throw new Error("missing temp project")
+
+    const slug = sourceSummarySlugFromIdentity("project-a/config.pdf")
+
+    await expect(
+      findRawSourceForImage(`media/${slug}/img-1.png`, tmp.path),
+    ).resolves.toBe(`${tmp.path}/raw/sources/project-a/config.pdf`)
+  })
+
+  it("normalizes wiki-relative image URLs to absolute wiki media paths", () => {
+    expect(imageUrlToAbsolute("media/report/img-1.png", "/project")).toBe(
+      "/project/wiki/media/report/img-1.png",
+    )
+  })
+})

--- a/src/lib/raw-source-resolver.ts
+++ b/src/lib/raw-source-resolver.ts
@@ -3,14 +3,10 @@
  *
  * Image URLs we generate always live under
  *   `<project>/wiki/media/<slug>/img-N.<ext>`
- * — emitted either ABSOLUTE (from the unified Rust extractor that
- * runs at `read_file` time) or WIKI-RELATIVE
- * (`media/<slug>/img-N.png`, from the post-write safety-net section
- * in `wiki/sources/<slug>.md`). The slug equals the basename of
- * the original raw source file (we wrote it that way at extraction
- * time in `extract_pdf_markdown` / fs.rs's raw-sources-layout
- * heuristic), so finding the raw file is a stem match against
- * `<project>/raw/sources/`.
+ * — emitted either ABSOLUTE or WIKI-RELATIVE (`media/<slug>/img-N.png`).
+ * The slug is the source-summary slug for the raw source identity. Root
+ * sources keep their legacy basename stem slug; nested sources include their
+ * `raw/sources` relative path plus a stable hash.
  *
  * Used in two places that want to "open the original document
  * around this image" rather than its LLM summary:
@@ -24,6 +20,10 @@
  *     the wiki summary). Callers fall back gracefully.
  */
 import { listDirectory } from "@/commands/fs"
+import {
+  sourceIdentityForPath,
+  sourceSummarySlugFromIdentity,
+} from "@/lib/source-identity"
 import type { FileNode } from "@/types/wiki"
 
 export async function findRawSourceForImage(
@@ -37,30 +37,36 @@ export async function findRawSourceForImage(
   const m = imageUrl.replace(/\\/g, "/").match(/(?:^|\/)media\/([^/]+)\//)
   if (!m) return null
   const slug = m[1]
+  const normalizedProjectPath = projectPath.replace(/\/+$/, "")
 
   let tree: FileNode[]
   try {
-    tree = await listDirectory(`${projectPath}/raw/sources`)
+    tree = await listDirectory(`${normalizedProjectPath}/raw/sources`)
   } catch {
     return null
   }
 
-  const findByStem = (nodes: FileNode[]): string | null => {
+  const findByMediaSlug = (nodes: FileNode[]): string | null => {
     for (const node of nodes) {
       if (node.is_dir) {
         if (node.children) {
-          const found = findByStem(node.children)
+          const found = findByMediaSlug(node.children)
           if (found) return found
         }
         continue
       }
+      const identity = sourceIdentityForPath(normalizedProjectPath, node.path)
+      if (sourceSummarySlugFromIdentity(identity) === slug) return node.path
+
+      // Backward compatibility for media folders created before nested source
+      // identities were encoded into the slug.
       const stem = node.name.replace(/\.[^.]+$/, "")
       if (stem === slug) return node.path
     }
     return null
   }
 
-  return findByStem(tree)
+  return findByMediaSlug(tree)
 }
 
 /**

--- a/src/lib/source-identity.test.ts
+++ b/src/lib/source-identity.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest"
+import {
+  sourceIdentityForPath,
+  sourceReferenceIdentity,
+  sourceSummarySlugFromIdentity,
+} from "./source-identity"
+
+describe("source identity helpers", () => {
+  it("keeps raw/sources relative folder context as the source identity", () => {
+    expect(
+      sourceIdentityForPath("/tmp/project", "/tmp/project/raw/sources/project-a/config.yaml"),
+    ).toBe("project-a/config.yaml")
+  })
+
+  it("normalizes source references that include raw/sources prefixes", () => {
+    expect(sourceReferenceIdentity("raw/sources/project-a/config.yaml")).toBe(
+      "project-a/config.yaml",
+    )
+    expect(sourceReferenceIdentity("/tmp/project/raw/sources/project-a/config.yaml")).toBe(
+      "project-a/config.yaml",
+    )
+  })
+
+  it("keeps legacy basename slugs for root-level sources", () => {
+    expect(sourceSummarySlugFromIdentity("config.yaml")).toBe("config")
+  })
+
+  it("escapes slug segments so delimiter-containing folders do not collide", () => {
+    expect(sourceSummarySlugFromIdentity("a--b/config.yaml")).toMatch(
+      /^4-a--b--6-config--[a-z0-9]+$/,
+    )
+    expect(sourceSummarySlugFromIdentity("a/b/config.yaml")).toMatch(
+      /^1-a--1-b--6-config--[a-z0-9]+$/,
+    )
+    expect(sourceSummarySlugFromIdentity("4-a--b--6-config.yaml")).not.toBe(
+      sourceSummarySlugFromIdentity("a--b/config.yaml"),
+    )
+  })
+})

--- a/src/lib/source-identity.ts
+++ b/src/lib/source-identity.ts
@@ -1,0 +1,61 @@
+import { getFileName, normalizePath } from "@/lib/path-utils"
+
+const RAW_SOURCES_PREFIX = "raw/sources/"
+const RAW_SOURCES_MARKER = "/raw/sources/"
+
+export function sourceIdentityForPath(projectPath: string, sourcePath: string): string {
+  const pp = normalizePath(projectPath).replace(/\/+$/, "")
+  const sp = normalizePath(sourcePath)
+  const projectRawSourcesPrefix = `${pp}/${RAW_SOURCES_PREFIX}`
+  if (sp.startsWith(projectRawSourcesPrefix)) {
+    return sp.slice(projectRawSourcesPrefix.length)
+  }
+  if (sp.startsWith(RAW_SOURCES_PREFIX)) {
+    return sp.slice(RAW_SOURCES_PREFIX.length)
+  }
+  if (sp.includes(RAW_SOURCES_MARKER)) {
+    return sp.slice(sp.indexOf(RAW_SOURCES_MARKER) + RAW_SOURCES_MARKER.length)
+  }
+  return getFileName(sp)
+}
+
+export function sourceReferenceIdentity(sourceReference: string): string {
+  const ref = normalizePath(sourceReference)
+  if (ref.startsWith(RAW_SOURCES_PREFIX)) {
+    return ref.slice(RAW_SOURCES_PREFIX.length)
+  }
+  if (ref.includes(RAW_SOURCES_MARKER)) {
+    return ref.slice(ref.indexOf(RAW_SOURCES_MARKER) + RAW_SOURCES_MARKER.length)
+  }
+  return ref
+}
+
+export function sourceSummarySlugFromIdentity(sourceIdentity: string): string {
+  const withoutExt = sourceIdentity.replace(/\.[^/.]+$/, "")
+  const parts = withoutExt
+    .split("/")
+    .map((part) => part.trim())
+    .filter(Boolean)
+
+  if (parts.length <= 1) {
+    return parts[0] || "source"
+  }
+
+  const slug = parts.map((part) => {
+    const encoded = encodeURIComponent(part).replace(
+      /[!'()*]/g,
+      (char) => `%${char.charCodeAt(0).toString(16).toUpperCase()}`,
+    )
+    return `${encoded.length}-${encoded}`
+  }).join("--")
+  return `${slug}--${stableSlugHash(sourceIdentity)}`
+}
+
+function stableSlugHash(value: string): string {
+  let hash = 0x811c9dc5
+  for (let i = 0; i < value.length; i += 1) {
+    hash ^= value.charCodeAt(i)
+    hash = Math.imul(hash, 0x01000193)
+  }
+  return (hash >>> 0).toString(36)
+}

--- a/src/lib/source-lifecycle-delete.test.ts
+++ b/src/lib/source-lifecycle-delete.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { createTempProject, readFileRaw, realFs, writeFileRaw } from "@/test-helpers/fs-temp"
+
+vi.mock("@/commands/fs", () => realFs)
+
+import { deleteSourceFiles } from "./source-lifecycle"
+
+describe("source lifecycle source deletion", () => {
+  let tmp: { path: string; cleanup: () => Promise<void> } | undefined
+
+  beforeEach(async () => {
+    tmp = await createTempProject("source-lifecycle-delete")
+    await writeFileRaw(`${tmp.path}/raw/sources/project-a/config.yaml`, "name: alpha\n")
+    await writeFileRaw(`${tmp.path}/raw/sources/project-b/config.yaml`, "name: beta\n")
+    await writeFileRaw(`${tmp.path}/wiki/log.md`, "# Wiki Log\n")
+    await writeFileRaw(
+      `${tmp.path}/wiki/concepts/shared.md`,
+      [
+        "---",
+        'sources: ["project-a/config.yaml", "project-b/config.yaml"]',
+        "---",
+        "# Shared",
+      ].join("\n"),
+    )
+    await writeFileRaw(
+      `${tmp.path}/wiki/concepts/project-b-only.md`,
+      [
+        "---",
+        'sources: ["project-b/config.yaml"]',
+        "---",
+        "# Project B",
+      ].join("\n"),
+    )
+  })
+
+  afterEach(async () => {
+    await tmp?.cleanup()
+    tmp = undefined
+  })
+
+  it("does not remove path-aware source references that only share a basename", async () => {
+    if (!tmp) throw new Error("missing temp project")
+
+    const result = await deleteSourceFiles(
+      tmp.path,
+      [`${tmp.path}/raw/sources/project-a/config.yaml`],
+      { fileAlreadyDeleted: true },
+    )
+
+    await expect(readFileRaw(`${tmp.path}/wiki/concepts/shared.md`)).resolves.toContain(
+      'sources: ["project-b/config.yaml"]',
+    )
+    await expect(readFileRaw(`${tmp.path}/wiki/concepts/project-b-only.md`)).resolves.toContain(
+      'sources: ["project-b/config.yaml"]',
+    )
+    expect(result.deletedWikiPaths).toEqual([])
+    expect(result.rewrittenSourcePages).toBe(1)
+  })
+})

--- a/src/lib/source-lifecycle.ts
+++ b/src/lib/source-lifecycle.ts
@@ -14,6 +14,10 @@ import { enqueueBatch } from "@/lib/ingest-queue"
 import { hasUsableLlm } from "@/lib/has-usable-llm"
 import { getFileName, getFileStem, normalizePath } from "@/lib/path-utils"
 import {
+  sourceIdentityForPath,
+  sourceReferenceIdentity,
+} from "@/lib/source-identity"
+import {
   parseFrontmatterArray,
   parseSources,
   writeFrontmatterArray,
@@ -176,33 +180,44 @@ export async function deleteSourceFiles(
   options: { fileAlreadyDeleted?: boolean; logReason?: string } = {},
 ): Promise<DeleteSourcesResult> {
   const pp = normalizePath(projectPath)
-  const normalizedSources = sourcePaths.map(normalizePath)
-  const fileNames = normalizedSources
-    .map((source) => source.split("/").pop() ?? "")
-    .filter(Boolean)
+  const sourceInfos = sourcePaths
+    .map((sourcePath) => {
+      const source = normalizePath(sourcePath)
+      return {
+        source,
+        fileName: getFileName(source),
+        identity: sourceIdentityForPath(pp, source),
+      }
+    })
+    .filter((info) => info.fileName.length > 0)
 
-  if (fileNames.length === 0) {
+  if (sourceInfos.length === 0) {
     return { deletedWikiPaths: [], rewrittenSourcePages: 0, skippedPages: 0 }
   }
 
-  const deletingNames = new Set(fileNames.map((name) => name.toLowerCase()))
+  const deletingNames = new Set(sourceInfos.map((info) => info.fileName.toLowerCase()))
+  const deletingIdentities = new Set(
+    sourceInfos.map((info) => sourceReferenceIdentity(info.identity).toLowerCase()),
+  )
 
   if (!options.fileAlreadyDeleted) {
-    for (const source of normalizedSources) {
-      await deleteFile(source)
+    for (const info of sourceInfos) {
+      await deleteFile(info.source)
     }
   }
 
-  for (const fileName of fileNames) {
+  for (const info of sourceInfos) {
     try {
-      await deleteFile(`${pp}/raw/sources/.cache/${fileName}.txt`)
+      await deleteFile(`${pp}/raw/sources/.cache/${info.fileName}.txt`)
     } catch {
       // cache file may not exist
     }
-    try {
-      await removeFromIngestCache(pp, fileName)
-    } catch {
-      // non-critical
+    for (const cacheKey of new Set([info.identity, info.fileName])) {
+      try {
+        await removeFromIngestCache(pp, cacheKey)
+      } catch {
+        // non-critical
+      }
     }
   }
 
@@ -232,7 +247,9 @@ export async function deleteSourceFiles(
       continue
     }
 
-    const survivors = sources.filter((source) => !sourceNameMatchesAny(source, deletingNames))
+    const survivors = sources.filter(
+      (source) => !sourceNameMatchesAny(source, deletingIdentities, deletingNames),
+    )
     if (survivors.length === sources.length) {
       continue
     }
@@ -256,7 +273,7 @@ export async function deleteSourceFiles(
     deletedWikiPaths = result.deletedPaths
   }
 
-  await appendSourceDeleteLog(pp, fileNames, {
+  await appendSourceDeleteLog(pp, sourceInfos.map((info) => info.identity), {
     reason: options.logReason ?? (options.fileAlreadyDeleted ? "external delete" : "delete"),
     deletedWikiCount: deletedWikiPaths.length,
     keptWikiCount: rewrittenSourcePages,
@@ -264,7 +281,7 @@ export async function deleteSourceFiles(
 
   if (skippedPages > 0) {
     console.debug(
-      `[source-lifecycle] skipped ${skippedPages} wiki pages with no parseable sources while deleting ${fileNames.length} source(s)`,
+      `[source-lifecycle] skipped ${skippedPages} wiki pages with no parseable sources while deleting ${sourceInfos.length} source(s)`,
     )
   }
 
@@ -413,8 +430,21 @@ function flattenMd(nodes: readonly FileNode[]): FileNode[] {
   return out
 }
 
-function sourceNameMatchesAny(source: string, deletingNames: Set<string>): boolean {
-  const normalizedSource = normalizePath(source).split("/").pop()?.toLowerCase() ?? ""
+function sourceNameMatchesAny(
+  source: string,
+  deletingIdentities: Set<string>,
+  deletingNames: Set<string>,
+): boolean {
+  const normalized = normalizePath(source)
+  const identity = sourceReferenceIdentity(normalized).toLowerCase()
+  if (deletingIdentities.has(identity)) return true
+
+  // Legacy wiki pages stored only basenames in `sources`. Keep that fallback
+  // for old pages, but do not let a path-aware source like
+  // `project-b/config.yaml` match a different deleted `config.yaml`.
+  if (normalized.includes("/")) return false
+
+  const normalizedSource = normalized.toLowerCase()
   return deletingNames.has(normalizedSource)
 }
 

--- a/src/lib/wiki-page-resolver.test.ts
+++ b/src/lib/wiki-page-resolver.test.ts
@@ -177,6 +177,12 @@ describe("resolveSourceName", () => {
     )
   })
 
+  it("accepts a raw/sources relative source identity", () => {
+    expect(resolveSourceName(TREE, "year-2025/q1.pdf", SOURCES)).toBe(
+      `${SOURCES}/year-2025/q1.pdf`,
+    )
+  })
+
   it("accepts a project-relative wiki/sources path", () => {
     expect(resolveSourceName(TREE, "wiki/sources/paper.md", SOURCES)).toBe(
       `${WIKI}/sources/paper.md`,

--- a/src/lib/wiki-page-resolver.ts
+++ b/src/lib/wiki-page-resolver.ts
@@ -103,8 +103,20 @@ export function resolveSourceName(
   const wikiSources = `${projectRoot}/wiki/sources`
 
   if (ref.includes("/")) {
-    const target = `${projectRoot}/${ref}`
-    return findInTreeByPath(tree, target)
+    const normalizedRef = ref.replace(/\\/g, "/").replace(/^\/+/, "")
+    const candidates = normalizedRef.startsWith("raw/sources/") ||
+      normalizedRef.startsWith("wiki/")
+      ? [`${projectRoot}/${normalizedRef}`]
+      : [
+          `${sourcesRoot}/${normalizedRef}`,
+          `${projectRoot}/${normalizedRef}`,
+        ]
+
+    for (const target of candidates) {
+      const found = findInTreeByPath(tree, target)
+      if (found) return found
+    }
+    return null
   }
 
   // Bare .md filename → look in wiki/sources/ first (ingest's


### PR DESCRIPTION
Fixes #221.

## Summary

- preserve `raw/sources` relative source identity for nested source files
- write nested same-basename source summaries to distinct collision-resistant paths
- canonicalize generated source-summary paths and `sources` frontmatter in auto-ingest and interactive save flows
- resolve nested `sources` values and media slugs back to their raw source files in UI navigation
- keep image extraction, cache keys, and source deletion lifecycle aligned with the path-aware identity
- add regression coverage for same-basename nested sources, delimiter collisions, source links, and source-image navigation

## Validation

- `npm run test:mocks -- src/lib/source-identity.test.ts src/lib/ingest.scenarios.test.ts src/lib/ingest-source-path-collision.test.ts src/lib/wiki-page-resolver.test.ts src/lib/raw-source-resolver.test.ts src/lib/source-lifecycle-delete.test.ts src/lib/source-lifecycle.test.ts`
- `npm run typecheck`
- `git diff --check`
- `scripts/validate-local.sh`

## Notes

Legacy basename-only `sources` entries remain inherently ambiguous. The fix preserves basename fallback for old root-level pages while using path-aware matching for new nested entries.
