### PR TITLE
Security: Hardcoded API Server Port and Localhost Binding

### DIFF
--- a/src/lib/api-server-constants.ts
+++ b/src/lib/api-server-constants.ts
@@ -1,3 +1,4 @@
-export const API_SERVER_PORT = 19828
-export const API_SERVER_BASE_URL = `http://127.0.0.1:${API_SERVER_PORT}`
+export const API_SERVER_PORT = parseInt(process.env.LLM_WIKI_API_PORT || '19828', 10)
+export const API_SERVER_HOST = process.env.LLM_WIKI_API_HOST || '127.0.0.1'
+export const API_SERVER_BASE_URL = `http://${API_SERVER_HOST}:${API_SERVER_PORT}`
 export const API_SERVER_HEALTH_URL = `${API_SERVER_BASE_URL}/api/v1/health`


### PR DESCRIPTION
## Problem

The API server constants define a fixed port (19828) and bind to 127.0.0.1. This creates a predictable attack surface if the API server is ever exposed beyond localhost. Additionally, hardcoded ports can lead to conflicts and there's no fallback or dynamic port allocation mechanism.

**Severity**: `medium`
**File**: `src/lib/api-server-constants.ts`

## Solution

Consider making the port configurable via environment variables or user settings, and implement port conflict detection with fallback to dynamic port allocation. Add binding to a Unix socket or named pipe for more secure local communication.

## Changes

- `src/lib/api-server-constants.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
