### PR TITLE
feat(search): add Exa AI as web search provider

### DIFF
--- a/src/components/settings/sections/web-search-section.tsx
+++ b/src/components/settings/sections/web-search-section.tsx
@@ -1,301 +1,366 @@
-import { useState } from "react"
-import { ChevronDown, ChevronRight } from "lucide-react"
-import { useTranslation } from "react-i18next"
-import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
+import { ChevronDown, ChevronRight } from "lucide-react";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import {
-  useWikiStore,
-  type SearchApiConfig,
-  type SearchProvider,
-  type SearchProviderOverride,
-} from "@/stores/wiki-store"
+	resolveSearchConfig,
+	SEARXNG_CATEGORY_OPTIONS,
+	SERPAPI_ENGINE_OPTIONS,
+} from "@/lib/web-search";
 import {
-  SEARXNG_CATEGORY_OPTIONS,
-  SERPAPI_ENGINE_OPTIONS,
-  resolveSearchConfig,
-} from "@/lib/web-search"
+	type SearchApiConfig,
+	type SearchProvider,
+	type SearchProviderOverride,
+	useWikiStore,
+} from "@/stores/wiki-store";
 
 const SEARCH_PROVIDERS = [
-  {
-    id: "ollama",
-    label: "Ollama",
-    hint: "Ollama Web Search API",
-    keyPlaceholder: "Enter your Ollama API key (ollama.com)",
-    needsApiKey: true,
-  },
-  {
-    id: "tavily",
-    label: "Tavily",
-    hint: "General web search for Deep Research",
-    keyPlaceholder: "Enter your Tavily API key (tavily.com)",
-    needsApiKey: true,
-  },
-  {
-    id: "serpapi",
-    label: "SerpApi",
-    hint: "Google, Bing, DuckDuckGo, Scholar, News, Images, Videos, YouTube",
-    keyPlaceholder: "Enter your SerpApi API key (serpapi.com)",
-    needsApiKey: true,
-  },
-  {
-    id: "searxng",
-    label: "SearXNG",
-    hint: "Self-hosted metasearch via the SearXNG JSON API",
-    urlPlaceholder: "https://search.example.com",
-    needsApiKey: false,
-  },
-] as const
+	{
+		id: "ollama",
+		label: "Ollama",
+		hint: "Ollama Web Search API",
+		keyPlaceholder: "Enter your Ollama API key (ollama.com)",
+		needsApiKey: true,
+	},
+	{
+		id: "tavily",
+		label: "Tavily",
+		hint: "General web search for Deep Research",
+		keyPlaceholder: "Enter your Tavily API key (tavily.com)",
+		needsApiKey: true,
+	},
+	{
+		id: "serpapi",
+		label: "SerpApi",
+		hint: "Google, Bing, DuckDuckGo, Scholar, News, Images, Videos, YouTube",
+		keyPlaceholder: "Enter your SerpApi API key (serpapi.com)",
+		needsApiKey: true,
+	},
+	{
+		id: "searxng",
+		label: "SearXNG",
+		hint: "Self-hosted metasearch via the SearXNG JSON API",
+		urlPlaceholder: "https://search.example.com",
+		needsApiKey: false,
+	},
+	{
+		id: "exa",
+		label: "Exa",
+		hint: "AI-powered web search with full page content for Deep Research",
+		keyPlaceholder: "Enter your Exa API key (exa.ai)",
+		needsApiKey: true,
+	},
+] as const;
 
 export function WebSearchSection() {
-  const { t } = useTranslation()
-  const searchApiConfig = useWikiStore((s) => s.searchApiConfig)
-  const setSearchApiConfig = useWikiStore((s) => s.setSearchApiConfig)
-  const resolvedConfig = resolveSearchConfig(searchApiConfig)
-  const [expanded, setExpanded] = useState<Record<string, boolean>>({})
-  const [savedId, setSavedId] = useState<string | null>(null)
+	const { t } = useTranslation();
+	const searchApiConfig = useWikiStore((s) => s.searchApiConfig);
+	const setSearchApiConfig = useWikiStore((s) => s.setSearchApiConfig);
+	const resolvedConfig = resolveSearchConfig(searchApiConfig);
+	const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+	const [savedId, setSavedId] = useState<string | null>(null);
 
-  async function persist(next: SearchApiConfig) {
-    const { saveSearchApiConfig } = await import("@/lib/project-store")
-    setSearchApiConfig(next)
-    await saveSearchApiConfig(next)
-  }
+	async function persist(next: SearchApiConfig) {
+		const { saveSearchApiConfig } = await import("@/lib/project-store");
+		setSearchApiConfig(next);
+		await saveSearchApiConfig(next);
+	}
 
-  function updateProvider(id: Exclude<SearchProvider, "none">, patch: SearchProviderOverride) {
-    const currentConfigs = resolvedConfig.providerConfigs ?? {}
-    const merged = { ...(currentConfigs[id] ?? {}), ...patch }
-    const nextConfigs = { ...currentConfigs, [id]: merged }
-    const next = resolveSearchConfig({
-      ...resolvedConfig,
-      providerConfigs: nextConfigs,
-    })
-    persist(next).catch(() => {})
-    setSavedId(id)
-    setTimeout(() => setSavedId((cur) => (cur === id ? null : cur)), 1500)
-  }
+	function updateProvider(
+		id: Exclude<SearchProvider, "none">,
+		patch: SearchProviderOverride,
+	) {
+		const currentConfigs = resolvedConfig.providerConfigs ?? {};
+		const merged = { ...(currentConfigs[id] ?? {}), ...patch };
+		const nextConfigs = { ...currentConfigs, [id]: merged };
+		const next = resolveSearchConfig({
+			...resolvedConfig,
+			providerConfigs: nextConfigs,
+		});
+		persist(next).catch(() => {});
+		setSavedId(id);
+		setTimeout(() => setSavedId((cur) => (cur === id ? null : cur)), 1500);
+	}
 
-  function toggleActive(id: Exclude<SearchProvider, "none">) {
-    const nextProvider = resolvedConfig.provider === id ? "none" : id
-    persist(resolveSearchConfig({ ...resolvedConfig, provider: nextProvider })).catch(() => {})
-  }
+	function toggleActive(id: Exclude<SearchProvider, "none">) {
+		const nextProvider = resolvedConfig.provider === id ? "none" : id;
+		persist(
+			resolveSearchConfig({ ...resolvedConfig, provider: nextProvider }),
+		).catch(() => {});
+	}
 
-  return (
-    <div className="space-y-4">
-      <div>
-        <h2 className="text-xl font-semibold">{t("settings.sections.webSearch.title")} (Deep Research)</h2>
-        <p className="mt-1 text-sm text-muted-foreground">
-          {t("settings.sections.webSearch.description")}
-        </p>
-      </div>
+	return (
+		<div className="space-y-4">
+			<div>
+				<h2 className="text-xl font-semibold">
+					{t("settings.sections.webSearch.title")} (Deep Research)
+				</h2>
+				<p className="mt-1 text-sm text-muted-foreground">
+					{t("settings.sections.webSearch.description")}
+				</p>
+			</div>
 
-      <div className="space-y-2">
-        {SEARCH_PROVIDERS.map((provider) => {
-          const override = resolvedConfig.providerConfigs?.[provider.id]
-          const isActive = resolvedConfig.provider === provider.id
-          const hasConfig = provider.id === "searxng"
-            ? !!override?.searXngUrl
-            : !!override?.apiKey
-          const isExpanded = !!expanded[provider.id]
-          return (
-            <div
-              key={provider.id}
-              className={`rounded-lg border transition-colors ${
-                isActive ? "border-primary/60 bg-primary/5" : "border-border"
-              }`}
-            >
-              <div className="flex items-center gap-3 px-3 py-2.5">
-                <button
-                  type="button"
-                  onClick={() => setExpanded((prev) => ({ ...prev, [provider.id]: !prev[provider.id] }))}
-                  className="shrink-0 rounded p-0.5 text-muted-foreground hover:bg-accent"
-                  title={isExpanded ? t("settings.sections.webSearch.collapse") : t("settings.sections.webSearch.expand")}
-                >
-                  {isExpanded ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
-                </button>
+			<div className="space-y-2">
+				{SEARCH_PROVIDERS.map((provider) => {
+					const override = resolvedConfig.providerConfigs?.[provider.id];
+					const isActive = resolvedConfig.provider === provider.id;
+					const hasConfig =
+						provider.id === "searxng"
+							? !!override?.searXngUrl
+							: !!override?.apiKey;
+					const isExpanded = !!expanded[provider.id];
+					return (
+						<div
+							key={provider.id}
+							className={`rounded-lg border transition-colors ${
+								isActive ? "border-primary/60 bg-primary/5" : "border-border"
+							}`}
+						>
+							<div className="flex items-center gap-3 px-3 py-2.5">
+								<button
+									type="button"
+									onClick={() =>
+										setExpanded((prev) => ({
+											...prev,
+											[provider.id]: !prev[provider.id],
+										}))
+									}
+									className="shrink-0 rounded p-0.5 text-muted-foreground hover:bg-accent"
+									title={
+										isExpanded
+											? t("settings.sections.webSearch.collapse")
+											: t("settings.sections.webSearch.expand")
+									}
+								>
+									{isExpanded ? (
+										<ChevronDown className="h-4 w-4" />
+									) : (
+										<ChevronRight className="h-4 w-4" />
+									)}
+								</button>
 
-                <button
-                  type="button"
-                  onClick={() => setExpanded((prev) => ({ ...prev, [provider.id]: !prev[provider.id] }))}
-                  className="min-w-0 flex-1 text-left"
-                >
-                  <div className="flex items-center gap-2">
-                    <span className="truncate text-sm font-medium">{provider.label}</span>
-                    {hasConfig && !isActive && (
-                      <span className="shrink-0 rounded-full bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
-                        {t("settings.sections.webSearch.configuredBadge")}
-                      </span>
-                    )}
-                    {isActive && (
-                      <span className="shrink-0 rounded-full bg-primary/20 px-1.5 py-0.5 text-[10px] font-medium text-primary">
-                        {t("settings.sections.webSearch.activeBadge")}
-                      </span>
-                    )}
-                    {savedId === provider.id && (
-                      <span className="shrink-0 text-[10px] text-emerald-600">
-                        {t("settings.sections.webSearch.savedBadge")}
-                      </span>
-                    )}
-                  </div>
-                  <div className="mt-0.5 truncate text-xs text-muted-foreground">
-                    {provider.hint}
-                  </div>
-                </button>
+								<button
+									type="button"
+									onClick={() =>
+										setExpanded((prev) => ({
+											...prev,
+											[provider.id]: !prev[provider.id],
+										}))
+									}
+									className="min-w-0 flex-1 text-left"
+								>
+									<div className="flex items-center gap-2">
+										<span className="truncate text-sm font-medium">
+											{provider.label}
+										</span>
+										{hasConfig && !isActive && (
+											<span className="shrink-0 rounded-full bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
+												{t("settings.sections.webSearch.configuredBadge")}
+											</span>
+										)}
+										{isActive && (
+											<span className="shrink-0 rounded-full bg-primary/20 px-1.5 py-0.5 text-[10px] font-medium text-primary">
+												{t("settings.sections.webSearch.activeBadge")}
+											</span>
+										)}
+										{savedId === provider.id && (
+											<span className="shrink-0 text-[10px] text-emerald-600">
+												{t("settings.sections.webSearch.savedBadge")}
+											</span>
+										)}
+									</div>
+									<div className="mt-0.5 truncate text-xs text-muted-foreground">
+										{provider.hint}
+									</div>
+								</button>
 
-                <button
-                  type="button"
-                  onClick={() => toggleActive(provider.id)}
-                  className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full border transition-colors ${
-                    isActive
-                      ? "border-primary bg-primary"
-                      : "border-muted-foreground/30 bg-muted-foreground/20 hover:bg-muted-foreground/30"
-                  }`}
-                  aria-label={isActive ? t("settings.sections.webSearch.deactivate") : t("settings.sections.webSearch.activate")}
-                >
-                  <span
-                    className={`inline-block h-3.5 w-3.5 rounded-full bg-white shadow-sm ring-1 ring-black/10 transition-transform ${
-                      isActive ? "translate-x-4" : "translate-x-0.5"
-                    }`}
-                  />
-                </button>
-              </div>
+								<button
+									type="button"
+									onClick={() => toggleActive(provider.id)}
+									className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full border transition-colors ${
+										isActive
+											? "border-primary bg-primary"
+											: "border-muted-foreground/30 bg-muted-foreground/20 hover:bg-muted-foreground/30"
+									}`}
+									aria-label={
+										isActive
+											? t("settings.sections.webSearch.deactivate")
+											: t("settings.sections.webSearch.activate")
+									}
+								>
+									<span
+										className={`inline-block h-3.5 w-3.5 rounded-full bg-white shadow-sm ring-1 ring-black/10 transition-transform ${
+											isActive ? "translate-x-4" : "translate-x-0.5"
+										}`}
+									/>
+								</button>
+							</div>
 
-              {isExpanded && (
-                <div className="space-y-4 border-t bg-background/50 px-4 py-3">
-                  {provider.needsApiKey ? (
-                    <div className="space-y-2">
-                      <Label>{t("settings.apiKey")}</Label>
-                      <Input
-                        type="password"
-                        value={override?.apiKey ?? ""}
-                        onChange={(e) => updateProvider(provider.id, { apiKey: e.target.value })}
-                        placeholder={provider.keyPlaceholder}
-                      />
-                      {provider.id === "ollama" && (
-                        <p className="text-xs text-muted-foreground">
-                          {t("settings.sections.webSearch.ollamaHint")}
-                        </p>
-                      )}
-                    </div>
-                  ) : (
-                    <div className="space-y-2">
-                      <Label>{t("settings.sections.webSearch.instanceUrl")}</Label>
-                      <Input
-                        value={override?.searXngUrl ?? resolvedConfig.searXngUrl ?? ""}
-                        onChange={(e) => updateProvider("searxng", { searXngUrl: e.target.value })}
-                        placeholder={provider.urlPlaceholder}
-                      />
-                      <p className="text-xs text-muted-foreground">
-                        {t("settings.sections.webSearch.searxngJsonHint")}
-                      </p>
-                    </div>
-                  )}
+							{isExpanded && (
+								<div className="space-y-4 border-t bg-background/50 px-4 py-3">
+									{provider.needsApiKey ? (
+										<div className="space-y-2">
+											<Label>{t("settings.apiKey")}</Label>
+											<Input
+												type="password"
+												value={override?.apiKey ?? ""}
+												onChange={(e) =>
+													updateProvider(provider.id, {
+														apiKey: e.target.value,
+													})
+												}
+												placeholder={provider.keyPlaceholder}
+											/>
+											{provider.id === "ollama" && (
+												<p className="text-xs text-muted-foreground">
+													{t("settings.sections.webSearch.ollamaHint")}
+												</p>
+											)}
+										</div>
+									) : (
+										<div className="space-y-2">
+											<Label>
+												{t("settings.sections.webSearch.instanceUrl")}
+											</Label>
+											<Input
+												value={
+													override?.searXngUrl ??
+													resolvedConfig.searXngUrl ??
+													""
+												}
+												onChange={(e) =>
+													updateProvider("searxng", {
+														searXngUrl: e.target.value,
+													})
+												}
+												placeholder={provider.urlPlaceholder}
+											/>
+											<p className="text-xs text-muted-foreground">
+												{t("settings.sections.webSearch.searxngJsonHint")}
+											</p>
+										</div>
+									)}
 
-                  {provider.id === "serpapi" && (
-                    <SerpApiEnginePicker
-                      value={override?.serpApiEngine ?? resolvedConfig.serpApiEngine ?? "google"}
-                      onChange={(serpApiEngine) => updateProvider("serpapi", { serpApiEngine })}
-                    />
-                  )}
+									{provider.id === "serpapi" && (
+										<SerpApiEnginePicker
+											value={
+												override?.serpApiEngine ??
+												resolvedConfig.serpApiEngine ??
+												"google"
+											}
+											onChange={(serpApiEngine) =>
+												updateProvider("serpapi", { serpApiEngine })
+											}
+										/>
+									)}
 
-                  {provider.id === "searxng" && (
-                    <SearXngCategoryPicker
-                      value={override?.searXngCategories ?? resolvedConfig.searXngCategories ?? ["general"]}
-                      onChange={(searXngCategories) => updateProvider("searxng", { searXngCategories })}
-                    />
-                  )}
-                </div>
-              )}
-            </div>
-          )
-        })}
-      </div>
-    </div>
-  )
+									{provider.id === "searxng" && (
+										<SearXngCategoryPicker
+											value={
+												override?.searXngCategories ??
+												resolvedConfig.searXngCategories ?? ["general"]
+											}
+											onChange={(searXngCategories) =>
+												updateProvider("searxng", { searXngCategories })
+											}
+										/>
+									)}
+								</div>
+							)}
+						</div>
+					);
+				})}
+			</div>
+		</div>
+	);
 }
 
 function SearXngCategoryPicker({
-  value,
-  onChange,
+	value,
+	onChange,
 }: {
-  value: string[]
-  onChange: (value: string[]) => void
+	value: string[];
+	onChange: (value: string[]) => void;
 }) {
-  const { t } = useTranslation()
-  const selected = value.length > 0 ? value : ["general"]
+	const { t } = useTranslation();
+	const selected = value.length > 0 ? value : ["general"];
 
-  function toggle(category: string) {
-    const next = selected.includes(category)
-      ? selected.filter((item) => item !== category)
-      : [...selected, category]
-    onChange(next.length > 0 ? next : ["general"])
-  }
+	function toggle(category: string) {
+		const next = selected.includes(category)
+			? selected.filter((item) => item !== category)
+			: [...selected, category];
+		onChange(next.length > 0 ? next : ["general"]);
+	}
 
-  return (
-    <div className="space-y-2">
-      <Label>{t("settings.sections.webSearch.searchCategories")}</Label>
-      <div className="flex flex-wrap gap-1.5">
-        {SEARXNG_CATEGORY_OPTIONS.map((category) => (
-          <button
-            key={category.value}
-            type="button"
-            onClick={() => toggle(category.value)}
-            className={`rounded-md border px-2.5 py-1 text-xs transition-colors ${
-              selected.includes(category.value)
-                ? "border-primary bg-primary text-primary-foreground"
-                : "border-border hover:bg-accent"
-            }`}
-            title={category.hint}
-          >
-            {category.label}
-          </button>
-        ))}
-      </div>
-      <p className="text-xs text-muted-foreground">
-        {t("settings.sections.webSearch.searxngCategoriesHint")}
-      </p>
-    </div>
-  )
+	return (
+		<div className="space-y-2">
+			<Label>{t("settings.sections.webSearch.searchCategories")}</Label>
+			<div className="flex flex-wrap gap-1.5">
+				{SEARXNG_CATEGORY_OPTIONS.map((category) => (
+					<button
+						key={category.value}
+						type="button"
+						onClick={() => toggle(category.value)}
+						className={`rounded-md border px-2.5 py-1 text-xs transition-colors ${
+							selected.includes(category.value)
+								? "border-primary bg-primary text-primary-foreground"
+								: "border-border hover:bg-accent"
+						}`}
+						title={category.hint}
+					>
+						{category.label}
+					</button>
+				))}
+			</div>
+			<p className="text-xs text-muted-foreground">
+				{t("settings.sections.webSearch.searxngCategoriesHint")}
+			</p>
+		</div>
+	);
 }
 
 function SerpApiEnginePicker({
-  value,
-  onChange,
+	value,
+	onChange,
 }: {
-  value: string
-  onChange: (value: string) => void
+	value: string;
+	onChange: (value: string) => void;
 }) {
-  const { t } = useTranslation()
-  const isCustom = value.length > 0 && !SERPAPI_ENGINE_OPTIONS.some((e) => e.value === value)
+	const { t } = useTranslation();
+	const isCustom =
+		value.length > 0 && !SERPAPI_ENGINE_OPTIONS.some((e) => e.value === value);
 
-  return (
-    <div className="space-y-2">
-      <Label>{t("settings.sections.webSearch.searchEngine")}</Label>
-      <div className="flex flex-wrap gap-1.5">
-        {SERPAPI_ENGINE_OPTIONS.map((engine) => (
-          <button
-            key={engine.value}
-            type="button"
-            onClick={() => onChange(engine.value)}
-            className={`rounded-md border px-2.5 py-1 text-xs transition-colors ${
-              value === engine.value
-                ? "border-primary bg-primary text-primary-foreground"
-                : "border-border hover:bg-accent"
-            }`}
-            title={engine.hint}
-          >
-            {engine.label}
-          </button>
-        ))}
-      </div>
-      <Input
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        placeholder={t("settings.sections.webSearch.customSerpApiPlaceholder")}
-      />
-      {isCustom && (
-        <p className="text-xs text-muted-foreground">
-          {t("settings.sections.webSearch.customSerpApiHint")}
-        </p>
-      )}
-    </div>
-  )
+	return (
+		<div className="space-y-2">
+			<Label>{t("settings.sections.webSearch.searchEngine")}</Label>
+			<div className="flex flex-wrap gap-1.5">
+				{SERPAPI_ENGINE_OPTIONS.map((engine) => (
+					<button
+						key={engine.value}
+						type="button"
+						onClick={() => onChange(engine.value)}
+						className={`rounded-md border px-2.5 py-1 text-xs transition-colors ${
+							value === engine.value
+								? "border-primary bg-primary text-primary-foreground"
+								: "border-border hover:bg-accent"
+						}`}
+						title={engine.hint}
+					>
+						{engine.label}
+					</button>
+				))}
+			</div>
+			<Input
+				value={value}
+				onChange={(e) => onChange(e.target.value)}
+				placeholder={t("settings.sections.webSearch.customSerpApiPlaceholder")}
+			/>
+			{isCustom && (
+				<p className="text-xs text-muted-foreground">
+					{t("settings.sections.webSearch.customSerpApiHint")}
+				</p>
+			)}
+		</div>
+	);
 }

--- a/src/lib/web-search.test.ts
+++ b/src/lib/web-search.test.ts
@@ -1,265 +1,356 @@
-import { beforeEach, describe, expect, it, vi } from "vitest"
-import { hasConfiguredSearchProvider, resolveSearchConfig, webSearch } from "./web-search"
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	hasConfiguredSearchProvider,
+	resolveSearchConfig,
+	webSearch,
+} from "./web-search";
 
-const fetchMock = vi.fn<typeof fetch>()
+const fetchMock = vi.fn<typeof fetch>();
 
 function jsonResponse(body: unknown, init?: ResponseInit): Response {
-  return new Response(JSON.stringify(body), {
-    status: 200,
-    headers: { "Content-Type": "application/json" },
-    ...init,
-  })
+	return new Response(JSON.stringify(body), {
+		status: 200,
+		headers: { "Content-Type": "application/json" },
+		...init,
+	});
 }
 
 describe("webSearch", () => {
-  beforeEach(() => {
-    fetchMock.mockReset()
-    vi.stubGlobal("fetch", fetchMock)
-  })
+	beforeEach(() => {
+		fetchMock.mockReset();
+		vi.stubGlobal("fetch", fetchMock);
+	});
 
-  it("normalizes Tavily results", async () => {
-    fetchMock.mockResolvedValueOnce(jsonResponse({
-      results: [
-        { title: "A", url: "https://www.example.com/a", content: "Alpha" },
-      ],
-    }))
+	it("normalizes Tavily results", async () => {
+		fetchMock.mockResolvedValueOnce(
+			jsonResponse({
+				results: [
+					{ title: "A", url: "https://www.example.com/a", content: "Alpha" },
+				],
+			}),
+		);
 
-    const out = await webSearch("alpha", { provider: "tavily", apiKey: "tvly" }, 3)
+		const out = await webSearch(
+			"alpha",
+			{ provider: "tavily", apiKey: "tvly" },
+			3,
+		);
 
-    expect(fetchMock).toHaveBeenCalledWith("https://api.tavily.com/search", expect.objectContaining({
-      method: "POST",
-    }))
-    expect(out).toEqual([
-      { title: "A", url: "https://www.example.com/a", snippet: "Alpha", source: "example.com" },
-    ])
-  })
+		expect(fetchMock).toHaveBeenCalledWith(
+			"https://api.tavily.com/search",
+			expect.objectContaining({
+				method: "POST",
+			}),
+		);
+		expect(out).toEqual([
+			{
+				title: "A",
+				url: "https://www.example.com/a",
+				snippet: "Alpha",
+				source: "example.com",
+			},
+		]);
+	});
 
-  it("calls SerpApi Google Search and normalizes organic results", async () => {
-    fetchMock.mockResolvedValueOnce(jsonResponse({
-      organic_results: [
-        { title: "Serp result", link: "https://www.serp.example/page", snippet: "Snippet" },
-        { title: "Second", link: "https://docs.example/item", snippet: "More" },
-      ],
-    }))
+	it("calls SerpApi Google Search and normalizes organic results", async () => {
+		fetchMock.mockResolvedValueOnce(
+			jsonResponse({
+				organic_results: [
+					{
+						title: "Serp result",
+						link: "https://www.serp.example/page",
+						snippet: "Snippet",
+					},
+					{
+						title: "Second",
+						link: "https://docs.example/item",
+						snippet: "More",
+					},
+				],
+			}),
+		);
 
-    const out = await webSearch("knowledge graph", { provider: "serpapi", apiKey: "serp" }, 1)
-    const [url, init] = fetchMock.mock.calls[0]
-    const parsed = new URL(String(url))
+		const out = await webSearch(
+			"knowledge graph",
+			{ provider: "serpapi", apiKey: "serp" },
+			1,
+		);
+		const [url, init] = fetchMock.mock.calls[0];
+		const parsed = new URL(String(url));
 
-    expect(parsed.origin + parsed.pathname).toBe("https://serpapi.com/search")
-    expect(parsed.searchParams.get("engine")).toBe("google")
-    expect(parsed.searchParams.get("q")).toBe("knowledge graph")
-    expect(parsed.searchParams.get("api_key")).toBe("serp")
-    expect(parsed.searchParams.get("num")).toBe("1")
-    expect(init).toEqual(expect.objectContaining({ method: "GET" }))
-    expect(out).toEqual([
-      { title: "Serp result", url: "https://www.serp.example/page", snippet: "Snippet", source: "serp.example" },
-    ])
-  })
+		expect(parsed.origin + parsed.pathname).toBe("https://serpapi.com/search");
+		expect(parsed.searchParams.get("engine")).toBe("google");
+		expect(parsed.searchParams.get("q")).toBe("knowledge graph");
+		expect(parsed.searchParams.get("api_key")).toBe("serp");
+		expect(parsed.searchParams.get("num")).toBe("1");
+		expect(init).toEqual(expect.objectContaining({ method: "GET" }));
+		expect(out).toEqual([
+			{
+				title: "Serp result",
+				url: "https://www.serp.example/page",
+				snippet: "Snippet",
+				source: "serp.example",
+			},
+		]);
+	});
 
-  it("uses SerpApi provider-specific config and selected engine", async () => {
-    fetchMock.mockResolvedValueOnce(jsonResponse({
-      news_results: [
-        { title: "News", link: "https://news.example/story", snippet: "Fresh" },
-      ],
-    }))
+	it("uses SerpApi provider-specific config and selected engine", async () => {
+		fetchMock.mockResolvedValueOnce(
+			jsonResponse({
+				news_results: [
+					{
+						title: "News",
+						link: "https://news.example/story",
+						snippet: "Fresh",
+					},
+				],
+			}),
+		);
 
-    const out = await webSearch(
-      "ai policy",
-      {
-        provider: "serpapi",
-        apiKey: "",
-        providerConfigs: {
-          tavily: { apiKey: "tavily-key" },
-          serpapi: { apiKey: "serp-key", serpApiEngine: "google_news" },
-        },
-      },
-      5,
-    )
-    const parsed = new URL(String(fetchMock.mock.calls[0][0]))
+		const out = await webSearch(
+			"ai policy",
+			{
+				provider: "serpapi",
+				apiKey: "",
+				providerConfigs: {
+					tavily: { apiKey: "tavily-key" },
+					serpapi: { apiKey: "serp-key", serpApiEngine: "google_news" },
+				},
+			},
+			5,
+		);
+		const parsed = new URL(String(fetchMock.mock.calls[0][0]));
 
-    expect(parsed.searchParams.get("engine")).toBe("google_news")
-    expect(parsed.searchParams.get("api_key")).toBe("serp-key")
-    expect(out).toEqual([
-      { title: "News", url: "https://news.example/story", snippet: "Fresh", source: "news.example" },
-    ])
-  })
+		expect(parsed.searchParams.get("engine")).toBe("google_news");
+		expect(parsed.searchParams.get("api_key")).toBe("serp-key");
+		expect(out).toEqual([
+			{
+				title: "News",
+				url: "https://news.example/story",
+				snippet: "Fresh",
+				source: "news.example",
+			},
+		]);
+	});
 
-  it("calls SearXNG JSON search with the configured instance and categories", async () => {
-    fetchMock.mockResolvedValueOnce(jsonResponse({
-      results: [
-        {
-          title: "SearXNG result",
-          url: "https://docs.example/page",
-          content: "Result content",
-          engine: "duckduckgo",
-        },
-      ],
-    }))
+	it("calls SearXNG JSON search with the configured instance and categories", async () => {
+		fetchMock.mockResolvedValueOnce(
+			jsonResponse({
+				results: [
+					{
+						title: "SearXNG result",
+						url: "https://docs.example/page",
+						content: "Result content",
+						engine: "duckduckgo",
+					},
+				],
+			}),
+		);
 
-    const out = await webSearch(
-      "local search",
-      {
-        provider: "searxng",
-        apiKey: "",
-        providerConfigs: {
-          searxng: {
-            searXngUrl: "https://search.example.com",
-            searXngCategories: ["general", "news"],
-          },
-        },
-      },
-      3,
-    )
-    const [url, init] = fetchMock.mock.calls[0]
-    const parsed = new URL(String(url))
+		const out = await webSearch(
+			"local search",
+			{
+				provider: "searxng",
+				apiKey: "",
+				providerConfigs: {
+					searxng: {
+						searXngUrl: "https://search.example.com",
+						searXngCategories: ["general", "news"],
+					},
+				},
+			},
+			3,
+		);
+		const [url, init] = fetchMock.mock.calls[0];
+		const parsed = new URL(String(url));
 
-    expect(parsed.origin + parsed.pathname).toBe("https://search.example.com/search")
-    expect(parsed.searchParams.get("q")).toBe("local search")
-    expect(parsed.searchParams.get("format")).toBe("json")
-    expect(parsed.searchParams.get("categories")).toBe("general,news")
-    expect(init).toEqual(expect.objectContaining({ method: "GET" }))
-    expect(out).toEqual([
-      { title: "SearXNG result", url: "https://docs.example/page", snippet: "Result content", source: "docs.example" },
-    ])
-  })
+		expect(parsed.origin + parsed.pathname).toBe(
+			"https://search.example.com/search",
+		);
+		expect(parsed.searchParams.get("q")).toBe("local search");
+		expect(parsed.searchParams.get("format")).toBe("json");
+		expect(parsed.searchParams.get("categories")).toBe("general,news");
+		expect(init).toEqual(expect.objectContaining({ method: "GET" }));
+		expect(out).toEqual([
+			{
+				title: "SearXNG result",
+				url: "https://docs.example/page",
+				snippet: "Result content",
+				source: "docs.example",
+			},
+		]);
+	});
 
-  it("preserves SearXNG subpath instances when building the search endpoint", async () => {
-    fetchMock.mockResolvedValueOnce(jsonResponse({ results: [] }))
+	it("preserves SearXNG subpath instances when building the search endpoint", async () => {
+		fetchMock.mockResolvedValueOnce(jsonResponse({ results: [] }));
 
-    await webSearch(
-      "subpath",
-      {
-        provider: "searxng",
-        apiKey: "",
-        providerConfigs: {
-          searxng: { searXngUrl: "http://localhost:8080/searx/" },
-        },
-      },
-      5,
-    )
-    const parsed = new URL(String(fetchMock.mock.calls[0][0]))
+		await webSearch(
+			"subpath",
+			{
+				provider: "searxng",
+				apiKey: "",
+				providerConfigs: {
+					searxng: { searXngUrl: "http://localhost:8080/searx/" },
+				},
+			},
+			5,
+		);
+		const parsed = new URL(String(fetchMock.mock.calls[0][0]));
 
-    expect(parsed.origin + parsed.pathname).toBe("http://localhost:8080/searx/search")
-    expect(parsed.searchParams.get("categories")).toBe("general")
-  })
+		expect(parsed.origin + parsed.pathname).toBe(
+			"http://localhost:8080/searx/search",
+		);
+		expect(parsed.searchParams.get("categories")).toBe("general");
+	});
 
-  it("surfaces SerpApi JSON errors", async () => {
-    fetchMock.mockResolvedValueOnce(jsonResponse({ error: "Invalid API key" }))
+	it("surfaces SerpApi JSON errors", async () => {
+		fetchMock.mockResolvedValueOnce(jsonResponse({ error: "Invalid API key" }));
 
-    await expect(webSearch("x", { provider: "serpapi", apiKey: "bad" }, 5))
-      .rejects.toThrow("SerpApi search failed: Invalid API key")
-  })
+		await expect(
+			webSearch("x", { provider: "serpapi", apiKey: "bad" }, 5),
+		).rejects.toThrow("SerpApi search failed: Invalid API key");
+	});
 
-  it("requires a configured search provider and key", async () => {
-    await expect(webSearch("x", { provider: "none", apiKey: "" }, 5))
-      .rejects.toThrow("Select a search provider")
-    await expect(webSearch("x", { provider: "serpapi", apiKey: "" }, 5))
-      .rejects.toThrow("Tavily or SerpApi API key")
-    await expect(webSearch("x", { provider: "searxng", apiKey: "" }, 5))
-      .rejects.toThrow("SearXNG instance URL")
-  })
+	it("requires a configured search provider and key", async () => {
+		await expect(
+			webSearch("x", { provider: "none", apiKey: "" }, 5),
+		).rejects.toThrow("Select a search provider");
+		await expect(
+			webSearch("x", { provider: "serpapi", apiKey: "" }, 5),
+		).rejects.toThrow("Tavily, SerpApi, or Exa API key");
+		await expect(
+			webSearch("x", { provider: "searxng", apiKey: "" }, 5),
+		).rejects.toThrow("SearXNG instance URL");
+	});
 
-  it("treats SearXNG instance URLs as configured without an API key", () => {
-    expect(hasConfiguredSearchProvider({
-      provider: "searxng",
-      apiKey: "",
-      providerConfigs: {
-        searxng: {
-          searXngUrl: "http://127.0.0.1:8080",
-          searXngCategories: ["general", "science", "it"],
-        },
-      },
-      searXngUrl: "http://127.0.0.1:8080",
-      searXngCategories: ["general", "science", "it"],
-      serpApiEngine: "google",
-    })).toBe(true)
-  })
+	it("treats SearXNG instance URLs as configured without an API key", () => {
+		expect(
+			hasConfiguredSearchProvider({
+				provider: "searxng",
+				apiKey: "",
+				providerConfigs: {
+					searxng: {
+						searXngUrl: "http://127.0.0.1:8080",
+						searXngCategories: ["general", "science", "it"],
+					},
+				},
+				searXngUrl: "http://127.0.0.1:8080",
+				searXngCategories: ["general", "science", "it"],
+				serpApiEngine: "google",
+			}),
+		).toBe(true);
+	});
 
-  it("requires an API key for the Ollama Web Search API", async () => {
-    await expect(webSearch(
-      "official ollama",
-      {
-        provider: "ollama",
-        apiKey: "",
-        providerConfigs: {
-          ollama: { ollamaUrl: "https://ollama.com" },
-        },
-      },
-      5,
-    )).rejects.toThrow("requires an Ollama API key")
+	it("requires an API key for the Ollama Web Search API", async () => {
+		await expect(
+			webSearch(
+				"official ollama",
+				{
+					provider: "ollama",
+					apiKey: "",
+					providerConfigs: {
+						ollama: { ollamaUrl: "https://ollama.com" },
+					},
+				},
+				5,
+			),
+		).rejects.toThrow("requires an Ollama API key");
 
-    expect(hasConfiguredSearchProvider({
-      provider: "ollama",
-      apiKey: "",
-      providerConfigs: {
-        ollama: { ollamaUrl: "https://ollama.com" },
-      },
-    })).toBe(false)
-  })
+		expect(
+			hasConfiguredSearchProvider({
+				provider: "ollama",
+				apiKey: "",
+				providerConfigs: {
+					ollama: { ollamaUrl: "https://ollama.com" },
+				},
+			}),
+		).toBe(false);
+	});
 
-  it("does not leak a stale top-level Ollama URL into non-Ollama providers", () => {
-    const resolved = resolveSearchConfig({
-      provider: "serpapi",
-      apiKey: "",
-      ollamaUrl: "http://localhost:11434",
-      providerConfigs: {
-        serpapi: { apiKey: "serp-key" },
-        ollama: { ollamaUrl: "https://ollama.com" },
-      },
-    })
+	it("does not leak a stale top-level Ollama URL into non-Ollama providers", () => {
+		const resolved = resolveSearchConfig({
+			provider: "serpapi",
+			apiKey: "",
+			ollamaUrl: "http://localhost:11434",
+			providerConfigs: {
+				serpapi: { apiKey: "serp-key" },
+				ollama: { ollamaUrl: "https://ollama.com" },
+			},
+		});
 
-    expect(resolved.ollamaUrl).toBe("https://ollama.com")
-  })
+		expect(resolved.ollamaUrl).toBe("https://ollama.com");
+	});
 
-  it("calls the Ollama Web Search API with Bearer auth", async () => {
-    fetchMock.mockResolvedValueOnce(jsonResponse({
-      results: [
-        { title: "Official", url: "https://ollama.example/search", content: "Cloud result" },
-      ],
-    }))
+	it("calls the Ollama Web Search API with Bearer auth", async () => {
+		fetchMock.mockResolvedValueOnce(
+			jsonResponse({
+				results: [
+					{
+						title: "Official",
+						url: "https://ollama.example/search",
+						content: "Cloud result",
+					},
+				],
+			}),
+		);
 
-    const out = await webSearch(
-      "official ollama",
-      {
-        provider: "ollama",
-        apiKey: "",
-        providerConfigs: {
-          ollama: { apiKey: "ollama-key" },
-        },
-      },
-      1,
-    )
-    const [url, init] = fetchMock.mock.calls[0]
+		const out = await webSearch(
+			"official ollama",
+			{
+				provider: "ollama",
+				apiKey: "",
+				providerConfigs: {
+					ollama: { apiKey: "ollama-key" },
+				},
+			},
+			1,
+		);
+		const [url, init] = fetchMock.mock.calls[0];
 
-    expect(url).toBe("https://ollama.com/api/web_search")
-    expect((init?.headers as Record<string, string>).Authorization).toBe("Bearer ollama-key")
-    expect(JSON.parse(String(init?.body))).toEqual({ query: "official ollama", max_results: 1 })
-    expect(out).toEqual([
-      { title: "Official", url: "https://ollama.example/search", snippet: "Cloud result", source: "ollama.example" },
-    ])
-    expect(hasConfiguredSearchProvider({
-      provider: "ollama",
-      apiKey: "",
-      providerConfigs: {
-        ollama: { apiKey: "ollama-key" },
-      },
-    })).toBe(true)
-  })
+		expect(url).toBe("https://ollama.com/api/web_search");
+		expect((init?.headers as Record<string, string>).Authorization).toBe(
+			"Bearer ollama-key",
+		);
+		expect(JSON.parse(String(init?.body))).toEqual({
+			query: "official ollama",
+			max_results: 1,
+		});
+		expect(out).toEqual([
+			{
+				title: "Official",
+				url: "https://ollama.example/search",
+				snippet: "Cloud result",
+				source: "ollama.example",
+			},
+		]);
+		expect(
+			hasConfiguredSearchProvider({
+				provider: "ollama",
+				apiKey: "",
+				providerConfigs: {
+					ollama: { apiKey: "ollama-key" },
+				},
+			}),
+		).toBe(true);
+	});
 
-  it("surfaces Ollama authentication guidance for 401 responses", async () => {
-    fetchMock.mockResolvedValueOnce(jsonResponse({ error: "unauthorized" }, { status: 401 }))
+	it("surfaces Ollama authentication guidance for 401 responses", async () => {
+		fetchMock.mockResolvedValueOnce(
+			jsonResponse({ error: "unauthorized" }, { status: 401 }),
+		);
 
-    await expect(webSearch(
-      "official ollama",
-      {
-        provider: "ollama",
-        apiKey: "",
-        providerConfigs: {
-          ollama: { apiKey: "bad-key" },
-        },
-      },
-      5,
-    )).rejects.toThrow("Check your Ollama API key")
-  })
-})
+		await expect(
+			webSearch(
+				"official ollama",
+				{
+					provider: "ollama",
+					apiKey: "",
+					providerConfigs: {
+						ollama: { apiKey: "bad-key" },
+					},
+				},
+				5,
+			),
+		).rejects.toThrow("Check your Ollama API key");
+	});
+});

--- a/src/lib/web-search.ts
+++ b/src/lib/web-search.ts
@@ -1,439 +1,591 @@
+import { getHttpFetch, isFetchNetworkError } from "@/lib/tauri-fetch";
 import type {
-  SearchApiConfig,
-  SearchProvider,
-  SearchProviderConfigs,
-  SearXngCategory,
-  SerpApiEngine,
-} from "@/stores/wiki-store"
-import { getHttpFetch, isFetchNetworkError } from "@/lib/tauri-fetch"
+	SearchApiConfig,
+	SearchProvider,
+	SearchProviderConfigs,
+	SearXngCategory,
+	SerpApiEngine,
+} from "@/stores/wiki-store";
 
 export interface WebSearchResult {
-  title: string
-  url: string
-  snippet: string
-  source: string
+	title: string;
+	url: string;
+	snippet: string;
+	source: string;
 }
 
-export const SERPAPI_ENGINE_OPTIONS: { value: SerpApiEngine; label: string; hint: string }[] = [
-  { value: "google", label: "Google Web", hint: "SerpApi Google Search API organic results" },
-  { value: "google_news", label: "Google News", hint: "News-focused results" },
-  { value: "google_scholar", label: "Google Scholar", hint: "Academic papers and citations" },
-  { value: "google_patents", label: "Google Patents", hint: "Patent search results" },
-  { value: "bing", label: "Bing", hint: "Bing organic results" },
-  { value: "duckduckgo", label: "DuckDuckGo", hint: "DuckDuckGo organic results" },
-  { value: "google_images", label: "Google Images", hint: "Image search results" },
-  { value: "google_videos", label: "Google Videos", hint: "Video search results" },
-  { value: "youtube", label: "YouTube", hint: "YouTube video results" },
-]
+export const SERPAPI_ENGINE_OPTIONS: {
+	value: SerpApiEngine;
+	label: string;
+	hint: string;
+}[] = [
+	{
+		value: "google",
+		label: "Google Web",
+		hint: "SerpApi Google Search API organic results",
+	},
+	{ value: "google_news", label: "Google News", hint: "News-focused results" },
+	{
+		value: "google_scholar",
+		label: "Google Scholar",
+		hint: "Academic papers and citations",
+	},
+	{
+		value: "google_patents",
+		label: "Google Patents",
+		hint: "Patent search results",
+	},
+	{ value: "bing", label: "Bing", hint: "Bing organic results" },
+	{
+		value: "duckduckgo",
+		label: "DuckDuckGo",
+		hint: "DuckDuckGo organic results",
+	},
+	{
+		value: "google_images",
+		label: "Google Images",
+		hint: "Image search results",
+	},
+	{
+		value: "google_videos",
+		label: "Google Videos",
+		hint: "Video search results",
+	},
+	{ value: "youtube", label: "YouTube", hint: "YouTube video results" },
+];
 
-export const SEARXNG_CATEGORY_OPTIONS: { value: SearXngCategory; label: string; hint: string }[] = [
-  { value: "general", label: "General", hint: "Default web results" },
-  { value: "news", label: "News", hint: "News engines" },
-  { value: "science", label: "Science", hint: "Academic and science-focused engines" },
-  { value: "it", label: "IT", hint: "Developer and technology engines" },
-  { value: "images", label: "Images", hint: "Image search results" },
-  { value: "videos", label: "Videos", hint: "Video search results" },
-  { value: "files", label: "Files", hint: "File and document search" },
-  { value: "map", label: "Map", hint: "Map and location results" },
-  { value: "music", label: "Music", hint: "Music engines" },
-  { value: "social media", label: "Social", hint: "Social media engines" },
-]
+export const SEARXNG_CATEGORY_OPTIONS: {
+	value: SearXngCategory;
+	label: string;
+	hint: string;
+}[] = [
+	{ value: "general", label: "General", hint: "Default web results" },
+	{ value: "news", label: "News", hint: "News engines" },
+	{
+		value: "science",
+		label: "Science",
+		hint: "Academic and science-focused engines",
+	},
+	{ value: "it", label: "IT", hint: "Developer and technology engines" },
+	{ value: "images", label: "Images", hint: "Image search results" },
+	{ value: "videos", label: "Videos", hint: "Video search results" },
+	{ value: "files", label: "Files", hint: "File and document search" },
+	{ value: "map", label: "Map", hint: "Map and location results" },
+	{ value: "music", label: "Music", hint: "Music engines" },
+	{ value: "social media", label: "Social", hint: "Social media engines" },
+];
 
 export function resolveSearchConfig(config: SearchApiConfig): SearchApiConfig {
-  const providerConfigs: SearchProviderConfigs = config.providerConfigs ?? {
-    ...(config.provider !== "none" && config.provider !== "ollama" && config.apiKey
-      ? {
-          [config.provider]: {
-            apiKey: config.apiKey,
-            serpApiEngine: config.serpApiEngine,
-            searXngUrl: config.searXngUrl,
-            searXngCategories: config.searXngCategories,
-          },
-        }
-      : {}),
-    ...(config.provider === "searxng" && config.searXngUrl
-      ? {
-          searxng: {
-            searXngUrl: config.searXngUrl,
-            searXngCategories: config.searXngCategories,
-          },
-        }
-      : {}),
-    ...(config.provider === "ollama" && config.ollamaUrl
-      ? {
-          ollama: {
-            ollamaUrl: config.ollamaUrl,
-          },
-        }
-      : {}),
-  }
+	const providerConfigs: SearchProviderConfigs = config.providerConfigs ?? {
+		...(config.provider !== "none" &&
+		config.provider !== "ollama" &&
+		config.apiKey
+			? {
+					[config.provider]: {
+						apiKey: config.apiKey,
+						serpApiEngine: config.serpApiEngine,
+						searXngUrl: config.searXngUrl,
+						searXngCategories: config.searXngCategories,
+					},
+				}
+			: {}),
+		...(config.provider === "searxng" && config.searXngUrl
+			? {
+					searxng: {
+						searXngUrl: config.searXngUrl,
+						searXngCategories: config.searXngCategories,
+					},
+				}
+			: {}),
+		...(config.provider === "ollama" && config.ollamaUrl
+			? {
+					ollama: {
+						ollamaUrl: config.ollamaUrl,
+					},
+				}
+			: {}),
+	};
 
-  const activeProvider = config.provider as SearchProvider
-  const activeOverride = activeProvider === "none" ? undefined : providerConfigs[activeProvider]
-  const resolvedOllamaUrl =
-    activeProvider === "ollama"
-      ? activeOverride?.ollamaUrl ?? config.ollamaUrl ?? "https://ollama.com"
-      : providerConfigs.ollama?.ollamaUrl ?? "https://ollama.com"
+	const activeProvider = config.provider as SearchProvider;
+	const activeOverride =
+		activeProvider === "none" ? undefined : providerConfigs[activeProvider];
+	const resolvedOllamaUrl =
+		activeProvider === "ollama"
+			? (activeOverride?.ollamaUrl ?? config.ollamaUrl ?? "https://ollama.com")
+			: (providerConfigs.ollama?.ollamaUrl ?? "https://ollama.com");
 
-  if (activeProvider === "none") {
-    return {
-      ...config,
-      provider: "none",
-      apiKey: "",
-      serpApiEngine: config.serpApiEngine ?? providerConfigs.serpapi?.serpApiEngine ?? "google",
-      searXngUrl: config.searXngUrl ?? providerConfigs.searxng?.searXngUrl ?? "",
-      searXngCategories: config.searXngCategories ?? providerConfigs.searxng?.searXngCategories ?? ["general"],
-      ollamaUrl: providerConfigs.ollama?.ollamaUrl ?? "https://ollama.com",
-      providerConfigs,
-    }
-  }
+	if (activeProvider === "none") {
+		return {
+			...config,
+			provider: "none",
+			apiKey: "",
+			serpApiEngine:
+				config.serpApiEngine ??
+				providerConfigs.serpapi?.serpApiEngine ??
+				"google",
+			searXngUrl:
+				config.searXngUrl ?? providerConfigs.searxng?.searXngUrl ?? "",
+			searXngCategories: config.searXngCategories ??
+				providerConfigs.searxng?.searXngCategories ?? ["general"],
+			ollamaUrl: providerConfigs.ollama?.ollamaUrl ?? "https://ollama.com",
+			providerConfigs,
+		};
+	}
 
-  return {
-    ...config,
-    provider: activeProvider,
-    apiKey: activeOverride?.apiKey ?? config.apiKey ?? "",
-    serpApiEngine: activeOverride?.serpApiEngine ?? config.serpApiEngine ?? "google",
-    searXngUrl: activeOverride?.searXngUrl ?? config.searXngUrl ?? "",
-    searXngCategories: activeOverride?.searXngCategories ?? config.searXngCategories ?? ["general"],
-    ollamaUrl: resolvedOllamaUrl,
-    providerConfigs,
-  }
+	return {
+		...config,
+		provider: activeProvider,
+		apiKey: activeOverride?.apiKey ?? config.apiKey ?? "",
+		serpApiEngine:
+			activeOverride?.serpApiEngine ?? config.serpApiEngine ?? "google",
+		searXngUrl: activeOverride?.searXngUrl ?? config.searXngUrl ?? "",
+		searXngCategories: activeOverride?.searXngCategories ??
+			config.searXngCategories ?? ["general"],
+		ollamaUrl: resolvedOllamaUrl,
+		providerConfigs,
+	};
 }
 
 export function hasConfiguredSearchProvider(config: SearchApiConfig): boolean {
-  const resolved = resolveSearchConfig(config)
-  if (resolved.provider === "none") return false
-  if (resolved.provider === "searxng") {
-    return Boolean(resolved.searXngUrl?.trim())
-  }
-  if (resolved.provider === "ollama") {
-    return Boolean(resolved.apiKey?.trim())
-  }
-  return Boolean(resolved.apiKey?.trim())
+	const resolved = resolveSearchConfig(config);
+	if (resolved.provider === "none") return false;
+	if (resolved.provider === "searxng") {
+		return Boolean(resolved.searXngUrl?.trim());
+	}
+	if (resolved.provider === "ollama") {
+		return Boolean(resolved.apiKey?.trim());
+	}
+	return Boolean(resolved.apiKey?.trim());
 }
 
 export async function webSearch(
-  query: string,
-  config: SearchApiConfig,
-  maxResults: number = 10,
+	query: string,
+	config: SearchApiConfig,
+	maxResults: number = 10,
 ): Promise<WebSearchResult[]> {
-  const resolved = resolveSearchConfig(config)
-  if (resolved.provider === "none") {
-    throw new Error("Web search not configured. Select a search provider in Settings.")
-  }
-  if ((resolved.provider === "tavily" || resolved.provider === "serpapi") && !resolved.apiKey) {
-    throw new Error("Web search not configured. Add a Tavily or SerpApi API key in Settings, or select a different provider.")
-  }
-  if (resolved.provider === "searxng" && !resolved.searXngUrl?.trim()) {
-    throw new Error("Web search not configured. Add a SearXNG instance URL in Settings.")
-  }
-  if (resolved.provider === "ollama" && !resolved.apiKey?.trim()) {
-    throw new Error("Ollama Web Search API requires an Ollama API key. Add one in Settings.")
-  }
+	const resolved = resolveSearchConfig(config);
+	if (resolved.provider === "none") {
+		throw new Error(
+			"Web search not configured. Select a search provider in Settings.",
+		);
+	}
+	if (
+		(resolved.provider === "tavily" ||
+			resolved.provider === "serpapi" ||
+			resolved.provider === "exa") &&
+		!resolved.apiKey
+	) {
+		throw new Error(
+			"Web search not configured. Add a Tavily, SerpApi, or Exa API key in Settings, or select a different provider.",
+		);
+	}
+	if (resolved.provider === "searxng" && !resolved.searXngUrl?.trim()) {
+		throw new Error(
+			"Web search not configured. Add a SearXNG instance URL in Settings.",
+		);
+	}
+	if (resolved.provider === "ollama" && !resolved.apiKey?.trim()) {
+		throw new Error(
+			"Ollama Web Search API requires an Ollama API key. Add one in Settings.",
+		);
+	}
 
-  switch (resolved.provider) {
-    case "tavily":
-      return tavilySearch(query, resolved.apiKey, maxResults)
-    case "serpapi":
-      return serpApiSearch(query, resolved.apiKey, maxResults, resolved.serpApiEngine ?? "google")
-    case "searxng":
-      return searXngSearch(query, resolved.searXngUrl ?? "", maxResults, resolved.searXngCategories ?? ["general"])
-    case "ollama":
-      return ollamaSearch(query, resolved.apiKey ?? "", maxResults)
-    default:
-      throw new Error(`Unknown search provider: ${resolved.provider}`)
-  }
+	switch (resolved.provider) {
+		case "tavily":
+			return tavilySearch(query, resolved.apiKey, maxResults);
+		case "serpapi":
+			return serpApiSearch(
+				query,
+				resolved.apiKey,
+				maxResults,
+				resolved.serpApiEngine ?? "google",
+			);
+		case "searxng":
+			return searXngSearch(
+				query,
+				resolved.searXngUrl ?? "",
+				maxResults,
+				resolved.searXngCategories ?? ["general"],
+			);
+		case "ollama":
+			return ollamaSearch(query, resolved.apiKey ?? "", maxResults);
+		case "exa":
+			return exaSearch(query, resolved.apiKey, maxResults);
+		default:
+			throw new Error(`Unknown search provider: ${resolved.provider}`);
+	}
 }
 
 function searXngSearchUrl(instanceUrl: string): URL {
-  const trimmed = instanceUrl.trim()
-  const withProtocol = /^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`
-  const url = new URL(withProtocol)
-  const path = url.pathname.replace(/\/+$/, "")
-  url.pathname = path.endsWith("/search") || path === "/search"
-    ? path
-    : `${path}/search`
-  url.search = ""
-  url.hash = ""
-  return url
+	const trimmed = instanceUrl.trim();
+	const withProtocol = /^https?:\/\//i.test(trimmed)
+		? trimmed
+		: `https://${trimmed}`;
+	const url = new URL(withProtocol);
+	const path = url.pathname.replace(/\/+$/, "");
+	url.pathname =
+		path.endsWith("/search") || path === "/search" ? path : `${path}/search`;
+	url.search = "";
+	url.hash = "";
+	return url;
 }
 
 async function searXngSearch(
-  query: string,
-  instanceUrl: string,
-  maxResults: number,
-  categories: SearXngCategory[],
+	query: string,
+	instanceUrl: string,
+	maxResults: number,
+	categories: SearXngCategory[],
 ): Promise<WebSearchResult[]> {
-  let endpoint: URL
-  try {
-    endpoint = searXngSearchUrl(instanceUrl)
-  } catch {
-    throw new Error("Invalid SearXNG instance URL. Use a valid http(s) URL, for example https://search.example.com.")
-  }
+	let endpoint: URL;
+	try {
+		endpoint = searXngSearchUrl(instanceUrl);
+	} catch {
+		throw new Error(
+			"Invalid SearXNG instance URL. Use a valid http(s) URL, for example https://search.example.com.",
+		);
+	}
 
-  endpoint.searchParams.set("q", query)
-  endpoint.searchParams.set("format", "json")
-  endpoint.searchParams.set("categories", (categories.length > 0 ? categories : ["general"]).join(","))
+	endpoint.searchParams.set("q", query);
+	endpoint.searchParams.set("format", "json");
+	endpoint.searchParams.set(
+		"categories",
+		(categories.length > 0 ? categories : ["general"]).join(","),
+	);
 
-  const httpFetch = await getHttpFetch()
-  let response: Response
-  try {
-    response = await httpFetch(endpoint.toString(), {
-      method: "GET",
-      headers: { Accept: "application/json" },
-    })
-  } catch (err) {
-    if (isFetchNetworkError(err)) {
-      throw new Error(
-        "Network error reaching the SearXNG instance. Check the instance URL and whether JSON search is enabled.",
-      )
-    }
-    throw err
-  }
+	const httpFetch = await getHttpFetch();
+	let response: Response;
+	try {
+		response = await httpFetch(endpoint.toString(), {
+			method: "GET",
+			headers: { Accept: "application/json" },
+		});
+	} catch (err) {
+		if (isFetchNetworkError(err)) {
+			throw new Error(
+				"Network error reaching the SearXNG instance. Check the instance URL and whether JSON search is enabled.",
+			);
+		}
+		throw err;
+	}
 
-  if (!response.ok) {
-    const errorText = await response.text().catch(() => "Unknown error")
-    throw new Error(`SearXNG search failed (${response.status}): ${errorText}`)
-  }
+	if (!response.ok) {
+		const errorText = await response.text().catch(() => "Unknown error");
+		throw new Error(`SearXNG search failed (${response.status}): ${errorText}`);
+	}
 
-  const data = await response.json()
-  return normalizeSearXngResults(data, maxResults)
+	const data = await response.json();
+	return normalizeSearXngResults(data, maxResults);
 }
 
-function normalizeSearXngResults(data: { results?: unknown[] }, maxResults: number): WebSearchResult[] {
-  return (data.results ?? [])
-    .slice(0, maxResults)
-    .map((item) => normalizeSearXngResult(item))
-    .filter((item) => item.url.length > 0)
+function normalizeSearXngResults(
+	data: { results?: unknown[] },
+	maxResults: number,
+): WebSearchResult[] {
+	return (data.results ?? [])
+		.slice(0, maxResults)
+		.map((item) => normalizeSearXngResult(item))
+		.filter((item) => item.url.length > 0);
 }
 
 function normalizeSearXngResult(item: unknown): WebSearchResult {
-  const r = item as {
-    title?: string
-    url?: string
-    content?: string
-    engine?: string
-    category?: string
-  }
-  const url = r.url ?? ""
-  return {
-    title: r.title ?? "Untitled",
-    url,
-    snippet: r.content ?? "",
-    source: hostnameFromUrl(url) || r.engine || r.category || "",
-  }
+	const r = item as {
+		title?: string;
+		url?: string;
+		content?: string;
+		engine?: string;
+		category?: string;
+	};
+	const url = r.url ?? "";
+	return {
+		title: r.title ?? "Untitled",
+		url,
+		snippet: r.content ?? "",
+		source: hostnameFromUrl(url) || r.engine || r.category || "",
+	};
 }
 
 function hostnameFromUrl(url: string): string {
-  try {
-    return new URL(url).hostname.replace("www.", "")
-  } catch {
-    return ""
-  }
+	try {
+		return new URL(url).hostname.replace("www.", "");
+	} catch {
+		return "";
+	}
 }
 
 async function tavilySearch(
-  query: string,
-  apiKey: string,
-  maxResults: number,
+	query: string,
+	apiKey: string,
+	maxResults: number,
 ): Promise<WebSearchResult[]> {
-  // Route through the Tauri HTTP plugin so future non-Tavily search
-  // providers (Serper, Exa, Brave, Google CSE, ...) with less friendly
-  // CORS don't each need their own workaround. See tauri-fetch.ts.
-  const httpFetch = await getHttpFetch()
-  let response: Response
-  try {
-    response = await httpFetch("https://api.tavily.com/search", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        api_key: apiKey,
-        query,
-        max_results: maxResults,
-        search_depth: "advanced",
-        include_answer: false,
-      }),
-    })
-  } catch (err) {
-    if (isFetchNetworkError(err)) {
-      throw new Error(
-        "Network error reaching api.tavily.com. Check your connectivity and whether the Tavily API key is still valid.",
-      )
-    }
-    throw err
-  }
+	// Route through the Tauri HTTP plugin so future non-Tavily search
+	// providers (Serper, Exa, Brave, Google CSE, ...) with less friendly
+	// CORS don't each need their own workaround. See tauri-fetch.ts.
+	const httpFetch = await getHttpFetch();
+	let response: Response;
+	try {
+		response = await httpFetch("https://api.tavily.com/search", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				api_key: apiKey,
+				query,
+				max_results: maxResults,
+				search_depth: "advanced",
+				include_answer: false,
+			}),
+		});
+	} catch (err) {
+		if (isFetchNetworkError(err)) {
+			throw new Error(
+				"Network error reaching api.tavily.com. Check your connectivity and whether the Tavily API key is still valid.",
+			);
+		}
+		throw err;
+	}
 
-  if (!response.ok) {
-    const errorText = await response.text().catch(() => "Unknown error")
-    throw new Error(`Tavily search failed (${response.status}): ${errorText}`)
-  }
+	if (!response.ok) {
+		const errorText = await response.text().catch(() => "Unknown error");
+		throw new Error(`Tavily search failed (${response.status}): ${errorText}`);
+	}
 
-  const data = await response.json()
+	const data = await response.json();
 
-  return (data.results ?? []).map((r: { title: string; url: string; content: string }) => ({
-    title: r.title ?? "Untitled",
-    url: r.url ?? "",
-    snippet: r.content ?? "",
-    source: hostnameFromUrl(r.url ?? ""),
-  }))
+	return (data.results ?? []).map(
+		(r: { title: string; url: string; content: string }) => ({
+			title: r.title ?? "Untitled",
+			url: r.url ?? "",
+			snippet: r.content ?? "",
+			source: hostnameFromUrl(r.url ?? ""),
+		}),
+	);
 }
 
 async function serpApiSearch(
-  query: string,
-  apiKey: string,
-  maxResults: number,
-  engine: SerpApiEngine,
+	query: string,
+	apiKey: string,
+	maxResults: number,
+	engine: SerpApiEngine,
 ): Promise<WebSearchResult[]> {
-  const params = new URLSearchParams({
-    engine,
-    q: query,
-    api_key: apiKey,
-    num: String(maxResults),
-  })
+	const params = new URLSearchParams({
+		engine,
+		q: query,
+		api_key: apiKey,
+		num: String(maxResults),
+	});
 
-  const httpFetch = await getHttpFetch()
-  let response: Response
-  try {
-    response = await httpFetch(`https://serpapi.com/search?${params.toString()}`, {
-      method: "GET",
-      headers: { Accept: "application/json" },
-    })
-  } catch (err) {
-    if (isFetchNetworkError(err)) {
-      throw new Error(
-        "Network error reaching serpapi.com. Check your connectivity and whether the SerpApi API key is still valid.",
-      )
-    }
-    throw err
-  }
+	const httpFetch = await getHttpFetch();
+	let response: Response;
+	try {
+		response = await httpFetch(
+			`https://serpapi.com/search?${params.toString()}`,
+			{
+				method: "GET",
+				headers: { Accept: "application/json" },
+			},
+		);
+	} catch (err) {
+		if (isFetchNetworkError(err)) {
+			throw new Error(
+				"Network error reaching serpapi.com. Check your connectivity and whether the SerpApi API key is still valid.",
+			);
+		}
+		throw err;
+	}
 
-  if (!response.ok) {
-    const errorText = await response.text().catch(() => "Unknown error")
-    throw new Error(`SerpApi search failed (${response.status}): ${errorText}`)
-  }
+	if (!response.ok) {
+		const errorText = await response.text().catch(() => "Unknown error");
+		throw new Error(`SerpApi search failed (${response.status}): ${errorText}`);
+	}
 
-  const data = await response.json()
-  if (typeof data.error === "string" && data.error.trim()) {
-    throw new Error(`SerpApi search failed: ${data.error}`)
-  }
+	const data = await response.json();
+	if (typeof data.error === "string" && data.error.trim()) {
+		throw new Error(`SerpApi search failed: ${data.error}`);
+	}
 
-  return normalizeSerpApiResults(data, maxResults)
+	return normalizeSerpApiResults(data, maxResults);
 }
 
-function normalizeSerpApiResults(data: {
-  organic_results?: unknown[]
-  news_results?: unknown[]
-  images_results?: unknown[]
-  video_results?: unknown[]
-  videos_results?: unknown[]
-  shopping_results?: unknown[]
-}, maxResults: number): WebSearchResult[] {
-  const rawResults =
-    data.organic_results ??
-    data.news_results ??
-    data.images_results ??
-    data.video_results ??
-    data.videos_results ??
-    data.shopping_results ??
-    []
+function normalizeSerpApiResults(
+	data: {
+		organic_results?: unknown[];
+		news_results?: unknown[];
+		images_results?: unknown[];
+		video_results?: unknown[];
+		videos_results?: unknown[];
+		shopping_results?: unknown[];
+	},
+	maxResults: number,
+): WebSearchResult[] {
+	const rawResults =
+		data.organic_results ??
+		data.news_results ??
+		data.images_results ??
+		data.video_results ??
+		data.videos_results ??
+		data.shopping_results ??
+		[];
 
-  return rawResults
-    .slice(0, maxResults)
-    .map((item) => normalizeSerpApiResult(item))
+	return rawResults
+		.slice(0, maxResults)
+		.map((item) => normalizeSerpApiResult(item));
 }
 
 function normalizeSerpApiResult(item: unknown): WebSearchResult {
-  const r = item as {
-    title?: string
-    link?: string
-    url?: string
-    source?: string
-    snippet?: string
-    summary?: string
-    description?: string
-    thumbnail?: string
-    original?: string
-    displayed_link?: string
-  }
-  const url = r.link ?? r.url ?? r.original ?? r.thumbnail ?? ""
-  return {
-    title: r.title ?? "Untitled",
-    url,
-    snippet: r.snippet ?? r.summary ?? r.description ?? "",
-    source: hostnameFromUrl(url) || r.source || r.displayed_link || "",
-  }
+	const r = item as {
+		title?: string;
+		link?: string;
+		url?: string;
+		source?: string;
+		snippet?: string;
+		summary?: string;
+		description?: string;
+		thumbnail?: string;
+		original?: string;
+		displayed_link?: string;
+	};
+	const url = r.link ?? r.url ?? r.original ?? r.thumbnail ?? "";
+	return {
+		title: r.title ?? "Untitled",
+		url,
+		snippet: r.snippet ?? r.summary ?? r.description ?? "",
+		source: hostnameFromUrl(url) || r.source || r.displayed_link || "",
+	};
 }
 
 interface OllamaSearchResponse {
-  results?: Array<{
-    title?: string
-    url?: string
-    content?: string
-  }>
-  error?: string
+	results?: Array<{
+		title?: string;
+		url?: string;
+		content?: string;
+	}>;
+	error?: string;
 }
 
 async function ollamaSearch(
-  query: string,
-  apiKey: string,
-  maxResults: number,
+	query: string,
+	apiKey: string,
+	maxResults: number,
 ): Promise<WebSearchResult[]> {
-  const trimmedApiKey = apiKey.trim()
-  if (!trimmedApiKey) {
-    throw new Error("Ollama Web Search API requires an Ollama API key. Add one in Settings.")
-  }
+	const trimmedApiKey = apiKey.trim();
+	if (!trimmedApiKey) {
+		throw new Error(
+			"Ollama Web Search API requires an Ollama API key. Add one in Settings.",
+		);
+	}
 
-  const headers: Record<string, string> = {
-    Accept: "application/json",
-    "Content-Type": "application/json",
-    Authorization: `Bearer ${trimmedApiKey}`,
-  }
+	const headers: Record<string, string> = {
+		Accept: "application/json",
+		"Content-Type": "application/json",
+		Authorization: `Bearer ${trimmedApiKey}`,
+	};
 
-  const httpFetch = await getHttpFetch()
-  let response: Response
-  try {
-    response = await httpFetch("https://ollama.com/api/web_search", {
-      method: "POST",
-      headers,
-      body: JSON.stringify({
-        query,
-        max_results: maxResults,
-      }),
-    })
-  } catch (err) {
-    if (isFetchNetworkError(err)) {
-      throw new Error(
-        "Network error reaching the Ollama Web Search API. Check your connectivity and whether the Ollama API key is still valid.",
-      )
-    }
-    throw err
-  }
+	const httpFetch = await getHttpFetch();
+	let response: Response;
+	try {
+		response = await httpFetch("https://ollama.com/api/web_search", {
+			method: "POST",
+			headers,
+			body: JSON.stringify({
+				query,
+				max_results: maxResults,
+			}),
+		});
+	} catch (err) {
+		if (isFetchNetworkError(err)) {
+			throw new Error(
+				"Network error reaching the Ollama Web Search API. Check your connectivity and whether the Ollama API key is still valid.",
+			);
+		}
+		throw err;
+	}
 
-  if (!response.ok) {
-    if (response.status === 401) {
-      throw new Error(
-        "Ollama Web Search API authentication failed. Check your Ollama API key.",
-      )
-    }
-    const errorText = await response.text().catch(() => "Unknown error")
-    throw new Error(`Ollama web search failed (${response.status}): ${errorText}`)
-  }
+	if (!response.ok) {
+		if (response.status === 401) {
+			throw new Error(
+				"Ollama Web Search API authentication failed. Check your Ollama API key.",
+			);
+		}
+		const errorText = await response.text().catch(() => "Unknown error");
+		throw new Error(
+			`Ollama web search failed (${response.status}): ${errorText}`,
+		);
+	}
 
-  const data = (await response.json()) as OllamaSearchResponse
+	const data = (await response.json()) as OllamaSearchResponse;
 
-  if (data.error) {
-    throw new Error(`Ollama web search error: ${data.error}`)
-  }
+	if (data.error) {
+		throw new Error(`Ollama web search error: ${data.error}`);
+	}
 
-  return (data.results ?? [])
-    .slice(0, maxResults)
-    .map((r) => {
-      const url = r.url ?? ""
-      return {
-        title: r.title ?? "Untitled",
-        url,
-        snippet: r.content ?? "",
-        source: hostnameFromUrl(url),
-      }
-    })
+	return (data.results ?? []).slice(0, maxResults).map((r) => {
+		const url = r.url ?? "";
+		return {
+			title: r.title ?? "Untitled",
+			url,
+			snippet: r.content ?? "",
+			source: hostnameFromUrl(url),
+		};
+	});
+}
+
+async function exaSearch(
+	query: string,
+	apiKey: string,
+	maxResults: number,
+): Promise<WebSearchResult[]> {
+	const httpFetch = await getHttpFetch();
+	let response: Response;
+	try {
+		response = await httpFetch("https://api.exa.ai/search", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				"x-api-key": apiKey,
+			},
+			body: JSON.stringify({
+				query,
+				type: "auto",
+				numResults: maxResults,
+				contents: { text: true },
+			}),
+		});
+	} catch (err) {
+		if (isFetchNetworkError(err)) {
+			throw new Error(
+				"Network error reaching api.exa.ai. Check your connectivity and whether the Exa API key is still valid.",
+			);
+		}
+		throw err;
+	}
+
+	if (!response.ok) {
+		if (response.status === 401) {
+			throw new Error(
+				"Exa API authentication failed. Check your Exa API key.",
+			);
+		}
+		const errorText = await response.text().catch(() => "Unknown error");
+		throw new Error(`Exa search failed (${response.status}): ${errorText}`);
+	}
+
+	const data = await response.json();
+
+	return (data.results ?? []).map(
+		(r: {
+			title?: string;
+			url?: string;
+			text?: string;
+			highlights?: string[];
+			summary?: string;
+		}) => {
+			const url = r.url ?? "";
+			const snippet = r.text || r.highlights?.[0] || r.summary || "";
+			return {
+				title: r.title ?? "Untitled",
+				url,
+				snippet,
+				source: hostnameFromUrl(url),
+			};
+		},
+	);
 }

--- a/src/stores/wiki-store.ts
+++ b/src/stores/wiki-store.ts
@@ -1,6 +1,6 @@
-import { create } from "zustand"
-import type { WikiProject, FileNode } from "@/types/wiki"
-import { DEFAULT_SOURCE_WATCH_CONFIG } from "@/lib/source-watch-config"
+import { create } from "zustand";
+import { DEFAULT_SOURCE_WATCH_CONFIG } from "@/lib/source-watch-config";
+import type { FileNode, WikiProject } from "@/types/wiki";
 
 /**
  * Wire protocol used when `provider === "custom"`. Other providers have a
@@ -8,95 +8,119 @@ import { DEFAULT_SOURCE_WATCH_CONFIG } from "@/lib/source-watch-config"
  * etc.), so this field is ignored for them. `undefined` defaults to
  * `chat_completions` for backward compatibility with pre-0.3.7 configs.
  */
-export type CustomApiMode = "chat_completions" | "anthropic_messages"
-export type AzureModelFamily = "auto" | "gpt5"
-export type ReasoningMode = "auto" | "off" | "low" | "medium" | "high" | "max" | "custom"
+export type CustomApiMode = "chat_completions" | "anthropic_messages";
+export type AzureModelFamily = "auto" | "gpt5";
+export type ReasoningMode =
+	| "auto"
+	| "off"
+	| "low"
+	| "medium"
+	| "high"
+	| "max"
+	| "custom";
 
 export interface ReasoningConfig {
-  mode: ReasoningMode
-  budgetTokens?: number
+	mode: ReasoningMode;
+	budgetTokens?: number;
 }
 
 interface LlmConfig {
-  provider: "openai" | "anthropic" | "google" | "azure" | "ollama" | "custom" | "minimax" | "claude-code" | "codex-cli"
-  apiKey: string
-  model: string
-  ollamaUrl: string
-  customEndpoint: string
-  azureApiVersion?: string
-  azureModelFamily?: AzureModelFamily
-  maxContextSize: number // max context window in characters
-  apiMode?: CustomApiMode
-  reasoning?: ReasoningConfig
+	provider:
+		| "openai"
+		| "anthropic"
+		| "google"
+		| "azure"
+		| "ollama"
+		| "custom"
+		| "minimax"
+		| "claude-code"
+		| "codex-cli";
+	apiKey: string;
+	model: string;
+	ollamaUrl: string;
+	customEndpoint: string;
+	azureApiVersion?: string;
+	azureModelFamily?: AzureModelFamily;
+	maxContextSize: number; // max context window in characters
+	apiMode?: CustomApiMode;
+	reasoning?: ReasoningConfig;
 }
 
-export type SearchProvider = "tavily" | "serpapi" | "searxng" | "ollama" | "none"
+export type SearchProvider =
+	| "tavily"
+	| "serpapi"
+	| "searxng"
+	| "ollama"
+	| "exa"
+	| "none";
 export type SerpApiEngine =
-  | "google"
-  | "google_news"
-  | "google_scholar"
-  | "google_patents"
-  | "bing"
-  | "duckduckgo"
-  | "google_images"
-  | "google_videos"
-  | "youtube"
-  | string
+	| "google"
+	| "google_news"
+	| "google_scholar"
+	| "google_patents"
+	| "bing"
+	| "duckduckgo"
+	| "google_images"
+	| "google_videos"
+	| "youtube"
+	| string;
 export type SearXngCategory =
-  | "general"
-  | "news"
-  | "science"
-  | "it"
-  | "images"
-  | "videos"
-  | "files"
-  | "map"
-  | "music"
-  | "social media"
-  | string
+	| "general"
+	| "news"
+	| "science"
+	| "it"
+	| "images"
+	| "videos"
+	| "files"
+	| "map"
+	| "music"
+	| "social media"
+	| string;
 
 export interface SearchProviderOverride {
-  apiKey?: string
-  serpApiEngine?: SerpApiEngine
-  searXngUrl?: string
-  searXngCategories?: SearXngCategory[]
-  ollamaUrl?: string
+	apiKey?: string;
+	serpApiEngine?: SerpApiEngine;
+	searXngUrl?: string;
+	searXngCategories?: SearXngCategory[];
+	ollamaUrl?: string;
 }
 
-export type SearchProviderConfigs = Partial<Record<Exclude<SearchProvider, "none">, SearchProviderOverride>>
+export type SearchProviderConfigs = Partial<
+	Record<Exclude<SearchProvider, "none">, SearchProviderOverride>
+>;
 
 interface SearchApiConfig {
-  provider: SearchProvider
-  apiKey: string
-  serpApiEngine?: SerpApiEngine
-  searXngUrl?: string
-  searXngCategories?: SearXngCategory[]
-  ollamaUrl?: string
-  providerConfigs?: SearchProviderConfigs
+	provider: SearchProvider;
+	apiKey: string;
+	serpApiEngine?: SerpApiEngine;
+	searXngUrl?: string;
+	searXngCategories?: SearXngCategory[];
+	ollamaUrl?: string;
+	providerConfigs?: SearchProviderConfigs;
 }
 
 interface EmbeddingConfig {
-  enabled: boolean
-  endpoint: string // e.g. "http://127.0.0.1:1234/v1/embeddings"
-  apiKey: string
-  model: string // e.g. "text-embedding-qwen3-embedding-0.6b"
-  /** Optional Gemini native `output_dimensionality` value. Ignored by OpenAI-compatible endpoints. */
-  outputDimensionality?: number
-  /**
-   * Chunking knobs (Phase 1 RAG). Undefined values fall back to the
-   * chunker's built-in defaults in `src/lib/text-chunker.ts`:
-   *   targetChars   1000
-   *   maxChars      1500
-   *   minChars      200
-   *   overlapChars  200
-   *
-   * Users on small-context endpoints (e.g. llama.cpp with n_ctx=512,
-   * Ollama `mxbai-embed-large`) should lower `maxChunkChars` to avoid
-   * per-request rejections; fetchEmbedding also auto-halves on
-   * "too long" server errors as a second line of defence.
-   */
-  maxChunkChars?: number
-  overlapChunkChars?: number
+	enabled: boolean;
+	endpoint: string; // e.g. "http://127.0.0.1:1234/v1/embeddings"
+	apiKey: string;
+	model: string; // e.g. "text-embedding-qwen3-embedding-0.6b"
+	/** Optional Gemini native `output_dimensionality` value. Ignored by OpenAI-compatible endpoints. */
+	outputDimensionality?: number;
+	/**
+	 * Chunking knobs (Phase 1 RAG). Undefined values fall back to the
+	 * chunker's built-in defaults in `src/lib/text-chunker.ts`:
+	 *   targetChars   1000
+	 *   maxChars      1500
+	 *   minChars      200
+	 *   overlapChars  200
+	 *
+	 * Users on small-context endpoints (e.g. llama.cpp with n_ctx=512,
+	 * Ollama `mxbai-embed-large`) should lower `maxChunkChars` to avoid
+	 * per-request rejections; fetchEmbedding also auto-halves on
+	 * "too long" server errors as a second line of defence.
+	 */
+	maxChunkChars?: number;
+	overlapChunkChars?: number;
 }
 
 /**
@@ -135,16 +159,16 @@ interface EmbeddingConfig {
  * apply on app restart only.
  */
 interface ProxyConfig {
-  enabled: boolean
-  url: string
-  bypassLocal: boolean
+	enabled: boolean;
+	url: string;
+	bypassLocal: boolean;
 }
 
 interface ScheduledImportConfig {
-  enabled: boolean
-  path: string // 监控目录的相对路径（相对于项目根目录），空字符串表示使用默认的 "raw"
-  interval: number // 扫描间隔（分钟）
-  lastScan: number | null // 上次扫描时间戳
+	enabled: boolean;
+	path: string; // 监控目录的相对路径（相对于项目根目录），空字符串表示使用默认的 "raw"
+	interval: number; // 扫描间隔（分钟）
+	lastScan: number | null; // 上次扫描时间戳
 }
 
 /**
@@ -162,36 +186,36 @@ interface ScheduledImportConfig {
  *     `LLM_WIKI_API_TOKEN` overrides this field at the backend.
  */
 interface ApiConfig {
-  enabled: boolean
-  allowUnauthenticated: boolean
-  token: string
+	enabled: boolean;
+	allowUnauthenticated: boolean;
+	token: string;
 }
 
 interface SourceWatchConfig {
-  enabled: boolean
-  autoIngest: boolean
-  includeExtensions: string[]
-  excludeExtensions: string[]
-  excludeDirs: string[]
-  excludeGlobs: string[]
-  maxFileSizeMb: number
+	enabled: boolean;
+	autoIngest: boolean;
+	includeExtensions: string[];
+	excludeExtensions: string[];
+	excludeDirs: string[];
+	excludeGlobs: string[];
+	maxFileSizeMb: number;
 }
 
 interface MultimodalConfig {
-  enabled: boolean
-  /** Reuse `llmConfig` for caption calls. When true, the fields
-   *  below are ignored. */
-  useMainLlm: boolean
-  provider: LlmConfig["provider"]
-  apiKey: string
-  model: string
-  ollamaUrl: string
-  customEndpoint: string
-  azureApiVersion?: string
-  azureModelFamily?: AzureModelFamily
-  apiMode?: CustomApiMode
-  /** Max parallel caption requests during ingest. >=1. */
-  concurrency: number
+	enabled: boolean;
+	/** Reuse `llmConfig` for caption calls. When true, the fields
+	 *  below are ignored. */
+	useMainLlm: boolean;
+	provider: LlmConfig["provider"];
+	apiKey: string;
+	model: string;
+	ollamaUrl: string;
+	customEndpoint: string;
+	azureApiVersion?: string;
+	azureModelFamily?: AzureModelFamily;
+	apiMode?: CustomApiMode;
+	/** Max parallel caption requests during ingest. >=1. */
+	concurrency: number;
 }
 
 /**
@@ -200,29 +224,29 @@ interface MultimodalConfig {
  * Otherwise = force all LLM output to use the specified language.
  */
 type OutputLanguage =
-  | "auto"
-  | "English"
-  | "Chinese"
-  | "Traditional Chinese"
-  | "Japanese"
-  | "Korean"
-  | "Vietnamese"
-  | "French"
-  | "German"
-  | "Spanish"
-  | "Portuguese"
-  | "Italian"
-  | "Russian"
-  | "Arabic"
-  | "Persian"
-  | "Hindi"
-  | "Turkish"
-  | "Dutch"
-  | "Polish"
-  | "Swedish"
-  | "Indonesian"
-  | "Thai"
-  | "Ukrainian"
+	| "auto"
+	| "English"
+	| "Chinese"
+	| "Traditional Chinese"
+	| "Japanese"
+	| "Korean"
+	| "Vietnamese"
+	| "French"
+	| "German"
+	| "Spanish"
+	| "Portuguese"
+	| "Italian"
+	| "Russian"
+	| "Arabic"
+	| "Persian"
+	| "Hindi"
+	| "Turkish"
+	| "Dutch"
+	| "Polish"
+	| "Swedish"
+	| "Indonesian"
+	| "Thai"
+	| "Ukrainian";
 
 /**
  * Per-preset saved fields. Each entry survives turning the preset off
@@ -230,180 +254,201 @@ type OutputLanguage =
  * briefly switch to a different provider.
  */
 export interface ProviderOverride {
-  apiKey?: string
-  model?: string
-  baseUrl?: string           // customEndpoint for custom presets, ollamaUrl for ollama
-  azureApiVersion?: string
-  azureModelFamily?: AzureModelFamily
-  apiMode?: CustomApiMode
-  maxContextSize?: number
-  reasoning?: ReasoningConfig
+	apiKey?: string;
+	model?: string;
+	baseUrl?: string; // customEndpoint for custom presets, ollamaUrl for ollama
+	azureApiVersion?: string;
+	azureModelFamily?: AzureModelFamily;
+	apiMode?: CustomApiMode;
+	maxContextSize?: number;
+	reasoning?: ReasoningConfig;
 }
 
-export type ProviderConfigs = Record<string, ProviderOverride>
+export type ProviderConfigs = Record<string, ProviderOverride>;
 
 interface WikiState {
-  project: WikiProject | null
-  fileTree: FileNode[]
-  selectedFile: string | null
-  fileContent: string
-  /**
-   * One-shot scroll target for the markdown preview. When the user
-   * clicks an image in search results and chooses "jump to source",
-   * we set this to the image URL alongside `selectedFile`. The
-   * markdown preview consumes it on its next render — finds the
-   * `<img data-mdsrc="..."/>` whose attribute matches and scrolls
-   * it into view, then clears this back to null so a stale target
-   * doesn't fire on the NEXT page open.
-   *
-   * Match by raw URL (the literal `src` from the markdown) rather
-   * than the resolved `convertFileSrc` URL — same image referenced
-   * across two pages with different URL conventions (one absolute,
-   * one wiki-relative) still works.
-   */
-  pendingScrollImageSrc: string | null
-  chatExpanded: boolean
-  activeView: "wiki" | "sources" | "search" | "graph" | "lint" | "review" | "settings"
-  llmConfig: LlmConfig
-  /** Per-provider-preset stored overrides (API key, model, endpoint, …). */
-  providerConfigs: ProviderConfigs
-  /** Which preset is currently active. `null` = no LLM configured. */
-  activePresetId: string | null
-  searchApiConfig: SearchApiConfig
-  embeddingConfig: EmbeddingConfig
-  multimodalConfig: MultimodalConfig
-  outputLanguage: OutputLanguage
-  proxyConfig: ProxyConfig
-  scheduledImportConfig: ScheduledImportConfig
-  sourceWatchConfig: SourceWatchConfig
-  apiConfig: ApiConfig
-  dataVersion: number
+	project: WikiProject | null;
+	fileTree: FileNode[];
+	selectedFile: string | null;
+	fileContent: string;
+	/**
+	 * One-shot scroll target for the markdown preview. When the user
+	 * clicks an image in search results and chooses "jump to source",
+	 * we set this to the image URL alongside `selectedFile`. The
+	 * markdown preview consumes it on its next render — finds the
+	 * `<img data-mdsrc="..."/>` whose attribute matches and scrolls
+	 * it into view, then clears this back to null so a stale target
+	 * doesn't fire on the NEXT page open.
+	 *
+	 * Match by raw URL (the literal `src` from the markdown) rather
+	 * than the resolved `convertFileSrc` URL — same image referenced
+	 * across two pages with different URL conventions (one absolute,
+	 * one wiki-relative) still works.
+	 */
+	pendingScrollImageSrc: string | null;
+	chatExpanded: boolean;
+	activeView:
+		| "wiki"
+		| "sources"
+		| "search"
+		| "graph"
+		| "lint"
+		| "review"
+		| "settings";
+	llmConfig: LlmConfig;
+	/** Per-provider-preset stored overrides (API key, model, endpoint, …). */
+	providerConfigs: ProviderConfigs;
+	/** Which preset is currently active. `null` = no LLM configured. */
+	activePresetId: string | null;
+	searchApiConfig: SearchApiConfig;
+	embeddingConfig: EmbeddingConfig;
+	multimodalConfig: MultimodalConfig;
+	outputLanguage: OutputLanguage;
+	proxyConfig: ProxyConfig;
+	scheduledImportConfig: ScheduledImportConfig;
+	sourceWatchConfig: SourceWatchConfig;
+	apiConfig: ApiConfig;
+	dataVersion: number;
 
-  setProject: (project: WikiProject | null) => void
-  setFileTree: (tree: FileNode[]) => void
-  setSelectedFile: (path: string | null) => void
-  setFileContent: (content: string) => void
-  setPendingScrollImageSrc: (src: string | null) => void
-  setChatExpanded: (expanded: boolean) => void
-  setActiveView: (view: WikiState["activeView"]) => void
-  setLlmConfig: (config: LlmConfig) => void
-  setProviderConfigs: (configs: ProviderConfigs) => void
-  setActivePresetId: (id: string | null) => void
-  setSearchApiConfig: (config: SearchApiConfig) => void
-  setEmbeddingConfig: (config: EmbeddingConfig) => void
-  setMultimodalConfig: (config: MultimodalConfig) => void
-  setOutputLanguage: (lang: OutputLanguage) => void
-  setProxyConfig: (config: ProxyConfig) => void
-  setScheduledImportConfig: (config: ScheduledImportConfig) => void
-  setSourceWatchConfig: (config: SourceWatchConfig) => void
-  setApiConfig: (config: ApiConfig) => void
-  bumpDataVersion: () => void
+	setProject: (project: WikiProject | null) => void;
+	setFileTree: (tree: FileNode[]) => void;
+	setSelectedFile: (path: string | null) => void;
+	setFileContent: (content: string) => void;
+	setPendingScrollImageSrc: (src: string | null) => void;
+	setChatExpanded: (expanded: boolean) => void;
+	setActiveView: (view: WikiState["activeView"]) => void;
+	setLlmConfig: (config: LlmConfig) => void;
+	setProviderConfigs: (configs: ProviderConfigs) => void;
+	setActivePresetId: (id: string | null) => void;
+	setSearchApiConfig: (config: SearchApiConfig) => void;
+	setEmbeddingConfig: (config: EmbeddingConfig) => void;
+	setMultimodalConfig: (config: MultimodalConfig) => void;
+	setOutputLanguage: (lang: OutputLanguage) => void;
+	setProxyConfig: (config: ProxyConfig) => void;
+	setScheduledImportConfig: (config: ScheduledImportConfig) => void;
+	setSourceWatchConfig: (config: SourceWatchConfig) => void;
+	setApiConfig: (config: ApiConfig) => void;
+	bumpDataVersion: () => void;
 }
 
 export const useWikiStore = create<WikiState>((set) => ({
-  project: null,
-  fileTree: [],
-  selectedFile: null,
-  fileContent: "",
-  pendingScrollImageSrc: null,
-  chatExpanded: false,
-  activeView: "wiki",
-  llmConfig: {
-    provider: "openai",
-    apiKey: "",
-    maxContextSize: 204800,
-    model: "",
-    ollamaUrl: "http://localhost:11434",
-    customEndpoint: "",
-    azureApiVersion: "2024-10-21",
-    reasoning: { mode: "auto" },
-  },
-  providerConfigs: {},
-  activePresetId: null,
+	project: null,
+	fileTree: [],
+	selectedFile: null,
+	fileContent: "",
+	pendingScrollImageSrc: null,
+	chatExpanded: false,
+	activeView: "wiki",
+	llmConfig: {
+		provider: "openai",
+		apiKey: "",
+		maxContextSize: 204800,
+		model: "",
+		ollamaUrl: "http://localhost:11434",
+		customEndpoint: "",
+		azureApiVersion: "2024-10-21",
+		reasoning: { mode: "auto" },
+	},
+	providerConfigs: {},
+	activePresetId: null,
 
-  dataVersion: 0,
+	dataVersion: 0,
 
-  setProject: (project) => set({ project }),
-  setFileTree: (fileTree) => set({ fileTree }),
-  setSelectedFile: (selectedFile) => set({ selectedFile }),
-  setFileContent: (fileContent) => set({ fileContent }),
-  setPendingScrollImageSrc: (pendingScrollImageSrc) => set({ pendingScrollImageSrc }),
-  setChatExpanded: (chatExpanded) => set({ chatExpanded }),
-  setActiveView: (activeView) => set({ activeView }),
-  searchApiConfig: {
-    provider: "none",
-    apiKey: "",
-    serpApiEngine: "google",
-    searXngUrl: "",
-    searXngCategories: ["general"],
-    providerConfigs: {},
-  },
+	setProject: (project) => set({ project }),
+	setFileTree: (fileTree) => set({ fileTree }),
+	setSelectedFile: (selectedFile) => set({ selectedFile }),
+	setFileContent: (fileContent) => set({ fileContent }),
+	setPendingScrollImageSrc: (pendingScrollImageSrc) =>
+		set({ pendingScrollImageSrc }),
+	setChatExpanded: (chatExpanded) => set({ chatExpanded }),
+	setActiveView: (activeView) => set({ activeView }),
+	searchApiConfig: {
+		provider: "none",
+		apiKey: "",
+		serpApiEngine: "google",
+		searXngUrl: "",
+		searXngCategories: ["general"],
+		providerConfigs: {},
+	},
 
-  embeddingConfig: {
-    enabled: false,
-    endpoint: "",
-    apiKey: "",
-    model: "",
-  },
+	embeddingConfig: {
+		enabled: false,
+		endpoint: "",
+		apiKey: "",
+		model: "",
+	},
 
-  multimodalConfig: {
-    // Off by default — captioning is a non-trivial token spend
-    // (one VLM call per extracted image), and silently turning it
-    // on for every user the first time they import a PDF would be
-    // a budget surprise. Users who want it flip the toggle in
-    // Settings → Image captioning.
-    enabled: false,
-    useMainLlm: true,
-    provider: "custom",
-    apiKey: "",
-    model: "",
-    ollamaUrl: "http://localhost:11434",
-    customEndpoint: "",
-    azureApiVersion: "2024-10-21",
-    apiMode: "chat_completions",
-    concurrency: 4,
-  },
+	multimodalConfig: {
+		// Off by default — captioning is a non-trivial token spend
+		// (one VLM call per extracted image), and silently turning it
+		// on for every user the first time they import a PDF would be
+		// a budget surprise. Users who want it flip the toggle in
+		// Settings → Image captioning.
+		enabled: false,
+		useMainLlm: true,
+		provider: "custom",
+		apiKey: "",
+		model: "",
+		ollamaUrl: "http://localhost:11434",
+		customEndpoint: "",
+		azureApiVersion: "2024-10-21",
+		apiMode: "chat_completions",
+		concurrency: 4,
+	},
 
-  outputLanguage: "auto",
+	outputLanguage: "auto",
 
-  proxyConfig: {
-    enabled: false,
-    url: "",
-    bypassLocal: true,
-  },
+	proxyConfig: {
+		enabled: false,
+		url: "",
+		bypassLocal: true,
+	},
 
-  scheduledImportConfig: {
-    enabled: false,
-    path: "",
-    interval: 60,
-    lastScan: null,
-  },
+	scheduledImportConfig: {
+		enabled: false,
+		path: "",
+		interval: 60,
+		lastScan: null,
+	},
 
-  sourceWatchConfig: DEFAULT_SOURCE_WATCH_CONFIG,
+	sourceWatchConfig: DEFAULT_SOURCE_WATCH_CONFIG,
 
-  // Default `enabled: true` preserves the pre-toggle behavior: anyone
-  // who already had `LLM_WIKI_API_TOKEN` set or `apiConfig.token`
-  // hand-edited keeps their working API. New users land in
-  // "enabled + no token = 401 on every endpoint" — fail-closed by
-  // virtue of the token being empty.
-  apiConfig: {
-    enabled: true,
-    allowUnauthenticated: false,
-    token: "",
-  },
+	// Default `enabled: true` preserves the pre-toggle behavior: anyone
+	// who already had `LLM_WIKI_API_TOKEN` set or `apiConfig.token`
+	// hand-edited keeps their working API. New users land in
+	// "enabled + no token = 401 on every endpoint" — fail-closed by
+	// virtue of the token being empty.
+	apiConfig: {
+		enabled: true,
+		allowUnauthenticated: false,
+		token: "",
+	},
 
-  setLlmConfig: (llmConfig) => set({ llmConfig }),
-  setProviderConfigs: (providerConfigs) => set({ providerConfigs }),
-  setActivePresetId: (activePresetId) => set({ activePresetId }),
-  setSearchApiConfig: (searchApiConfig) => set({ searchApiConfig }),
-  setEmbeddingConfig: (embeddingConfig) => set({ embeddingConfig }),
-  setMultimodalConfig: (multimodalConfig) => set({ multimodalConfig }),
-  setOutputLanguage: (outputLanguage) => set({ outputLanguage }),
-  setProxyConfig: (proxyConfig) => set({ proxyConfig }),
-  setScheduledImportConfig: (scheduledImportConfig) => set({ scheduledImportConfig }),
-  setSourceWatchConfig: (sourceWatchConfig) => set({ sourceWatchConfig }),
-  setApiConfig: (apiConfig) => set({ apiConfig }),
-  bumpDataVersion: () => set((state) => ({ dataVersion: state.dataVersion + 1 })),
-}))
+	setLlmConfig: (llmConfig) => set({ llmConfig }),
+	setProviderConfigs: (providerConfigs) => set({ providerConfigs }),
+	setActivePresetId: (activePresetId) => set({ activePresetId }),
+	setSearchApiConfig: (searchApiConfig) => set({ searchApiConfig }),
+	setEmbeddingConfig: (embeddingConfig) => set({ embeddingConfig }),
+	setMultimodalConfig: (multimodalConfig) => set({ multimodalConfig }),
+	setOutputLanguage: (outputLanguage) => set({ outputLanguage }),
+	setProxyConfig: (proxyConfig) => set({ proxyConfig }),
+	setScheduledImportConfig: (scheduledImportConfig) =>
+		set({ scheduledImportConfig }),
+	setSourceWatchConfig: (sourceWatchConfig) => set({ sourceWatchConfig }),
+	setApiConfig: (apiConfig) => set({ apiConfig }),
+	bumpDataVersion: () =>
+		set((state) => ({ dataVersion: state.dataVersion + 1 })),
+}));
 
-export type { WikiState, LlmConfig, SearchApiConfig, EmbeddingConfig, MultimodalConfig, OutputLanguage, ProxyConfig, ScheduledImportConfig, SourceWatchConfig, ApiConfig }
+export type {
+	ApiConfig,
+	EmbeddingConfig,
+	LlmConfig,
+	MultimodalConfig,
+	OutputLanguage,
+	ProxyConfig,
+	ScheduledImportConfig,
+	SearchApiConfig,
+	SourceWatchConfig,
+	WikiState,
+};


### PR DESCRIPTION
## Summary

- Add [Exa](https://exa.ai) as a web search provider option for Deep Research
- Exa returns full page content via its `contents.text` API, giving the LLM synthesis stage richer material than short snippets from other providers

## Changes

- **`src/stores/wiki-store.ts`** — Add `"exa"` to `SearchProvider` type union
- **`src/lib/web-search.ts`** — Implement `exaSearch()` function using `x-api-key` header auth, `contents: { text: true }` request; add switch case and API key validation
- **`src/components/settings/sections/web-search-section.tsx`** — Add Exa entry to `SEARCH_PROVIDERS` array (API key only, no additional config needed)
- **`src/lib/web-search.test.ts`** — Update validation error message assertion

## Technical Details

- **Auth**: `x-api-key` header (not in request body, not Bearer token)
- **Endpoint**: `POST https://api.exa.ai/search`
- **Response mapping**: `r.text || r.highlights?.[0] || r.summary || ""` → snippet fallback chain
- **Error handling**: Dedicated 401 auth error, network error via `isFetchNetworkError()`, generic HTTP error with status code

## Test plan

- [x] TypeScript compilation passes with 0 errors
- [x] `web-search.test.ts` — 12/12 tests pass
- [ ] Manual: Settings → Web Search → Exa appears as provider option
- [ ] Manual: Configure Exa API key → run Deep Research → verify results with full page content
- [ ] Verify no regressions in existing Tavily/SerpApi/SearXNG/Ollama providers

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)