### PR TITLE
Fix sources view scroll overflow

### DIFF
--- a/src/components/sources/sources-view.tsx
+++ b/src/components/sources/sources-view.tsx
@@ -291,7 +291,7 @@ export function SourcesView() {
         </div>
       </div>
 
-      <ScrollArea className="flex-1">
+      <ScrollArea className="flex-1 overflow-y-auto">
         {refreshError && (
           <div className="mx-4 mt-3 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
             {t("sources.refreshFailed", {


### PR DESCRIPTION
## Summary
- Add `overflow-y-auto` to the `ScrollArea` in `SourcesView` so the list scrolls when its content exceeds the available height.

## Test plan
- [ ] Open the Sources panel with enough sources to overflow the viewport and confirm the list scrolls vertically.
- [ ] Confirm short lists still render without an unexpected scrollbar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)