### PR TITLE
fix(claude-cli): await completion to fix empty analysis on ingest

### DIFF
--- a/src/lib/claude-cli-transport.ts
+++ b/src/lib/claude-cli-transport.ts
@@ -143,6 +143,16 @@ export async function streamClaudeCodeCli(
   let unlistenData: UnlistenFn | undefined
   let unlistenDone: UnlistenFn | undefined
   let finished = false
+  let aborted = signal?.aborted ?? false
+  // Track whether any assistant text was received — used to detect the
+  // silent-exit case where the CLI exits 0 but emits no content.
+  let emittedToken = false
+  // Completion promise: resolves when finishWith() fires so the caller
+  // awaits the full round-trip rather than returning after spawn.
+  let resolveCompletion: () => void = () => {}
+  const completion = new Promise<void>((resolve) => {
+    resolveCompletion = resolve
+  })
 
   // Diagnostic capture for failure paths. The Rust side emits every
   // stdout line; lines the parser doesn't recognize (non-JSON,
@@ -173,14 +183,20 @@ export async function streamClaudeCodeCli(
     finished = true
     cleanup()
     cb()
+    resolveCompletion()
   }
 
   const abortListener = () => {
+    aborted = true
     void invoke("claude_cli_kill", { streamId }).catch(() => {
       // Kill is best-effort; if the process already exited, the Rust
       // side returns Ok and the done handler fires normally.
     })
     finishWith(onDone)
+  }
+  if (aborted) {
+    finishWith(onDone)
+    return
   }
   signal?.addEventListener("abort", abortListener)
 
@@ -189,6 +205,7 @@ export async function streamClaudeCodeCli(
     unlistenData = await listen<string>(`claude-cli:${streamId}`, (event) => {
       const token = parse(event.payload)
       if (token !== null) {
+        emittedToken = true
         onToken(token)
       } else {
         // Parser didn't recognize this line. Stash it in case the
@@ -198,6 +215,10 @@ export async function streamClaudeCodeCli(
         captureUnparsed(event.payload)
       }
     })
+    if (aborted || finished) {
+      cleanup()
+      return
+    }
 
     unlistenDone = await listen<{ code: number | null; stderr: string }>(
       `claude-cli:${streamId}:done`,
@@ -210,11 +231,27 @@ export async function streamClaudeCodeCli(
               new Error(buildExitError(code, stderr, unparsedLines.join("\n"))),
             ),
           )
+        } else if (!emittedToken) {
+          // CLI exited successfully but produced no assistant text.
+          // Surface this as an explicit error so the ingest pipeline
+          // retries rather than silently writing an empty stub page.
+          const details = stderr || unparsedLines.join("\n").trim()
+          finishWith(() =>
+            onError(new Error(
+              details
+                ? `Claude Code CLI completed but returned no content:\n${details}`
+                : "Claude Code CLI completed but returned no content. Try running `claude -p` in a terminal to inspect the output, or switch to the Anthropic API in Settings.",
+            )),
+          )
         } else {
           finishWith(onDone)
         }
       },
     )
+    if (aborted || finished) {
+      cleanup()
+      return
+    }
 
     const payload: SpawnPayload = {
       streamId,
@@ -222,6 +259,18 @@ export async function streamClaudeCodeCli(
       messages,
     }
     await invoke("claude_cli_spawn", payload)
+    if (aborted || signal?.aborted) {
+      aborted = true
+      await invoke("claude_cli_kill", { streamId }).catch(() => {})
+      finishWith(onDone)
+      return
+    }
+    // Wait for the done event to be processed before returning.
+    // Without this await the caller sees an empty analysis buffer
+    // because streamClaudeCodeCli() resolves immediately after spawn
+    // while the CLI subprocess is still running. (Same race that was
+    // fixed for the Codex CLI transport in #238.)
+    await completion
   } catch (err) {
     finishWith(() => {
       const message = err instanceof Error ? err.message : String(err)


### PR DESCRIPTION
## Problem

When using the Claude Code CLI provider, ingest always produces stub pages with \"(Analysis not available)\" even though the CLI works correctly in the terminal.

Root cause: `streamClaudeCodeCli()` resolves its Promise immediately after `invoke(\"claude_cli_spawn\")` returns — before the claude subprocess emits any tokens. The ingest pipeline checks the `analysis` buffer while the CLI is still running, finds it empty, and writes a stub.

Same race that was fixed for the Codex CLI transport in #238.

## Fix

- Add a `completion` Promise that resolves only inside `finishWith()`, then `await completion` after spawn — matching the pattern from the Codex CLI fix
- Track `emittedToken` flag; surface a clear error when CLI exits 0 but produces no content, instead of silently writing a stub
- Guard pre-aborted and abort-during-spawn races (same pattern as Codex CLI)

## Test

Ingest with Claude Code CLI provider now reaches Step 2/2 and writes real wiki pages (entities, concepts, source summary) instead of stubs.

Fixes #292