### PR TITLE
Fix lint action row targeting

### DIFF
--- a/src/components/lint/lint-view.test.ts
+++ b/src/components/lint/lint-view.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest"
+import type { LintResult } from "@/lib/lint"
+import { groupLintResultsForDisplay } from "./lint-view"
+
+function lintResult(
+  page: string,
+  severity: LintResult["severity"],
+): LintResult {
+  return {
+    type: severity === "warning" ? "broken-link" : "orphan",
+    severity,
+    page,
+    detail: `${page} detail`,
+  }
+}
+
+describe("groupLintResultsForDisplay", () => {
+  it("keeps original result indices when warnings and infos are interleaved", () => {
+    const results = [
+      lintResult("info-a.md", "info"),
+      lintResult("warning-b.md", "warning"),
+      lintResult("info-c.md", "info"),
+      lintResult("warning-d.md", "warning"),
+    ]
+
+    const grouped = groupLintResultsForDisplay(results)
+
+    expect(grouped.warnings.map(({ index, result }) => [index, result.page])).toEqual([
+      [1, "warning-b.md"],
+      [3, "warning-d.md"],
+    ])
+    expect(grouped.infos.map(({ index, result }) => [index, result.page])).toEqual([
+      [0, "info-a.md"],
+      [2, "info-c.md"],
+    ])
+  })
+})

--- a/src/components/lint/lint-view.tsx
+++ b/src/components/lint/lint-view.tsx
@@ -20,6 +20,30 @@ import { readFile, writeFile, listDirectory } from "@/commands/fs"
 import { normalizePath } from "@/lib/path-utils"
 import { useTranslation } from "react-i18next"
 
+interface IndexedLintResult {
+  result: LintResult
+  index: number
+}
+
+export function groupLintResultsForDisplay(results: readonly LintResult[]): {
+  warnings: IndexedLintResult[]
+  infos: IndexedLintResult[]
+} {
+  const warnings: IndexedLintResult[] = []
+  const infos: IndexedLintResult[] = []
+
+  results.forEach((result, index) => {
+    const item = { result, index }
+    if (result.severity === "warning") {
+      warnings.push(item)
+    } else {
+      infos.push(item)
+    }
+  })
+
+  return { warnings, infos }
+}
+
 export function LintView() {
   const { t } = useTranslation()
   const project = useWikiStore((s) => s.project)
@@ -203,8 +227,10 @@ export function LintView() {
     }
   }
 
-  const warnings = results.filter((r) => r.severity === "warning")
-  const infos = results.filter((r) => r.severity === "info")
+  const { warnings, infos } = useMemo(
+    () => groupLintResultsForDisplay(results),
+    [results],
+  )
 
   return (
     <div className="flex h-full flex-col">
@@ -256,12 +282,12 @@ export function LintView() {
             {warnings.length > 0 && (
               <SectionHeader icon={AlertTriangle} label={t("lint.warnings")} count={warnings.length} color="text-amber-500" t={t} />
             )}
-            {warnings.map((result, i) => (
+            {warnings.map(({ result, index }) => (
               <LintCard
-                key={`warn-${i}`}
+                key={`warn-${index}`}
                 result={result}
-                index={i}
-                fixing={fixingId === `${result.type}-${i}`}
+                index={index}
+                fixing={fixingId === `${result.type}-${index}`}
                 onOpenPage={handleOpenPage}
                 onFix={handleFix}
                 onDelete={result.type === "orphan" ? handleDeleteOrphan : undefined}
@@ -272,22 +298,19 @@ export function LintView() {
             {infos.length > 0 && (
               <SectionHeader icon={Info} label={t("lint.info")} count={infos.length} color="text-blue-500" t={t} />
             )}
-            {infos.map((result, i) => {
-              const realIndex = warnings.length + i
-              return (
-                <LintCard
-                  key={`info-${i}`}
-                  result={result}
-                  index={realIndex}
-                  fixing={fixingId === `${result.type}-${realIndex}`}
-                  onOpenPage={handleOpenPage}
-                  onFix={handleFix}
-                  onDelete={result.type === "orphan" ? handleDeleteOrphan : undefined}
-                  typeConfig={typeConfig}
-                  t={t}
-                />
-              )
-            })}
+            {infos.map(({ result, index }) => (
+              <LintCard
+                key={`info-${index}`}
+                result={result}
+                index={index}
+                fixing={fixingId === `${result.type}-${index}`}
+                onOpenPage={handleOpenPage}
+                onFix={handleFix}
+                onDelete={result.type === "orphan" ? handleDeleteOrphan : undefined}
+                typeConfig={typeConfig}
+                t={t}
+              />
+            ))}
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary
- Preserve each lint result original index when rendering warning and info groups.
- Pass the preserved index to fix/delete handlers so the clicked card targets the intended result.
- Add a regression test for interleaved warning/info results.

## Evidence
Before: #193 reports that clicking a lint row action could execute against the next row. The code grouped warnings and info items separately, then passed grouped positions back into the original results array.
After: `groupLintResultsForDisplay()` keeps the original result index while preserving the grouped display order.

## Notes
The related Review view path mentioned in the issue discussion resolves actions by review item id, so this PR keeps the change scoped to lint list row targeting.

## Tests
- `npm run test:mocks -- src/components/lint/lint-view.test.ts`
- `npm run test:mocks`
- `npm run typecheck`
- `npm run build`
- `git diff --check`

Closes #193