### PR TITLE
fix: match reader mode styling with editor mode

### DIFF
--- a/src/components/editor/wiki-reader.tsx
+++ b/src/components/editor/wiki-reader.tsx
@@ -12,6 +12,7 @@ import { detectLanguage } from "@/lib/detect-language"
 import { getHtmlLang, getTextDirection } from "@/lib/language-metadata"
 import { useWikiStore } from "@/stores/wiki-store"
 import { MermaidDiagram, unwrapMermaidPre } from "@/components/mermaid-diagram"
+import "@milkdown/theme-nord/style.css"
 
 interface WikiReaderProps {
   body: string
@@ -58,7 +59,7 @@ export function WikiReader({ body }: WikiReaderProps) {
 
   return (
     <div
-      className="prose prose-invert min-w-0 max-w-none"
+      className="milkdown-theme-nord min-w-0 max-w-none"
       dir={direction}
       lang={htmlLang}
       style={{ textAlign: "start" }}

--- a/src/components/editor/wiki-reader.tsx
+++ b/src/components/editor/wiki-reader.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react"
+import React, { useMemo } from "react"
 import ReactMarkdown from "react-markdown"
 import remarkGfm from "remark-gfm"
 import remarkMath from "remark-math"
@@ -135,6 +135,14 @@ export function WikiReader({ body }: WikiReaderProps) {
             const codeText = String(children).replace(/\n$/, "")
             if (lang === "mermaid") return <MermaidDiagram code={codeText} />
             return <code dir="ltr" className={className} {...props}>{children}</code>
+          },
+          li: ({ children, ...props }) => {
+            // ReactMarkdown wraps <li> content in <p> tags, but Milkdown
+            // renders bare text — strip the wrapper to match edit mode.
+            const flat = Array.isArray(children) && children.length === 1 && React.isValidElement(children[0]) && (children[0] as React.ReactElement).type === "p"
+              ? (children[0] as React.ReactElement<{ children: React.ReactNode }>).props.children
+              : children
+            return <li {...props}>{flat}</li>
           },
         }}
       >


### PR DESCRIPTION
## Summary
- Add @milkdown/theme-nord/style.css import to WikiReader so Read mode typography matches Edit mode
- Flatten <li> content to remove redundant <p> wrappers, matching Milkdown's structure

## Test plan
- [ ] Open a wiki page in Read mode, verify heading styles (h1-h6) match Edit mode
- [ ] Verify list items (ul/ol) have same spacing in both modes
- [ ] Verify code blocks and blockquotes are styled identically