### PR TITLE
Add retry-all control for failed ingest tasks

### DIFF
--- a/src/components/layout/activity-panel.tsx
+++ b/src/components/layout/activity-panel.tsx
@@ -8,7 +8,15 @@ import { useActivityStore, type ActivityItem } from "@/stores/activity-store"
 import { useWikiStore } from "@/stores/wiki-store"
 import { useFileSyncStore } from "@/stores/file-sync-store"
 import { normalizePath, getFileName, isAbsolutePath } from "@/lib/path-utils"
-import { getQueue, getQueueSummary, retryTask, cancelTask, cancelAllTasks, type IngestTask } from "@/lib/ingest-queue"
+import {
+  getQueue,
+  getQueueSummary,
+  retryTask,
+  retryAllFailedTasks,
+  cancelTask,
+  cancelAllTasks,
+  type IngestTask,
+} from "@/lib/ingest-queue"
 import {
   ignoreFileChangeTask,
   rescanProjectFiles,
@@ -74,6 +82,11 @@ export function ActivityPanel() {
   const handleIngestRetry = useCallback((taskId: string) => {
     if (!project) return
     retryTask(taskId)
+  }, [project])
+
+  const handleRetryAllFailed = useCallback(() => {
+    if (!project) return
+    void retryAllFailedTasks().then(() => setQueueTasks([...getQueue()]))
   }, [project])
 
   const handleIngestCancel = useCallback((taskId: string) => {
@@ -226,12 +239,39 @@ export function ActivityPanel() {
                     Cancel all
                   </button>
                 )}
+                {queueSummary.failed > 0 && (
+                  <button
+                    onClick={handleRetryAllFailed}
+                    className="rounded px-1.5 py-0.5 text-[10px] hover:bg-accent hover:text-foreground"
+                    title="Retry all failed ingest tasks"
+                  >
+                    Retry failed
+                  </button>
+                )}
               </div>
               <div className="h-1.5 rounded-full bg-muted overflow-hidden">
                 <div
                   className="h-full rounded-full bg-primary transition-all"
                   style={{ width: `${((queueSummary.total - queueSummary.pending - queueSummary.processing) / Math.max(queueSummary.total, 1)) * 100}%` }}
                 />
+              </div>
+            </div>
+          )}
+
+          {hasQueue && queueSummary.processing === 0 && queueSummary.pending === 0 && queueSummary.failed > 0 && (
+            <div className="px-3 py-1.5 border-b border-border/50">
+              <div className="flex items-center justify-between text-[10px] text-muted-foreground gap-2">
+                <span>Ingest Queue</span>
+                <span className="flex-1 text-right">
+                  {queueSummary.failed} failed
+                </span>
+                <button
+                  onClick={handleRetryAllFailed}
+                  className="rounded px-1.5 py-0.5 text-[10px] hover:bg-accent hover:text-foreground"
+                  title="Retry all failed ingest tasks"
+                >
+                  Retry failed
+                </button>
               </div>
             </div>
           )}

--- a/src/lib/ingest-queue.test.ts
+++ b/src/lib/ingest-queue.test.ts
@@ -54,6 +54,7 @@ import {
   enqueueIngest,
   enqueueBatch,
   retryTask,
+  retryAllFailedTasks,
   cancelTask,
   cancelAllTasks,
   clearCompletedTasks,
@@ -211,6 +212,52 @@ describe("ingest-queue — retry & failure", () => {
     await flushMicrotasks(10)
 
     expect(getQueue()).toHaveLength(0)
+  })
+
+  it("retryAllFailedTasks requeues every failed task and resumes processing", async () => {
+    const saved = [
+      {
+        id: "ingest-failed-a",
+        sourcePath: "a.md",
+        folderContext: "",
+        status: "failed",
+        addedAt: 0,
+        error: "rate limit",
+        retryCount: 3,
+      },
+      {
+        id: "ingest-failed-b",
+        sourcePath: "b.md",
+        folderContext: "",
+        status: "failed",
+        addedAt: 1,
+        error: "timeout",
+        retryCount: 3,
+      },
+    ]
+    mockReadFile.mockResolvedValue(JSON.stringify(saved))
+    mockAutoIngest.mockImplementation(() => new Promise(() => {}))
+
+    await restoreQueue(TEST_ID, TEST_PATH)
+    mockWriteFile.mockClear()
+
+    const requeued = await retryAllFailedTasks()
+    await flushMicrotasks(2)
+
+    expect(requeued).toBe(2)
+    expect(mockAutoIngest).toHaveBeenCalledOnce()
+    expect(getQueue().map((task) => task.error)).toEqual([null, null])
+    expect(getQueue().map((task) => task.status)).toEqual(["processing", "pending"])
+    expect(mockWriteFile).toHaveBeenCalled()
+  })
+
+  it("retryAllFailedTasks returns 0 when there are no failed tasks", async () => {
+    mockAutoIngest.mockImplementation(() => new Promise(() => {}))
+
+    const requeued = await retryAllFailedTasks()
+
+    expect(requeued).toBe(0)
+    expect(mockAutoIngest).not.toHaveBeenCalled()
   })
 })
 

--- a/src/lib/ingest-queue.ts
+++ b/src/lib/ingest-queue.ts
@@ -237,6 +237,28 @@ export async function retryTask(taskId: string): Promise<void> {
 }
 
 /**
+ * Retry every failed task for the active project.
+ * Returns the number of tasks requeued.
+ */
+export async function retryAllFailedTasks(): Promise<number> {
+  if (!currentProjectId) return 0
+
+  let requeued = 0
+  for (const task of queue) {
+    if (task.projectId !== currentProjectId || task.status !== "failed") continue
+    task.status = "pending"
+    task.error = null
+    requeued++
+  }
+
+  if (requeued === 0) return 0
+
+  await saveQueue(currentProjectPath)
+  processNext(currentProjectId)
+  return requeued
+}
+
+/**
  * Cancel a pending or processing task.
  * If processing, aborts the LLM call and cleans up generated files.
  */


### PR DESCRIPTION
## Summary
- Add an ingest queue action that requeues every failed task for the active project.
- Show a compact Retry failed control in the activity panel for active queues and failed-only queues.
- Add regression coverage for batch retry behavior.

## Evidence
Before: #228 reports that failed batch ingest tasks had to be retried one by one.
After: `retryAllFailedTasks()` resets all failed active-project tasks to pending, clears their error text, persists the queue, and resumes processing.

## Tests
- `npm run test:mocks -- src/lib/ingest-queue.test.ts`
- `npm run test:mocks`
- `npm run typecheck`
- `npm run build`
- `git diff --check`

Closes #228