### PR TITLE
fix(fs): reject relative write paths

### DIFF
--- a/src-tauri/src/commands/fs.rs
+++ b/src-tauri/src/commands/fs.rs
@@ -22,6 +22,17 @@ const MEDIA_EXTS: &[&str] = &[
 ];
 const LEGACY_DOC_EXTS: &[&str] = &["ppt", "pages", "numbers", "key", "epub"];
 
+fn require_absolute_path(operation: &str, path: &str) -> Result<(), String> {
+    if Path::new(path).is_absolute() {
+        Ok(())
+    } else {
+        Err(format!(
+            "{operation} requires an absolute path; got relative path '{}'",
+            path
+        ))
+    }
+}
+
 #[tauri::command]
 pub async fn read_file(path: String, extract_images: Option<bool>) -> Result<String, String> {
     // `spawn_blocking` is REQUIRED, not a perf nicety. The body does
@@ -941,6 +952,7 @@ fn extract_odf_text(archive: &mut zip::ZipArchive<fs::File>) -> Result<String, S
 pub async fn write_file(path: String, contents: String) -> Result<(), String> {
     tauri::async_runtime::spawn_blocking(move || {
         run_guarded("write_file", || {
+            require_absolute_path("write_file", &path)?;
             let p = Path::new(&path);
             if let Some(parent) = p.parent() {
                 fs::create_dir_all(parent)
@@ -961,6 +973,7 @@ pub async fn write_file(path: String, contents: String) -> Result<(), String> {
 pub async fn write_file_atomic(path: String, contents: String) -> Result<(), String> {
     tauri::async_runtime::spawn_blocking(move || {
         run_guarded("write_file_atomic", || {
+            require_absolute_path("write_file_atomic", &path)?;
             let p = Path::new(&path);
             if let Some(parent) = p.parent() {
                 fs::create_dir_all(parent)
@@ -1365,6 +1378,7 @@ fn collect_related_pages(
 pub async fn create_directory(path: String) -> Result<(), String> {
     tauri::async_runtime::spawn_blocking(move || {
         run_guarded("create_directory", || {
+            require_absolute_path("create_directory", &path)?;
             fs::create_dir_all(&path)
                 .map_err(|e| format!("Failed to create directory '{}': {}", path, e))
         })
@@ -1919,6 +1933,27 @@ mod tests {
         ));
         std::fs::create_dir_all(&dir).unwrap();
         dir
+    }
+
+    #[test]
+    fn reject_relative_write_paths_before_touching_cwd() {
+        assert!(require_absolute_path("write_file", "wiki/sources/stray.md").is_err());
+        assert!(require_absolute_path("write_file", "./wiki/sources/stray.md").is_err());
+    }
+
+    #[test]
+    fn allow_absolute_write_paths() {
+        assert!(require_absolute_path("write_file", "/tmp/project/wiki/sources/page.md").is_ok());
+        #[cfg(windows)]
+        {
+            assert!(require_absolute_path("write_file", "C:/project/wiki/sources/page.md").is_ok());
+            assert!(
+                require_absolute_path("write_file", r"C:\project\wiki\sources\page.md").is_ok()
+            );
+            assert!(
+                require_absolute_path("write_file", r"\\server\share\wiki\sources\page.md").is_ok()
+            );
+        }
     }
 
     /// Pull the inner sync `copy_recursive` body out from

--- a/src/commands/fs.test.ts
+++ b/src/commands/fs.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  invoke: vi.fn(),
+}))
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: mocks.invoke,
+}))
+
+import { createDirectory, writeFile, writeFileAtomic } from "./fs"
+
+describe("fs command path guards", () => {
+  beforeEach(() => {
+    mocks.invoke.mockReset()
+  })
+
+  it("rejects relative write paths before invoking Tauri", async () => {
+    await expect(writeFile("wiki/sources/stray.md", "content")).rejects.toThrow(
+      /absolute path/i,
+    )
+
+    expect(mocks.invoke).not.toHaveBeenCalled()
+  })
+
+  it("rejects relative atomic write paths before invoking Tauri", async () => {
+    await expect(writeFileAtomic("wiki/sources/stray.md", "content")).rejects.toThrow(
+      /absolute path/i,
+    )
+
+    expect(mocks.invoke).not.toHaveBeenCalled()
+  })
+
+  it("rejects relative directory paths before invoking Tauri", async () => {
+    await expect(createDirectory("wiki/sources")).rejects.toThrow(/absolute path/i)
+
+    expect(mocks.invoke).not.toHaveBeenCalled()
+  })
+
+  it("allows absolute write paths", async () => {
+    mocks.invoke.mockResolvedValue(undefined)
+
+    await writeFile("/tmp/project/wiki/sources/page.md", "content")
+
+    expect(mocks.invoke).toHaveBeenCalledWith("write_file", {
+      path: "/tmp/project/wiki/sources/page.md",
+      contents: "content",
+    })
+  })
+})

--- a/src/commands/fs.ts
+++ b/src/commands/fs.ts
@@ -1,6 +1,7 @@
 import { invoke } from "@tauri-apps/api/core"
 import type { FileNode, WikiProject } from "@/types/wiki"
 import { ensureProjectId, upsertProjectInfo } from "@/lib/project-identity"
+import { isAbsolutePath } from "@/lib/path-utils"
 
 /** Raw shape returned by the Rust commands — id is attached client-side. */
 interface RawProject {
@@ -19,10 +20,12 @@ export async function readFile(
 }
 
 export async function writeFile(path: string, contents: string): Promise<void> {
+  assertAbsoluteFsPath("writeFile", path)
   return invoke<void>("write_file", { path, contents })
 }
 
 export async function writeFileAtomic(path: string, contents: string): Promise<void> {
+  assertAbsoluteFsPath("writeFileAtomic", path)
   return invoke<void>("write_file_atomic", { path, contents })
 }
 
@@ -60,6 +63,7 @@ export async function findRelatedWikiPages(
 }
 
 export async function createDirectory(path: string): Promise<void> {
+  assertAbsoluteFsPath("createDirectory", path)
   return invoke<void>("create_directory", { path })
 }
 
@@ -77,6 +81,12 @@ export async function getFileSize(path: string): Promise<number> {
 
 export async function getFileMd5(path: string): Promise<string> {
   return invoke<string>("get_file_md5", { path })
+}
+
+function assertAbsoluteFsPath(operation: string, path: string): void {
+  if (!isAbsolutePath(path)) {
+    throw new Error(`${operation} requires an absolute path: ${path}`)
+  }
 }
 
 /** Mirror of `commands::fs::FileBase64` (Rust side). */


### PR DESCRIPTION
## Summary

- Reject relative paths in the frontend fs write/create wrappers before invoking Tauri.
- Add a backend guard so Tauri write_file, write_file_atomic, and create_directory also refuse relative paths.
- Add regression coverage for the stray wiki/sources path case.

## Root Cause

Tauri file write commands accepted project-relative paths such as `wiki/sources/foo.md`. In dev mode, the Tauri process can run with `src-tauri` as its current working directory, so those paths were resolved under the app repository and could create stray files like `src-tauri/wiki/sources/foo.md`.

## Validation

- `npx vitest run src/commands/fs.test.ts`
- `npm run typecheck`
- `npm run test:mocks`
- `cargo test write_paths`
