### PR TITLE
Fix typo: 'ouput' -> 'output' in Turndown.js

### DIFF
--- a/extension/Turndown.js
+++ b/extension/Turndown.js
@@ -739,7 +739,7 @@
    * Appends strings as each rule requires and trims the output
    * @private
    * @param {String} output The conversion output
-   * @returns A trimmed version of the ouput
+   * @returns A trimmed version of the output
    * @type String
    */
 


### PR DESCRIPTION
Fixes #255

### Description

Fixed a typo in `extension/Turndown.js` where `output` was misspelled as `ouput` in a JSDoc comment.

### Change
- File: `extension/Turndown.js` (line 742)
- `ouput` → `output`
