### PR TITLE
Security: Missing Content Security Policy in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: tauri://localhost; connect-src 'self' tauri://localhost http://127.0.0.1:*;" />
     <title>LLM Wiki</title>
   </head>
   <body>


### PR DESCRIPTION
## Problem

The index.html file lacks a Content-Security-Policy meta tag. Since this is a Tauri application with a webview, without a CSP, the application is more vulnerable to XSS attacks if any user-controlled content is rendered, or if there are injection points in the rendered markdown or other content.

**Severity**: `medium`
**File**: `index.html`

## Solution

Add a strict Content-Security-Policy meta tag appropriate for a Tauri application. For example: <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: tauri://localhost; connect-src 'self' tauri://localhost http://127.0.0.1:*;">

## Changes

- `index.html` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
