### PR TITLE
Isolate local CLI provider configuration

### DIFF
--- a/src-tauri/src/commands/claude_cli.rs
+++ b/src-tauri/src/commands/claude_cli.rs
@@ -127,6 +127,30 @@ fn find_claude_command() -> Result<PathBuf, String> {
     which::which("claude").map_err(|_| "`claude` not found on PATH".to_string())
 }
 
+fn claude_cli_args(model: &str) -> Vec<String> {
+    vec![
+        "-p".to_string(),
+        "--output-format".to_string(),
+        "stream-json".to_string(),
+        "--input-format".to_string(),
+        "stream-json".to_string(),
+        "--verbose".to_string(),
+        "--setting-sources".to_string(),
+        "project".to_string(),
+        "--strict-mcp-config".to_string(),
+        "--mcp-config".to_string(),
+        "{}".to_string(),
+        "--disable-slash-commands".to_string(),
+        "--tools".to_string(),
+        "".to_string(),
+        "--no-session-persistence".to_string(),
+        "--prompt-suggestions".to_string(),
+        "false".to_string(),
+        "--model".to_string(),
+        model.to_string(),
+    ]
+}
+
 /// Locate `claude` on PATH and confirm it's runnable by calling
 /// `claude --version` with a short timeout. Cheap — safe to call on
 /// mount of the settings panel.
@@ -198,12 +222,11 @@ pub async fn claude_cli_detect() -> Result<DetectResult, String> {
     }
 }
 
-/// Spawn `claude -p --output-format stream-json --input-format stream-json
-/// --verbose --model <model>` and pipe stdout back to the frontend as
-/// `claude-cli:{stream_id}` events (one line per event). Closes stdin
-/// after writing the serialized history so claude starts processing.
-/// Emits a final `claude-cli:{stream_id}:done` event with `{ code }`
-/// when the child exits.
+/// Spawn `claude` in print/stream-json mode and pipe stdout back to the
+/// frontend as `claude-cli:{stream_id}` events (one line per event).
+/// Closes stdin after writing the serialized history so claude starts
+/// processing. Emits a final `claude-cli:{stream_id}:done` event with
+/// `{ code }` when the child exits.
 #[tauri::command]
 pub async fn claude_cli_spawn(
     app: AppHandle,
@@ -252,14 +275,7 @@ pub async fn claude_cli_spawn(
 
     let claude = find_claude_command()?;
     let mut cmd = Command::new(&claude);
-    cmd.arg("-p")
-        .arg("--output-format")
-        .arg("stream-json")
-        .arg("--input-format")
-        .arg("stream-json")
-        .arg("--verbose")
-        .arg("--model")
-        .arg(&model);
+    cmd.args(claude_cli_args(&model));
 
     cmd.stdin(Stdio::piped())
         .stdout(Stdio::piped())
@@ -406,6 +422,37 @@ pub async fn claude_cli_kill(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn claude_cli_args_disable_user_customizations() {
+        let args = claude_cli_args("claude-sonnet-4-5");
+        let args = args.iter().map(String::as_str).collect::<Vec<_>>();
+
+        assert_eq!(
+            args,
+            vec![
+                "-p",
+                "--output-format",
+                "stream-json",
+                "--input-format",
+                "stream-json",
+                "--verbose",
+                "--setting-sources",
+                "project",
+                "--strict-mcp-config",
+                "--mcp-config",
+                "{}",
+                "--disable-slash-commands",
+                "--tools",
+                "",
+                "--no-session-persistence",
+                "--prompt-suggestions",
+                "false",
+                "--model",
+                "claude-sonnet-4-5",
+            ]
+        );
+    }
 
     #[test]
     fn claude_content_blocks_maps_frontend_image_blocks_to_anthropic_shape() {

--- a/src-tauri/src/commands/codex_cli.rs
+++ b/src-tauri/src/commands/codex_cli.rs
@@ -75,6 +75,24 @@ fn suppress_windows_console(_cmd: &mut Command) {
     }
 }
 
+fn codex_cli_args(model: &str) -> Vec<String> {
+    vec![
+        "-a".to_string(),
+        "never".to_string(),
+        "exec".to_string(),
+        "--json".to_string(),
+        "--skip-git-repo-check".to_string(),
+        "--sandbox".to_string(),
+        "read-only".to_string(),
+        "--ephemeral".to_string(),
+        "--ignore-user-config".to_string(),
+        "--ignore-rules".to_string(),
+        "--model".to_string(),
+        model.to_string(),
+        "-".to_string(),
+    ]
+}
+
 #[tauri::command]
 pub async fn codex_cli_detect() -> Result<DetectResult, String> {
     let path = match find_codex_command() {
@@ -147,17 +165,7 @@ pub async fn codex_cli_spawn(
     let codex = find_codex_command()?;
     let mut cmd = Command::new(&codex);
     suppress_windows_console(&mut cmd);
-    cmd.arg("-a")
-        .arg("never")
-        .arg("exec")
-        .arg("--json")
-        .arg("--skip-git-repo-check")
-        .arg("--sandbox")
-        .arg("read-only")
-        .arg("--ephemeral")
-        .arg("--model")
-        .arg(&model)
-        .arg("-");
+    cmd.args(codex_cli_args(&model));
 
     cmd.stdin(Stdio::piped())
         .stdout(Stdio::piped())
@@ -298,6 +306,31 @@ pub async fn codex_cli_kill(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn codex_cli_args_ignore_user_config_and_rules() {
+        let args = codex_cli_args("gpt-5.2");
+        let args = args.iter().map(String::as_str).collect::<Vec<_>>();
+
+        assert_eq!(
+            args,
+            vec![
+                "-a",
+                "never",
+                "exec",
+                "--json",
+                "--skip-git-repo-check",
+                "--sandbox",
+                "read-only",
+                "--ephemeral",
+                "--ignore-user-config",
+                "--ignore-rules",
+                "--model",
+                "gpt-5.2",
+                "-",
+            ]
+        );
+    }
 
     #[test]
     fn append_capped_line_appends_newline_when_space_remains() {


### PR DESCRIPTION
## Summary
- add shared argument builders for the Claude and Codex local CLI transports
- run Claude print mode with project-only settings, an empty strict MCP config, disabled slash commands/tools, disabled session persistence, and disabled prompt suggestions
- run Codex exec with `--ignore-user-config` and `--ignore-rules` so user config and exec policy files cannot affect wiki generation

## Why
Local CLI providers can inherit user-level configuration. Claude hooks/plugins/output styles/MCP servers or Codex config/rules can change the assistant response and leak explanatory output into generated wiki pages.

This intentionally avoids Claude `--bare` because that mode skips keychain/OAuth reads and would break the existing local-subscription workflow for many users.

## Verification
- `cargo test --lib cli_args -- --nocapture`
- `cargo test --lib commands::claude_cli -- --nocapture`
- `cargo test --lib commands::codex_cli -- --nocapture`
- `cargo fmt --check`
- `npm run typecheck`
- `npm run test:mocks`