### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/src/components/settings/llm-presets.ts
+++ b/src/components/settings/llm-presets.ts
@@ -331,11 +331,13 @@ export const LLM_PRESETS: LlmPreset[] = [
     hint: "api.minimax.io/anthropic",
     provider: "custom",
     baseUrl: "https://api.minimax.io/anthropic",
-    defaultModel: "MiniMax-M2.7",
+    defaultModel: "MiniMax-M3",
     apiMode: "anthropic_messages",
-    // Current-gen only. M2 and M2.1 are legacy and being retired —
-    // users who need them can type the id into the custom input.
-    suggestedModels: ["MiniMax-M2.7", "MiniMax-M2.5"],
+    // M3 is the current-gen default; M2.7 stays as a fallback for users
+    // pinned to it. Older M2.5 / M2.1 / M2 are legacy and have been
+    // dropped — users who still need them can type the id into the
+    // custom input.
+    suggestedModels: ["MiniMax-M3", "MiniMax-M2.7"],
     suggestedContextSize: 200000,
   },
   {
@@ -344,9 +346,9 @@ export const LLM_PRESETS: LlmPreset[] = [
     hint: "api.minimaxi.com/anthropic",
     provider: "custom",
     baseUrl: "https://api.minimaxi.com/anthropic",
-    defaultModel: "MiniMax-M2.7",
+    defaultModel: "MiniMax-M3",
     apiMode: "anthropic_messages",
-    suggestedModels: ["MiniMax-M2.7", "MiniMax-M2.5"],
+    suggestedModels: ["MiniMax-M3", "MiniMax-M2.7"],
     suggestedContextSize: 200000,
   },
   {

--- a/src/lib/__tests__/llm-providers.test.ts
+++ b/src/lib/__tests__/llm-providers.test.ts
@@ -47,7 +47,7 @@ function buildMiniMaxProviderConfig(config: LlmConfig) {
 const makeConfig = (overrides: Partial<LlmConfig> = {}): LlmConfig => ({
   provider: "minimax",
   apiKey: "test-key",
-  model: "MiniMax-M2.7",
+  model: "MiniMax-M3",
   ollamaUrl: "http://localhost:11434",
   customEndpoint: "",
   maxContextSize: 204800,
@@ -91,9 +91,9 @@ describe("MiniMax Provider", () => {
   })
 
   it("carries the model in the body", () => {
-    const cfg = buildMiniMaxProviderConfig(makeConfig({ model: "MiniMax-M2.7" }))
+    const cfg = buildMiniMaxProviderConfig(makeConfig({ model: "MiniMax-M3" }))
     const body = cfg.buildBody([]) as Record<string, unknown>
-    expect(body.model).toBe("MiniMax-M2.7")
+    expect(body.model).toBe("MiniMax-M3")
   })
 
   it("separates system messages from conversation (Anthropic convention)", () => {


### PR DESCRIPTION
## Summary
Upgrade MiniMax model configuration to include the latest M3 model as default for both the Global and CN presets.

## Changes
- Add `MiniMax-M3` to the suggested model list for `minimax-global` and `minimax-cn` presets (placed first)
- Set `MiniMax-M3` as the new `defaultModel` for both presets
- Retain `MiniMax-M2.7` as the second suggested model so existing users can pin to it
- Remove deprecated `MiniMax-M2.5` from the suggested list (still usable via free-text input)
- Update the makeConfig default in `src/lib/__tests__/llm-providers.test.ts` to `MiniMax-M3` so the unit tests reflect the new baseline
- Other gateways listing MiniMax models (NVIDIA NIM, Bailian Coding Plan, Volcengine Ark) are left untouched — those entries reflect whatever those third-party gateways themselves host today

## Why
MiniMax-M3 is the new flagship model with a 512K context window, 128K max output, and image input support across both OpenAI-compatible and Anthropic-compatible interfaces. Promoting it to default lets new users get the latest capabilities out of the box while keeping M2.7 reachable as a fallback.

## Testing
- `npm run typecheck` clean
- `npx vitest run src/lib/__tests__/llm-providers.test.ts` — 40/40 pass
- `npx vitest run src/lib/__tests__/llm-providers.test.ts src/lib/has-usable-llm.test.ts src/lib/endpoint-normalizer.test.ts` — 77/77 pass
- `npx vite build` succeeds