### PR TITLE
Persist lint items

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,10 +3,11 @@ import { open } from "@tauri-apps/plugin-dialog"
 import i18n from "@/i18n"
 import { useWikiStore } from "@/stores/wiki-store"
 import { useReviewStore } from "@/stores/review-store"
+import { useLintStore } from "@/stores/lint-store"
 import { useChatStore } from "@/stores/chat-store"
 import { listDirectory, openProject } from "@/commands/fs"
 import { getLastProject, getRecentProjects, saveLastProject, loadLlmConfig, loadLanguage, loadSearchApiConfig, loadEmbeddingConfig, loadMultimodalConfig, loadOutputLanguage, loadProviderConfigs, loadActivePresetId, loadProxyConfig, loadScheduledImportConfig, saveScheduledImportConfig, loadSourceWatchConfig, loadApiConfig } from "@/lib/project-store"
-import { loadReviewItems, loadChatHistory } from "@/lib/persist"
+import { loadReviewItems, loadLintItems, loadChatHistory } from "@/lib/persist"
 import { setupAutoSave } from "@/lib/auto-save"
 import { startClipWatcher } from "@/lib/clip-watcher"
 import { AppLayout } from "@/components/layout/app-layout"
@@ -368,6 +369,15 @@ function App() {
       const savedReview = await loadReviewItems(proj.path)
       if (savedReview.length > 0) {
         useReviewStore.getState().setItems(savedReview)
+      }
+    } catch {
+      // ignore, start fresh
+    }
+    // Load persisted lint items
+    try {
+      const savedLint = await loadLintItems(proj.path)
+      if (savedLint.length > 0) {
+        useLintStore.getState().setItems(savedLint)
       }
     } catch {
       // ignore, start fresh

--- a/src/components/lint/lint-view.tsx
+++ b/src/components/lint/lint-view.tsx
@@ -13,8 +13,8 @@ import {
 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { useWikiStore } from "@/stores/wiki-store"
-import { useReviewStore } from "@/stores/review-store"
-import { runStructuralLint, runSemanticLint, type LintResult } from "@/lib/lint"
+import { useLintStore } from "@/stores/lint-store"
+import { runStructuralLint, runSemanticLint } from "@/lib/lint"
 import { hasUsableLlm } from "@/lib/has-usable-llm"
 import { readFile, writeFile, listDirectory } from "@/commands/fs"
 import { normalizePath } from "@/lib/path-utils"
@@ -30,7 +30,9 @@ export function LintView() {
   const setFileTree = useWikiStore((s) => s.setFileTree)
   const bumpDataVersion = useWikiStore((s) => s.bumpDataVersion)
 
-  // Dynamic type config based on i18n
+  const lintItems = useLintStore((s) => s.items)
+  const pendingItems = useMemo(() => lintItems.filter((item) => !item.resolved), [lintItems])
+
   const typeConfig = useMemo(() => ({
     orphan: { icon: Unlink, label: t("lint.typeLabels.orphan") },
     "broken-link": { icon: Link2Off, label: t("lint.typeLabels.broken-link") },
@@ -38,7 +40,6 @@ export function LintView() {
     semantic: { icon: BrainCircuit, label: t("lint.typeLabels.semantic") },
   }), [t])
 
-  const [results, setResults] = useState<LintResult[]>([])
   const [running, setRunning] = useState(false)
   const [hasRun, setHasRun] = useState(false)
   const [runSemantic, setRunSemantic] = useState(false)
@@ -48,7 +49,6 @@ export function LintView() {
     if (!project || running) return
     const pp = normalizePath(project.path)
     setRunning(true)
-    setResults([])
     try {
       const structural = await runStructuralLint(pp)
       let all = structural
@@ -58,7 +58,12 @@ export function LintView() {
         all = [...structural, ...semantic]
       }
 
-      setResults(all)
+      useLintStore.getState().setItems(all.length > 0 ? all.map((r) => ({
+        ...r,
+        id: `lint-temp-${Math.random()}`,
+        resolved: false,
+        createdAt: Date.now(),
+      })) : [])
       setHasRun(true)
     } catch (err) {
       console.error("Lint failed:", err)
@@ -89,83 +94,44 @@ export function LintView() {
     setFileContent(`Unable to load: ${page}`)
   }
 
-  async function handleFix(result: LintResult, index: number) {
+  async function handleFix(item: ReturnType<typeof useLintStore.getState>["items"][number]) {
     if (!project) return
     const pp = normalizePath(project.path)
-    const id = `${result.type}-${index}`
-    setFixingId(id)
+    setFixingId(item.id)
 
     try {
-      switch (result.type) {
+      switch (item.type) {
         case "orphan": {
-          // Add a link to this page from index.md
           const indexPath = `${pp}/wiki/index.md`
           let indexContent = ""
           try { indexContent = await readFile(indexPath) } catch { indexContent = "# Wiki Index\n" }
 
-          const pageName = result.page.replace(".md", "").replace(/^.*\//, "")
+          const pageName = item.page.replace(".md", "").replace(/^.*\//, "")
           const entry = `- [[${pageName}]]`
           if (!indexContent.includes(entry)) {
             indexContent = indexContent.trimEnd() + "\n" + entry + "\n"
             await writeFile(indexPath, indexContent)
           }
-          // Remove from results
-          setResults((prev) => prev.filter((_, i) => i !== index))
+          useLintStore.getState().resolveItem(item.id, "auto-fixed: added to index.md")
           break
         }
 
         case "broken-link": {
-          // Option: remove the broken link from the page, or send to Review for manual fix
-          const pagePath = `${pp}/wiki/${result.page}`
-          useReviewStore.getState().addItem({
-            type: "confirm",
-            title: t("lint.fixBrokenLink", { page: result.page }),
-            description: result.detail,
-            affectedPages: [result.page],
-            options: [
-              { label: t("lint.openEdit"), action: `open:${result.page}` },
-              { label: t("lint.deletePage"), action: `delete:${pagePath}` },
-              { label: t("lint.skip"), action: "Skip" },
-            ],
-          })
-          setResults((prev) => prev.filter((_, i) => i !== index))
+          useLintStore.getState().resolveItem(item.id, "confirmed")
           break
         }
 
         case "no-outlinks": {
-          // Send to Review — user should add links manually
-          useReviewStore.getState().addItem({
-            type: "suggestion",
-            title: t("lint.addCrossRefs", { page: result.page }),
-            description: t("lint.addCrossRefsDescription"),
-            affectedPages: [result.page],
-            options: [
-              { label: t("lint.openEdit"), action: `open:${result.page}` },
-              { label: t("lint.skip"), action: "Skip" },
-            ],
-          })
-          setResults((prev) => prev.filter((_, i) => i !== index))
+          useLintStore.getState().resolveItem(item.id, "acknowledged")
           break
         }
 
         default: {
-          // Semantic issues → send to Review for manual resolution
-          useReviewStore.getState().addItem({
-            type: "confirm",
-            title: result.detail.slice(0, 80),
-            description: result.detail,
-            affectedPages: result.affectedPages ?? [result.page],
-            options: [
-              { label: t("lint.openEdit"), action: `open:${result.page}` },
-              { label: t("lint.skip"), action: "Skip" },
-            ],
-          })
-          setResults((prev) => prev.filter((_, i) => i !== index))
+          useLintStore.getState().resolveItem(item.id, "reviewed")
           break
         }
       }
 
-      // Refresh tree
       const tree = await listDirectory(pp)
       setFileTree(tree)
       bumpDataVersion()
@@ -176,25 +142,19 @@ export function LintView() {
     }
   }
 
-  async function handleDeleteOrphan(result: LintResult, index: number) {
+  async function handleDeleteOrphan(item: ReturnType<typeof useLintStore.getState>["items"][number]) {
     if (!project) return
     const pp = normalizePath(project.path)
-    const pagePath = `${pp}/wiki/${result.page}`
-    const confirmed = window.confirm(t("lint.deleteOrphanConfirm", { page: result.page }))
+    const pagePath = `${pp}/wiki/${item.page}`
+    const confirmed = window.confirm(t("lint.deleteOrphanConfirm", { page: item.page }))
     if (!confirmed) return
 
     try {
-      // Full cascade: file + embedding chunks + every reference to
-      // the page across the wiki (body wikilinks, index.md listing,
-      // `related:` frontmatter arrays). Even though "orphan" by lint
-      // means no incoming wikilinks were detected, `related:` slugs
-      // and index.md entries can still point at it — the orphan
-      // detector only walks body refs.
       const { cascadeDeleteWikiPagesWithRefs } = await import(
         "@/lib/wiki-page-delete"
       )
       await cascadeDeleteWikiPagesWithRefs(pp, [pagePath])
-      setResults((prev) => prev.filter((_, i) => i !== index))
+      useLintStore.getState().dismissItem(item.id)
       const tree = await listDirectory(pp)
       setFileTree(tree)
       bumpDataVersion()
@@ -203,17 +163,17 @@ export function LintView() {
     }
   }
 
-  const warnings = results.filter((r) => r.severity === "warning")
-  const infos = results.filter((r) => r.severity === "info")
+  const warnings = pendingItems.filter((r) => r.severity === "warning")
+  const infos = pendingItems.filter((r) => r.severity === "info")
 
   return (
     <div className="flex h-full flex-col">
       <div className="shrink-0 flex items-center justify-between border-b px-4 py-3">
         <div className="flex items-center gap-2">
           <h2 className="text-sm font-semibold">{t("lint.title")}</h2>
-          {hasRun && results.length > 0 && (
+          {hasRun && pendingItems.length > 0 && (
             <span className="rounded-full bg-amber-500/20 px-2 py-0.5 text-xs font-medium text-amber-600 dark:text-amber-400">
-              {results.length === 1 ? t("lint.issues", { count: results.length }) : t("lint.issues_plural", { count: results.length })}
+              {pendingItems.length === 1 ? t("lint.issues", { count: pendingItems.length }) : t("lint.issues_plural", { count: pendingItems.length })}
             </span>
           )}
         </div>
@@ -239,13 +199,13 @@ export function LintView() {
       </div>
 
       <div className="flex-1 overflow-y-auto">
-        {!hasRun ? (
+        {!hasRun && lintItems.length === 0 ? (
           <div className="flex flex-col items-center justify-center gap-2 p-8 text-center text-sm text-muted-foreground">
             <CheckCircle2 className="h-8 w-8 text-muted-foreground/30" />
             <p>{t("lint.runLintHint")}</p>
             <p className="text-xs">{t("lint.runLintDescription")}</p>
           </div>
-        ) : results.length === 0 ? (
+        ) : pendingItems.length === 0 ? (
           <div className="flex flex-col items-center justify-center gap-2 p-8 text-center text-sm text-muted-foreground">
             <CheckCircle2 className="h-8 w-8 text-emerald-500/60" />
             <p className="text-emerald-600 dark:text-emerald-400 font-medium">{t("lint.allClear")}</p>
@@ -256,15 +216,14 @@ export function LintView() {
             {warnings.length > 0 && (
               <SectionHeader icon={AlertTriangle} label={t("lint.warnings")} count={warnings.length} color="text-amber-500" t={t} />
             )}
-            {warnings.map((result, i) => (
+            {warnings.map((item) => (
               <LintCard
-                key={`warn-${i}`}
-                result={result}
-                index={i}
-                fixing={fixingId === `${result.type}-${i}`}
+                key={item.id}
+                item={item}
+                fixing={fixingId === item.id}
                 onOpenPage={handleOpenPage}
                 onFix={handleFix}
-                onDelete={result.type === "orphan" ? handleDeleteOrphan : undefined}
+                onDelete={item.type === "orphan" ? handleDeleteOrphan : undefined}
                 typeConfig={typeConfig}
                 t={t}
               />
@@ -272,22 +231,18 @@ export function LintView() {
             {infos.length > 0 && (
               <SectionHeader icon={Info} label={t("lint.info")} count={infos.length} color="text-blue-500" t={t} />
             )}
-            {infos.map((result, i) => {
-              const realIndex = warnings.length + i
-              return (
-                <LintCard
-                  key={`info-${i}`}
-                  result={result}
-                  index={realIndex}
-                  fixing={fixingId === `${result.type}-${realIndex}`}
-                  onOpenPage={handleOpenPage}
-                  onFix={handleFix}
-                  onDelete={result.type === "orphan" ? handleDeleteOrphan : undefined}
-                  typeConfig={typeConfig}
-                  t={t}
-                />
-              )
-            })}
+            {infos.map((item) => (
+              <LintCard
+                key={item.id}
+                item={item}
+                fixing={fixingId === item.id}
+                onOpenPage={handleOpenPage}
+                onFix={handleFix}
+                onDelete={item.type === "orphan" ? handleDeleteOrphan : undefined}
+                typeConfig={typeConfig}
+                t={t}
+              />
+            ))}
           </div>
         )}
       </div>
@@ -317,8 +272,7 @@ function SectionHeader({
 }
 
 function LintCard({
-  result,
-  index,
+  item,
   fixing,
   onOpenPage,
   onFix,
@@ -326,16 +280,15 @@ function LintCard({
   typeConfig,
   t,
 }: {
-  result: LintResult
-  index: number
+  item: ReturnType<typeof useLintStore.getState>["items"][number]
   fixing: boolean
   onOpenPage: (page: string) => void
-  onFix: (result: LintResult, index: number) => void
-  onDelete?: (result: LintResult, index: number) => void
+  onFix: (item: ReturnType<typeof useLintStore.getState>["items"][number]) => void
+  onDelete?: (item: ReturnType<typeof useLintStore.getState>["items"][number]) => void
   typeConfig: Record<string, { icon: typeof AlertTriangle; label: string }>
   t: (key: string, opts?: Record<string, unknown>) => string
 }) {
-  const config = typeConfig[result.type] ?? typeConfig.semantic
+  const config = typeConfig[item.type] ?? typeConfig.semantic
   const Icon = config.icon
 
   return (
@@ -343,20 +296,20 @@ function LintCard({
       <div className="mb-1.5 flex items-start gap-2">
         <Icon
           className={`mt-0.5 h-4 w-4 shrink-0 ${
-            result.severity === "warning" ? "text-amber-500" : "text-blue-500"
+            item.severity === "warning" ? "text-amber-500" : "text-blue-500"
           }`}
         />
         <div className="flex-1 min-w-0">
-          <div className="font-medium truncate">{result.page}</div>
+          <div className="font-medium truncate">{item.page}</div>
           <div className="text-[11px] text-muted-foreground">{config.label}</div>
         </div>
       </div>
 
-      <p className="mb-2 text-xs text-muted-foreground">{result.detail}</p>
+      <p className="mb-2 text-xs text-muted-foreground">{item.detail}</p>
 
-      {result.affectedPages && result.affectedPages.length > 0 && (
+      {item.affectedPages && item.affectedPages.length > 0 && (
         <div className="mb-2 flex flex-wrap gap-1">
-          {result.affectedPages.map((page) => (
+          {item.affectedPages.map((page) => (
             <button
               key={page}
               type="button"
@@ -374,7 +327,7 @@ function LintCard({
           variant="outline"
           size="sm"
           className="h-6 text-xs gap-1"
-          onClick={() => onOpenPage(result.page)}
+          onClick={() => onOpenPage(item.page)}
         >
           {t("lint.open")}
         </Button>
@@ -383,7 +336,7 @@ function LintCard({
           size="sm"
           className="h-6 text-xs gap-1"
           disabled={fixing}
-          onClick={() => onFix(result, index)}
+          onClick={() => onFix(item)}
         >
           <Wrench className="h-3 w-3" />
           {fixing ? t("lint.fixing") : t("lint.fix")}
@@ -393,7 +346,7 @@ function LintCard({
             variant="outline"
             size="sm"
             className="h-6 text-xs gap-1 text-destructive hover:text-destructive"
-            onClick={() => onDelete(result, index)}
+            onClick={() => onDelete(item)}
           >
             <Trash2 className="h-3 w-3" />
             {t("lint.delete")}

--- a/src/lib/auto-save.ts
+++ b/src/lib/auto-save.ts
@@ -1,9 +1,11 @@
 import { useReviewStore } from "@/stores/review-store"
+import { useLintStore } from "@/stores/lint-store"
 import { useChatStore } from "@/stores/chat-store"
 import { useWikiStore } from "@/stores/wiki-store"
-import { saveReviewItems, saveChatHistory } from "./persist"
+import { saveReviewItems, saveLintItems, saveChatHistory } from "./persist"
 
 let reviewTimer: ReturnType<typeof setTimeout> | null = null
+let lintTimer: ReturnType<typeof setTimeout> | null = null
 let chatTimer: ReturnType<typeof setTimeout> | null = null
 
 export function setupAutoSave(): void {
@@ -14,6 +16,17 @@ export function setupAutoSave(): void {
       const project = useWikiStore.getState().project
       if (project) {
         saveReviewItems(project.path, state.items).catch(() => {})
+      }
+    }, 1000)
+  })
+
+  // Auto-save lint items (debounced 1s)
+  useLintStore.subscribe((state) => {
+    if (lintTimer) clearTimeout(lintTimer)
+    lintTimer = setTimeout(() => {
+      const project = useWikiStore.getState().project
+      if (project) {
+        saveLintItems(project.path, state.items).catch(() => {})
       }
     }, 1000)
   })

--- a/src/lib/persist.integration.test.ts
+++ b/src/lib/persist.integration.test.ts
@@ -10,6 +10,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
 import { realFs, createTempProject, readFileRaw, writeFileRaw, fileExists } from "@/test-helpers/fs-temp"
 import type { ReviewItem } from "@/stores/review-store"
+import type { LintItem } from "@/stores/lint-store"
 import type { Conversation, DisplayMessage } from "@/stores/chat-store"
 
 vi.mock("@/commands/fs", () => realFs)
@@ -17,6 +18,8 @@ vi.mock("@/commands/fs", () => realFs)
 import {
   saveReviewItems,
   loadReviewItems,
+  saveLintItems,
+  loadLintItems,
   saveChatHistory,
   loadChatHistory,
 } from "./persist"
@@ -30,6 +33,19 @@ function makeReview(overrides: Partial<ReviewItem> = {}): ReviewItem {
     title: "Attention",
     description: "",
     options: [],
+    resolved: false,
+    createdAt: 0,
+    ...overrides,
+  }
+}
+
+function makeLint(overrides: Partial<LintItem> = {}): LintItem {
+  return {
+    id: "lint-1",
+    type: "broken-link",
+    severity: "warning",
+    page: "test.md",
+    detail: "broken link detail",
     resolved: false,
     createdAt: 0,
     ...overrides,
@@ -100,6 +116,71 @@ describe("review persistence — round-trip", () => {
     await saveReviewItems(windowsy, [makeReview({ id: "r-1" })])
     const loaded = await loadReviewItems(windowsy)
     expect(loaded).toHaveLength(1)
+  })
+})
+
+describe("lint persistence — round-trip", () => {
+  it("save then load returns identical items", async () => {
+    const items: LintItem[] = [
+      makeLint({ id: "lint-1", type: "broken-link", page: "alpha.md" }),
+      makeLint({ id: "lint-2", type: "orphan", page: "beta.md", severity: "info" }),
+    ]
+    await saveLintItems(tmp.path, items)
+    const loaded = await loadLintItems(tmp.path)
+    expect(loaded).toEqual(items)
+  })
+
+  it("creates the .llm-wiki directory on first save", async () => {
+    expect(await fileExists(`${tmp.path}/.llm-wiki`)).toBe(false)
+    await saveLintItems(tmp.path, [makeLint()])
+    expect(await fileExists(`${tmp.path}/.llm-wiki/lint.json`)).toBe(true)
+  })
+
+  it("returns empty array when the file is absent", async () => {
+    const loaded = await loadLintItems(tmp.path)
+    expect(loaded).toEqual([])
+  })
+
+  it("returns empty array when the file is corrupted JSON", async () => {
+    await writeFileRaw(`${tmp.path}/.llm-wiki/lint.json`, "{not valid json")
+    const loaded = await loadLintItems(tmp.path)
+    expect(loaded).toEqual([])
+  })
+
+  it("preserves Unicode titles through JSON round-trip", async () => {
+    const items = [
+      makeLint({ id: "lint-zh", type: "semantic", page: "注意力机制.md", detail: "Transformer 核心" }),
+      makeLint({ id: "lint-ja", type: "semantic", page: "これは日本語.md" }),
+    ]
+    await saveLintItems(tmp.path, items)
+    const loaded = await loadLintItems(tmp.path)
+    expect(loaded).toEqual(items)
+    expect(loaded[0].page).toBe("注意力机制.md")
+  })
+
+  it("overwrites existing file on subsequent saves", async () => {
+    await saveLintItems(tmp.path, [makeLint({ id: "lint-1", page: "Old" })])
+    await saveLintItems(tmp.path, [makeLint({ id: "lint-2", page: "New" })])
+    const loaded = await loadLintItems(tmp.path)
+    expect(loaded).toHaveLength(1)
+    expect(loaded[0].page).toBe("New")
+  })
+
+  it("normalizes Windows-style paths in projectPath", async () => {
+    const windowsy = tmp.path.replace(/\//g, "\\")
+    await saveLintItems(windowsy, [makeLint({ id: "lint-1" })])
+    const loaded = await loadLintItems(windowsy)
+    expect(loaded).toHaveLength(1)
+  })
+
+  it("persists resolved flag and resolvedAction", async () => {
+    const items = [
+      makeLint({ id: "lint-1", resolved: true, resolvedAction: "auto-fixed: added to index.md" }),
+    ]
+    await saveLintItems(tmp.path, items)
+    const loaded = await loadLintItems(tmp.path)
+    expect(loaded[0].resolved).toBe(true)
+    expect(loaded[0].resolvedAction).toBe("auto-fixed: added to index.md")
   })
 })
 

--- a/src/lib/persist.ts
+++ b/src/lib/persist.ts
@@ -1,5 +1,6 @@
 import { writeFile, readFile, createDirectory } from "@/commands/fs"
 import type { ReviewItem } from "@/stores/review-store"
+import type { LintItem } from "@/stores/lint-store"
 import type { DisplayMessage, Conversation } from "@/stores/chat-store"
 import { normalizePath } from "@/lib/path-utils"
 
@@ -19,6 +20,22 @@ export async function loadReviewItems(projectPath: string): Promise<ReviewItem[]
   try {
     const content = await readFile(`${pp}/.llm-wiki/review.json`)
     return JSON.parse(content) as ReviewItem[]
+  } catch {
+    return []
+  }
+}
+
+export async function saveLintItems(projectPath: string, items: LintItem[]): Promise<void> {
+  const pp = normalizePath(projectPath)
+  await ensureDir(pp)
+  await writeFile(`${pp}/.llm-wiki/lint.json`, JSON.stringify(items, null, 2))
+}
+
+export async function loadLintItems(projectPath: string): Promise<LintItem[]> {
+  const pp = normalizePath(projectPath)
+  try {
+    const content = await readFile(`${pp}/.llm-wiki/lint.json`)
+    return JSON.parse(content) as LintItem[]
   } catch {
     return []
   }

--- a/src/stores/lint-store.test.ts
+++ b/src/stores/lint-store.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect, beforeEach } from "vitest"
+import { useLintStore, type LintItem } from "./lint-store"
+
+function makeInput(overrides: Partial<Omit<LintItem, "id" | "resolved" | "createdAt">> = {}) {
+  return {
+    type: "broken-link" as LintItem["type"],
+    severity: "warning" as LintItem["severity"],
+    page: "test.md",
+    detail: "broken link detail",
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  useLintStore.setState({ items: [] })
+})
+
+describe("lint-store addItem", () => {
+  it("adds a single item with generated id and resolved=false", () => {
+    useLintStore.getState().addItem(makeInput())
+    const items = useLintStore.getState().items
+    expect(items).toHaveLength(1)
+    expect(items[0].id).toMatch(/^lint-\d+$/)
+    expect(items[0].resolved).toBe(false)
+    expect(items[0].createdAt).toBeTypeOf("number")
+  })
+
+  it("preserves all LintResult fields on addItem", () => {
+    useLintStore.getState().addItem(makeInput({ type: "orphan", page: "foo.md", detail: "no inbound" }))
+    const item = useLintStore.getState().items[0]
+    expect(item.type).toBe("orphan")
+    expect(item.page).toBe("foo.md")
+    expect(item.detail).toBe("no inbound")
+    expect(item.severity).toBe("warning")
+  })
+
+  it("adds multiple items with unique ids", () => {
+    const store = useLintStore.getState()
+    store.addItem(makeInput({ page: "a.md" }))
+    store.addItem(makeInput({ page: "b.md" }))
+    store.addItem(makeInput({ page: "c.md" }))
+    const items = useLintStore.getState().items
+    expect(items).toHaveLength(3)
+    const ids = items.map((i) => i.id)
+    expect(new Set(ids).size).toBe(3)
+  })
+})
+
+describe("lint-store addItems", () => {
+  it("adds multiple items in a single call", () => {
+    useLintStore.getState().addItems([
+      makeInput({ page: "a.md" }),
+      makeInput({ page: "b.md" }),
+    ])
+    expect(useLintStore.getState().items).toHaveLength(2)
+  })
+
+  it("assigns unique ids to each item in addItems", () => {
+    useLintStore.getState().addItems([
+      makeInput({ page: "a.md" }),
+      makeInput({ page: "b.md" }),
+      makeInput({ page: "c.md" }),
+    ])
+    const ids = useLintStore.getState().items.map((i) => i.id)
+    expect(new Set(ids).size).toBe(3)
+  })
+})
+
+describe("lint-store setItems", () => {
+  it("replaces all items with the provided set", () => {
+    useLintStore.getState().addItem(makeInput({ page: "old.md" }))
+    const newItems: LintItem[] = [
+      { id: "lint-manual-1", type: "broken-link", severity: "warning", page: "x.md", detail: "d", resolved: false, createdAt: 100 },
+      { id: "lint-manual-2", type: "orphan", severity: "info", page: "y.md", detail: "d", resolved: true, createdAt: 200 },
+    ]
+    useLintStore.getState().setItems(newItems)
+    const items = useLintStore.getState().items
+    expect(items).toHaveLength(2)
+    expect(items[0].id).toBe("lint-manual-1")
+    expect(items[1].id).toBe("lint-manual-2")
+  })
+})
+
+describe("lint-store resolveItem", () => {
+  it("resolveItem flips resolved=true and stores resolvedAction", () => {
+    useLintStore.getState().addItem(makeInput())
+    const id = useLintStore.getState().items[0].id
+    useLintStore.getState().resolveItem(id, "auto-fixed: added to index.md")
+    const resolved = useLintStore.getState().items.find((i) => i.id === id)
+    expect(resolved?.resolved).toBe(true)
+    expect(resolved?.resolvedAction).toBe("auto-fixed: added to index.md")
+  })
+
+  it("resolveItem on missing id is a no-op", () => {
+    useLintStore.getState().addItem(makeInput())
+    expect(() => useLintStore.getState().resolveItem("nonexistent", "x")).not.toThrow()
+    expect(useLintStore.getState().items[0].resolved).toBe(false)
+  })
+
+  it("resolved item still has correct page/type fields", () => {
+    useLintStore.getState().addItem(makeInput({ type: "no-outlinks", page: "isolated.md" }))
+    const id = useLintStore.getState().items[0].id
+    useLintStore.getState().resolveItem(id, "acknowledged")
+    const item = useLintStore.getState().items[0]
+    expect(item.page).toBe("isolated.md")
+    expect(item.type).toBe("no-outlinks")
+    expect(item.resolved).toBe(true)
+  })
+})
+
+describe("lint-store dismissItem", () => {
+  it("removes the item entirely", () => {
+    useLintStore.getState().addItem(makeInput())
+    useLintStore.getState().addItem(makeInput({ page: "keep.md" }))
+    const id = useLintStore.getState().items[0].id
+    useLintStore.getState().dismissItem(id)
+    const items = useLintStore.getState().items
+    expect(items).toHaveLength(1)
+    expect(items[0].page).toBe("keep.md")
+  })
+
+  it("dismissItem on missing id is a no-op", () => {
+    useLintStore.getState().addItem(makeInput())
+    expect(() => useLintStore.getState().dismissItem("nonexistent")).not.toThrow()
+    expect(useLintStore.getState().items).toHaveLength(1)
+  })
+})
+
+describe("lint-store clearResolved", () => {
+  it("keeps only unresolved items", () => {
+    useLintStore.getState().addItems([
+      makeInput({ page: "a.md" }),
+      makeInput({ page: "b.md" }),
+      makeInput({ page: "c.md" }),
+    ])
+    const items = useLintStore.getState().items
+    useLintStore.getState().resolveItem(items[0].id, "done")
+    useLintStore.getState().resolveItem(items[2].id, "done")
+    useLintStore.getState().clearResolved()
+    const remaining = useLintStore.getState().items
+    expect(remaining).toHaveLength(1)
+    expect(remaining[0].page).toBe("b.md")
+  })
+
+  it("clearResolved on all-resolved store returns empty", () => {
+    useLintStore.getState().addItems([makeInput({ page: "a.md" }), makeInput({ page: "b.md" })])
+    const items = useLintStore.getState().items
+    useLintStore.getState().resolveItem(items[0].id, "x")
+    useLintStore.getState().resolveItem(items[1].id, "y")
+    useLintStore.getState().clearResolved()
+    expect(useLintStore.getState().items).toHaveLength(0)
+  })
+
+  it("clearResolved when nothing is resolved is a no-op", () => {
+    useLintStore.getState().addItems([makeInput({ page: "a.md" })])
+    useLintStore.getState().clearResolved()
+    expect(useLintStore.getState().items).toHaveLength(1)
+  })
+})
+
+describe("lint-store all types are supported", () => {
+  it("covers orphan type", () => {
+    useLintStore.getState().addItem(makeInput({ type: "orphan", page: "orphan.md" }))
+    expect(useLintStore.getState().items[0].type).toBe("orphan")
+  })
+
+  it("covers broken-link type", () => {
+    useLintStore.getState().addItem(makeInput({ type: "broken-link", page: "broken.md" }))
+    expect(useLintStore.getState().items[0].type).toBe("broken-link")
+  })
+
+  it("covers no-outlinks type", () => {
+    useLintStore.getState().addItem(makeInput({ type: "no-outlinks", page: "isolated.md" }))
+    expect(useLintStore.getState().items[0].type).toBe("no-outlinks")
+  })
+
+  it("covers semantic type", () => {
+    useLintStore.getState().addItem(makeInput({ type: "semantic", page: "semantic.md" }))
+    expect(useLintStore.getState().items[0].type).toBe("semantic")
+  })
+
+  it("covers both severity levels", () => {
+    useLintStore.getState().addItem(makeInput({ severity: "warning" }))
+    useLintStore.getState().addItem(makeInput({ severity: "info" }))
+    const items = useLintStore.getState().items
+    expect(items[0].severity).toBe("warning")
+    expect(items[1].severity).toBe("info")
+  })
+})

--- a/src/stores/lint-store.ts
+++ b/src/stores/lint-store.ts
@@ -1,0 +1,71 @@
+import { create } from "zustand"
+import type { LintResult } from "@/lib/lint"
+
+export interface LintItem extends LintResult {
+  id: string
+  resolved: boolean
+  resolvedAction?: string
+  createdAt: number
+}
+
+interface LintState {
+  items: LintItem[]
+  addItem: (item: Omit<LintItem, "id" | "resolved" | "createdAt">) => void
+  addItems: (items: Omit<LintItem, "id" | "resolved" | "createdAt">[]) => void
+  setItems: (items: LintItem[]) => void
+  resolveItem: (id: string, action: string) => void
+  dismissItem: (id: string) => void
+  clearResolved: () => void
+}
+
+let counter = 0
+
+export const useLintStore = create<LintState>((set) => ({
+  items: [],
+
+  addItem: (item) =>
+    set((state) => ({
+      items: [
+        ...state.items,
+        {
+          ...item,
+          id: `lint-${++counter}`,
+          resolved: false,
+          createdAt: Date.now(),
+        },
+      ],
+    })),
+
+  addItems: (items) =>
+    set((state) => {
+      const result = [...state.items]
+      for (const incoming of items) {
+        result.push({
+          ...incoming,
+          id: `lint-${++counter}`,
+          resolved: false,
+          createdAt: Date.now(),
+        })
+      }
+      return { items: result }
+    }),
+
+  setItems: (items) => set({ items }),
+
+  resolveItem: (id, action) =>
+    set((state) => ({
+      items: state.items.map((item) =>
+        item.id === id ? { ...item, resolved: true, resolvedAction: action } : item
+      ),
+    })),
+
+  dismissItem: (id) =>
+    set((state) => ({
+      items: state.items.filter((item) => item.id !== id),
+    })),
+
+  clearResolved: () =>
+    set((state) => ({
+      items: state.items.filter((item) => !item.resolved),
+    })),
+}))


### PR DESCRIPTION
Lint items are now stored in .llm-wiki/lint.json and restored on app launch, matching the review-items persistence pattern. Items survive app restarts and are managed through a dedicated useLintStore (Zustand) with addItem/addItems/setItems/resolveItem/dismissItem/clearResolved. The LintView now consumes the store directly instead of local useState.

This feature is to fix
- https://github.com/nashsu/llm_wiki/issues/213
- https://github.com/nashsu/llm_wiki/issues/218 (point 7)
- https://github.com/nashsu/llm_wiki/issues/196