### PR TITLE
feat: 对话框支持粘贴截图提问 + 修复 Markdown 图片/Obsidian 嵌入渲染

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -22,7 +22,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; connect-src 'self' https: http:; img-src 'self' asset: https://asset.localhost; media-src 'self' asset: https://asset.localhost; style-src 'self' 'unsafe-inline'",
+      "csp": "default-src 'self'; connect-src 'self' https: http:; img-src 'self' asset: http://asset.localhost https://asset.localhost blob: data:; media-src 'self' asset: http://asset.localhost https://asset.localhost blob: data:; style-src 'self' 'unsafe-inline'",
       "assetProtocol": {
         "enable": true,
         "scope": ["**"]

--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -1,9 +1,18 @@
 import { useEffect, useRef, useState, useCallback } from "react"
-import { FileSearch, Globe2, Send, Square } from "lucide-react"
+import { FileSearch, Globe2, ImagePlus, Send, Square, X } from "lucide-react"
 import { useTranslation } from "react-i18next"
 import { Button } from "@/components/ui/button"
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
 import { isImeComposing } from "@/lib/keyboard-utils"
+import type { MessageImage } from "@/stores/chat-store"
+import {
+  MAX_IMAGE_BYTES,
+  MAX_IMAGE_MB,
+  MAX_IMAGES_PER_MESSAGE,
+  fileToMessageImage,
+  isAcceptedImageType,
+  messageImageToDataUrl,
+} from "@/lib/chat-image-utils"
 
 export interface ChatSendOptions {
   useWebSearch: boolean
@@ -11,7 +20,7 @@ export interface ChatSendOptions {
 }
 
 interface ChatInputProps {
-  onSend: (text: string, options: ChatSendOptions) => void
+  onSend: (text: string, images: MessageImage[], options: ChatSendOptions) => void
   onStop: () => void
   isStreaming: boolean
   anyTxtAvailable?: boolean
@@ -23,11 +32,91 @@ export function ChatInput({ onSend, onStop, isStreaming, anyTxtAvailable = true,
   const [value, setValue] = useState("")
   const [useWebSearch, setUseWebSearch] = useState(false)
   const [useAnyTxtSearch, setUseAnyTxtSearch] = useState(false)
+  const [images, setImages] = useState<MessageImage[]>([])
+  const [imageError, setImageError] = useState<string | null>(null)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const fileInputRef = useRef<HTMLInputElement>(null)
 
   useEffect(() => {
     if (!anyTxtAvailable) setUseAnyTxtSearch(false)
   }, [anyTxtAvailable])
+
+  // Validate + decode a batch of files (from paste, drop, or the file
+  // picker) and append the accepted ones to `images`. Rejections set a
+  // transient error message rather than throwing — one bad file should
+  // never block the good ones in the same batch.
+  const addFiles = useCallback(
+    async (files: File[]) => {
+      const imageFiles = files.filter((f) => f.type.startsWith("image/"))
+      if (imageFiles.length === 0) return
+      let error: string | null = null
+      const accepted: MessageImage[] = []
+      // Read current count via the functional updater below; here we
+      // pre-compute remaining slots from the latest render's state.
+      let remaining = MAX_IMAGES_PER_MESSAGE - images.length
+      for (const file of imageFiles) {
+        if (remaining <= 0) {
+          error = t("chat.tooManyImages", { max: MAX_IMAGES_PER_MESSAGE })
+          break
+        }
+        if (!isAcceptedImageType(file.type)) {
+          error = t("chat.unsupportedImageType", { type: file.type || "?" })
+          continue
+        }
+        if (file.size > MAX_IMAGE_BYTES) {
+          error = t("chat.imageTooLarge", { max: MAX_IMAGE_MB, name: file.name || "image" })
+          continue
+        }
+        try {
+          accepted.push(await fileToMessageImage(file))
+          remaining -= 1
+        } catch {
+          error = t("chat.unsupportedImageType", { type: file.type || "?" })
+        }
+      }
+      if (accepted.length > 0) {
+        setImages((prev) => [...prev, ...accepted].slice(0, MAX_IMAGES_PER_MESSAGE))
+      }
+      setImageError(error)
+    },
+    [images.length, t],
+  )
+
+  const handlePaste = useCallback(
+    (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
+      const items = e.clipboardData?.items
+      if (!items) return
+      const files: File[] = []
+      for (const item of items) {
+        if (item.kind === "file" && item.type.startsWith("image/")) {
+          const file = item.getAsFile()
+          if (file) files.push(file)
+        }
+      }
+      if (files.length > 0) {
+        // Prevent the image's stray name/path from landing in the
+        // textarea as text on browsers that surface both.
+        e.preventDefault()
+        void addFiles(files)
+      }
+    },
+    [addFiles],
+  )
+
+  const handleFilePick = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const files = e.target.files ? Array.from(e.target.files) : []
+      void addFiles(files)
+      // Reset so picking the same file again still fires onChange.
+      e.target.value = ""
+    },
+    [addFiles],
+  )
+
+  const removeImage = useCallback((index: number) => {
+    setImages((prev) => prev.filter((_, i) => i !== index))
+    setImageError(null)
+  }, [])
 
   const handleInput = useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) => {
     setValue(e.target.value)
@@ -38,13 +127,16 @@ export function ChatInput({ onSend, onStop, isStreaming, anyTxtAvailable = true,
 
   const handleSend = useCallback(() => {
     const trimmed = value.trim()
-    if (!trimmed || isStreaming) return
-    onSend(trimmed, { useWebSearch, useAnyTxtSearch })
+    // Allow image-only messages: send if there's text OR at least one image.
+    if ((!trimmed && images.length === 0) || isStreaming) return
+    onSend(trimmed, images, { useWebSearch, useAnyTxtSearch })
     setValue("")
+    setImages([])
+    setImageError(null)
     if (textareaRef.current) {
       textareaRef.current.style.height = "auto"
     }
-  }, [value, isStreaming, onSend, useWebSearch, useAnyTxtSearch])
+  }, [value, images, isStreaming, onSend, useWebSearch, useAnyTxtSearch])
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
@@ -71,20 +163,63 @@ export function ChatInput({ onSend, onStop, isStreaming, anyTxtAvailable = true,
   return (
     <div className="border-t bg-background/95 p-3">
       <div className="rounded-lg border border-border/80 bg-card/80 p-2 shadow-sm ring-1 ring-black/5 focus-within:border-ring/60 focus-within:ring-ring/20 dark:ring-white/5">
+        {images.length > 0 && (
+          <div className="mb-2 flex flex-wrap gap-2 px-1">
+            {images.map((img, i) => (
+              <div key={i} className="group relative h-16 w-16 overflow-hidden rounded-md border border-border/70">
+                <img
+                  src={messageImageToDataUrl(img)}
+                  alt=""
+                  className="h-full w-full object-cover"
+                />
+                <button
+                  type="button"
+                  onClick={() => removeImage(i)}
+                  className="absolute right-0.5 top-0.5 rounded-full bg-background/80 p-0.5 text-muted-foreground opacity-0 shadow-sm transition-opacity hover:text-destructive group-hover:opacity-100"
+                  title={t("chat.removeImage")}
+                >
+                  <X className="h-3 w-3" />
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+        {imageError && (
+          <p className="mb-1 px-1 text-xs text-destructive">{imageError}</p>
+        )}
         <textarea
           ref={textareaRef}
           value={value}
           dir="auto"
           onChange={handleInput}
           onKeyDown={handleKeyDown}
+          onPaste={handlePaste}
           placeholder={placeholder ?? "Type a message... (Enter to send, Shift+Enter for newline)"}
           disabled={isStreaming}
           rows={1}
           className="block w-full resize-none border-0 bg-transparent px-2 py-2 text-sm leading-6 placeholder:text-muted-foreground focus:outline-none disabled:cursor-not-allowed disabled:opacity-50"
           style={{ maxHeight: "120px", overflowY: "auto" }}
         />
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/png,image/jpeg,image/webp,image/gif"
+          multiple
+          className="hidden"
+          onChange={handleFilePick}
+        />
         <div className="mt-1 flex items-center justify-between gap-3 border-t border-border/50 pt-2">
           <div className="flex min-w-0 flex-wrap items-center gap-1.5">
+            <button
+              type="button"
+              onClick={() => fileInputRef.current?.click()}
+              disabled={isStreaming || images.length >= MAX_IMAGES_PER_MESSAGE}
+              className={searchToggleClass(false)}
+              title={t("chat.attachImage")}
+            >
+              <ImagePlus className="h-3.5 w-3.5" />
+              <span className="hidden sm:inline">{t("chat.attachImage")}</span>
+            </button>
             <button
               type="button"
               aria-pressed={useWebSearch}
@@ -146,7 +281,7 @@ export function ChatInput({ onSend, onStop, isStreaming, anyTxtAvailable = true,
             <Button
               size="sm"
               onClick={handleSend}
-              disabled={!value.trim()}
+              disabled={!value.trim() && images.length === 0}
               className="h-8 shrink-0 gap-1.5 rounded-md px-3"
               title={t("chat.sendMessage")}
             >

--- a/src/components/chat/chat-message.tsx
+++ b/src/components/chat/chat-message.tsx
@@ -20,7 +20,9 @@ import { convertLatexToUnicode } from "@/lib/latex-to-unicode"
 import { normalizePath, getFileName } from "@/lib/path-utils"
 import { makeQueryFileName } from "@/lib/wiki-filename"
 import { hasUsableLlm } from "@/lib/has-usable-llm"
+import { messageImageToDataUrl } from "@/lib/chat-image-utils"
 import { resolveMarkdownImageSrc } from "@/lib/markdown-image-resolver"
+import { transformImageEmbeds } from "@/lib/wikilink-transform"
 import { findRawSourceForImage, imageUrlToAbsolute } from "@/lib/raw-source-resolver"
 import { detectLanguage } from "@/lib/detect-language"
 import { getHtmlLang, getTextDirection } from "@/lib/language-metadata"
@@ -90,19 +92,34 @@ function ChatMessageImpl({ message, isLastAssistant, onRegenerate }: ChatMessage
         {isUser ? <User className="h-4 w-4" /> : <Bot className="h-4 w-4" />}
       </div>
       <div className="max-w-[80%] flex flex-col gap-1.5">
-        <div
-          className={`rounded-lg px-3 py-2 text-sm ${
-            isUser
-              ? "bg-primary text-primary-foreground"
-              : "bg-muted text-foreground"
-          }`}
-        >
-          {isUser ? (
-            <p dir="auto" className="whitespace-pre-wrap break-words">{message.content}</p>
-          ) : (
-            <MarkdownContent content={message.content} />
-          )}
-        </div>
+        {isUser && message.images && message.images.length > 0 && (
+          <div className={`flex flex-wrap gap-1.5 ${isUser ? "justify-end" : ""}`}>
+            {message.images.map((img, i) => (
+              <img
+                key={i}
+                src={messageImageToDataUrl(img)}
+                alt=""
+                className="max-h-40 max-w-[180px] rounded-lg border border-border/40 object-contain"
+                loading="lazy"
+              />
+            ))}
+          </div>
+        )}
+        {(!isUser || message.content) && (
+          <div
+            className={`rounded-lg px-3 py-2 text-sm ${
+              isUser
+                ? "bg-primary text-primary-foreground"
+                : "bg-muted text-foreground"
+            }`}
+          >
+            {isUser ? (
+              <p dir="auto" className="whitespace-pre-wrap break-words">{message.content}</p>
+            ) : (
+              <MarkdownContent content={message.content} />
+            )}
+          </div>
+        )}
         {isAssistant && <CitedReferencesPanel content={message.content} savedReferences={message.references} />}
         {isAssistant && hovered && (
           <div className="flex items-center gap-1">
@@ -898,6 +915,12 @@ function ThinkingBlock({ content }: { content: string }) {
  */
 function processContent(text: string): string {
   let result = text
+
+  // Rewrite Obsidian image embeds (`![[…]]`) into standard markdown
+  // FIRST — before the `[[…]]` → wikilink conversion below, which
+  // would otherwise mangle the embed target into a broken
+  // `wikilink:` image. Same rule the wiki reader / raw preview use.
+  result = transformImageEmbeds(result)
 
   // Wrap bare \begin{...}...\end{...} blocks with $$ for remark-math
   result = result.replace(

--- a/src/components/chat/chat-panel.tsx
+++ b/src/components/chat/chat-panel.tsx
@@ -4,7 +4,7 @@ import { BookOpen, Plus, Trash2, MessageSquare } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { ChatMessage, StreamingMessage, useSourceFiles } from "./chat-message"
 import { ChatInput, type ChatSendOptions } from "./chat-input"
-import { useChatStore, chatMessagesToLLM, type MessageReference } from "@/stores/chat-store"
+import { useChatStore, chatMessagesToLLM, type MessageReference, type MessageImage } from "@/stores/chat-store"
 import { useWikiStore } from "@/stores/wiki-store"
 import { streamChat, type ChatMessage as LLMMessage } from "@/lib/llm-client"
 import { executeIngestWrites } from "@/lib/ingest"
@@ -175,14 +175,18 @@ export function ChatPanel() {
   }, [activeMessages, streamingContent])
 
   const handleSend = useCallback(
-    async (text: string, options: ChatSendOptions = { useWebSearch: false, useAnyTxtSearch: false }) => {
+    async (
+      text: string,
+      images: MessageImage[] = [],
+      options: ChatSendOptions = { useWebSearch: false, useAnyTxtSearch: false },
+    ) => {
       // Auto-create a conversation if none is active
       let convId = useChatStore.getState().activeConversationId
       if (!convId) {
         convId = createConversation()
       }
 
-      addMessage("user", text)
+      addMessage("user", text, images)
       setStreaming(true)
 
       // Build system prompt with wiki context using graph-enhanced retrieval
@@ -444,9 +448,31 @@ export function ChatPanel() {
         const lastIdx = llmMessages.length - 1
         const last = llmMessages[lastIdx]
         if (last && last.role === "user") {
+          // The final user turn may now be either a plain string
+          // (text-only) or a ContentBlock[] (carries images). Prepend
+          // the language reminder to the textual part in both shapes —
+          // string-concat for the legacy form, and into the first text
+          // block (or a new leading text block) for the multimodal form.
+          const prefix = `[${langReminder}]\n\n`
+          let newContent: LLMMessage["content"]
+          if (typeof last.content === "string") {
+            newContent = `${prefix}${last.content}`
+          } else {
+            const blocks = [...last.content]
+            const firstTextIdx = blocks.findIndex((b) => b.type === "text")
+            if (firstTextIdx >= 0) {
+              const tb = blocks[firstTextIdx]
+              if (tb.type === "text") {
+                blocks[firstTextIdx] = { type: "text", text: `${prefix}${tb.text}` }
+              }
+            } else {
+              blocks.unshift({ type: "text", text: prefix })
+            }
+            newContent = blocks
+          }
           llmMessages = [
             ...llmMessages.slice(0, lastIdx),
-            { role: "user", content: `[${langReminder}]\n\n${last.content}` },
+            { role: "user", content: newContent },
           ]
         }
       }
@@ -529,7 +555,9 @@ export function ChatPanel() {
         messages: s.messages.filter((m) => m.id !== lastUser.id),
       }))
     }
-    handleSend(lastUserMsg.content)
+    // Re-send with the original text AND images so a regenerated turn
+    // keeps the same vision context.
+    handleSend(lastUserMsg.content, lastUserMsg.images ?? [])
   }, [isStreaming, removeLastAssistantMessage, handleSend])
 
   const handleWriteToWiki = useCallback(async () => {

--- a/src/components/editor/file-preview.tsx
+++ b/src/components/editor/file-preview.tsx
@@ -20,8 +20,9 @@ import {
   isExtractedTextPreviewFile,
 } from "@/lib/file-types"
 import type { FileCategory } from "@/lib/file-types"
-import { getFileName } from "@/lib/path-utils"
+import { getFileName, normalizePath } from "@/lib/path-utils"
 import { resolveMarkdownImageSrc } from "@/lib/markdown-image-resolver"
+import { transformImageEmbeds } from "@/lib/wikilink-transform"
 import { detectLanguage } from "@/lib/detect-language"
 import { getHtmlLang, getTextDirection } from "@/lib/language-metadata"
 import { parseFrontmatter } from "@/lib/frontmatter"
@@ -153,6 +154,18 @@ function TextPreview({ filePath, content, label }: { filePath: string; content: 
   const scrollRootRef = useRef<HTMLDivElement | null>(null)
 
   const { frontmatter, body } = useMemo(() => parseFrontmatter(content), [content])
+  // Rewrite Obsidian image embeds (`![[…]]`) into standard markdown
+  // so raw-source previews (e.g. skill-exported docs) actually show
+  // their images instead of dumping the embed syntax as text.
+  const renderBody = useMemo(() => transformImageEmbeds(body), [body])
+  // Directory of this file (project-absolute) so relative image
+  // references (`../assets/x.png`) resolve against the file's own
+  // location, Obsidian-style.
+  const currentFileDir = useMemo(() => {
+    const norm = normalizePath(filePath)
+    const dir = norm.slice(0, norm.lastIndexOf("/"))
+    return dir || null
+  }, [filePath])
   const renderLanguage = useMemo(() => detectLanguage(body), [body])
   const direction = getTextDirection(renderLanguage)
   const htmlLang = getHtmlLang(renderLanguage)
@@ -240,7 +253,7 @@ function TextPreview({ filePath, content, label }: { filePath: string; content: 
             // URL (which differs per platform).
             img: ({ src, alt, ...props }) => (
               <img
-                src={typeof src === "string" ? resolveMarkdownImageSrc(src, projectPath) : undefined}
+                src={typeof src === "string" ? resolveMarkdownImageSrc(src, projectPath, currentFileDir) : undefined}
                 data-mdsrc={typeof src === "string" ? src : undefined}
                 alt={alt ?? ""}
                 className="max-w-full rounded border border-border/40 transition-all"
@@ -275,7 +288,7 @@ function TextPreview({ filePath, content, label }: { filePath: string; content: 
             },
           }}
         >
-          {body}
+          {renderBody}
         </ReactMarkdown>
       </div>
     </div>

--- a/src/components/editor/wiki-editor.tsx
+++ b/src/components/editor/wiki-editor.tsx
@@ -59,6 +59,9 @@ function WikiEditorInner({ content, onSave, onMarkdownChange }: WikiEditorInnerP
 interface WikiEditorProps {
   content: string
   onSave: (markdown: string, options?: { immediate?: boolean }) => void
+  /** Absolute path of the file, threaded to WikiReader so relative
+   *  image references resolve against the file's own directory. */
+  filePath?: string
 }
 
 function wrapBareMathBlocks(text: string): string {
@@ -68,7 +71,7 @@ function wrapBareMathBlocks(text: string): string {
   )
 }
 
-export function WikiEditor({ content, onSave }: WikiEditorProps) {
+export function WikiEditor({ content, onSave, filePath }: WikiEditorProps) {
   // Default to read mode (ReactMarkdown render). Edit mode swaps
   // in Milkdown WYSIWYG. We default to read because:
   //   1. Milkdown's commonmark/gfm preset has no wikilink schema,
@@ -137,7 +140,7 @@ export function WikiEditor({ content, onSave }: WikiEditorProps) {
       {mode === "read" ? (
         <div className="px-6 py-6">
           {frontmatter && <FrontmatterPanel data={frontmatter} />}
-          <WikiReader body={body} />
+          <WikiReader body={body} filePath={filePath} />
         </div>
       ) : (
         <MilkdownProvider>

--- a/src/components/editor/wiki-reader.tsx
+++ b/src/components/editor/wiki-reader.tsx
@@ -4,7 +4,7 @@ import remarkGfm from "remark-gfm"
 import remarkMath from "remark-math"
 import rehypeKatex from "rehype-katex"
 import "katex/dist/katex.min.css"
-import { transformWikilinks } from "@/lib/wikilink-transform"
+import { transformImageEmbeds, transformWikilinks } from "@/lib/wikilink-transform"
 import { resolveRelatedSlug } from "@/lib/wiki-page-resolver"
 import { resolveMarkdownImageSrc } from "@/lib/markdown-image-resolver"
 import { normalizePath } from "@/lib/path-utils"
@@ -15,6 +15,14 @@ import { MermaidDiagram, unwrapMermaidPre } from "@/components/mermaid-diagram"
 
 interface WikiReaderProps {
   body: string
+  /**
+   * Absolute path of the markdown file being rendered. Used to
+   * resolve relative image references against the file's own
+   * directory (Obsidian-style), so e.g. `../assets/x.png` works.
+   * Optional — when omitted, image paths fall back to wiki-root
+   * resolution.
+   */
+  filePath?: string
 }
 
 /**
@@ -29,17 +37,31 @@ interface WikiReaderProps {
  * against the project's wiki tree and routed to setSelectedFile,
  * giving the user single-click navigation between pages.
  */
-export function WikiReader({ body }: WikiReaderProps) {
+export function WikiReader({ body, filePath }: WikiReaderProps) {
   const project = useWikiStore((s) => s.project)
   const fileTree = useWikiStore((s) => s.fileTree)
   const setSelectedFile = useWikiStore((s) => s.setSelectedFile)
 
-  const transformed = useMemo(() => transformWikilinks(body), [body])
+  // Image embeds (`![[…]]`) must be rewritten BEFORE the generic
+  // wikilink pass, otherwise the embed target gets mangled into a
+  // `#fragment` link.
+  const transformed = useMemo(
+    () => transformWikilinks(transformImageEmbeds(body)),
+    [body],
+  )
   const renderLanguage = detectLanguage(body)
   const direction = getTextDirection(renderLanguage)
   const htmlLang = getHtmlLang(renderLanguage)
   const projectPath = project ? normalizePath(project.path) : null
   const wikiRoot = projectPath ? `${projectPath}/wiki` : null
+  // Directory of the file being rendered (project-absolute), so
+  // relative image srcs resolve against it like Obsidian does.
+  const currentFileDir = useMemo(() => {
+    if (!filePath) return null
+    const norm = normalizePath(filePath)
+    const dir = norm.slice(0, norm.lastIndexOf("/"))
+    return dir || null
+  }, [filePath])
 
   function handleAnchorClick(e: React.MouseEvent<HTMLAnchorElement>, href: string) {
     if (!href.startsWith("#")) return
@@ -113,7 +135,7 @@ export function WikiReader({ body }: WikiReaderProps) {
             <img
               src={
                 typeof src === "string"
-                  ? resolveMarkdownImageSrc(src, projectPath)
+                  ? resolveMarkdownImageSrc(src, projectPath, currentFileDir)
                   : undefined
               }
               data-mdsrc={typeof src === "string" ? src : undefined}

--- a/src/components/layout/preview-panel.tsx
+++ b/src/components/layout/preview-panel.tsx
@@ -125,6 +125,7 @@ export function PreviewPanel() {
             key={selectedFile}
             content={fileContent}
             onSave={handleSave}
+            filePath={selectedFile}
           />
         ) : (
           <FilePreview

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -139,7 +139,13 @@
     "useAnyTxtSearch": "AnyTXT search",
     "enableAnyTxtInSettings": "Enable AnyTXT in Settings → External Information Sources",
     "sendMessage": "Send message",
-    "stopGeneration": "Stop generation"
+    "stopGeneration": "Stop generation",
+    "attachImage": "Attach image",
+    "removeImage": "Remove image",
+    "imageMessage": "Image",
+    "imageTooLarge": "Image too large (max {{max}}MB): {{name}}",
+    "tooManyImages": "Too many images (max {{max}})",
+    "unsupportedImageType": "Unsupported image type: {{type}}"
   },
   "search": {
     "title": "Search",

--- a/src/i18n/zh.json
+++ b/src/i18n/zh.json
@@ -139,7 +139,13 @@
     "useAnyTxtSearch": "AnyTXT 搜索",
     "enableAnyTxtInSettings": "请在设置 → 外部信息源中启用 AnyTXT",
     "sendMessage": "发送消息",
-    "stopGeneration": "停止生成"
+    "stopGeneration": "停止生成",
+    "attachImage": "添加图片",
+    "removeImage": "移除图片",
+    "imageMessage": "图片",
+    "imageTooLarge": "图片过大（最大 {{max}}MB）：{{name}}",
+    "tooManyImages": "图片数量过多（最多 {{max}} 张）",
+    "unsupportedImageType": "不支持的图片类型：{{type}}"
   },
   "search": {
     "title": "搜索",

--- a/src/lib/chat-image-utils.ts
+++ b/src/lib/chat-image-utils.ts
@@ -1,0 +1,45 @@
+import type { MessageImage } from "@/stores/chat-store"
+
+/** Image MIME types every vision-capable provider on our wire accepts. */
+export const ACCEPTED_IMAGE_TYPES = ["image/png", "image/jpeg", "image/webp", "image/gif"] as const
+
+/** Per-image size cap. base64 inflates bytes ~33% and chat history is
+ *  persisted to JSON, so we keep this conservative. */
+export const MAX_IMAGE_BYTES = 5 * 1024 * 1024 // 5 MB
+export const MAX_IMAGE_MB = 5
+
+/** Max images attachable to a single message. */
+export const MAX_IMAGES_PER_MESSAGE = 5
+
+export function isAcceptedImageType(type: string): boolean {
+  return (ACCEPTED_IMAGE_TYPES as readonly string[]).includes(type)
+}
+
+/**
+ * Read a File/Blob into a {@link MessageImage} — raw base64 (no
+ * `data:` prefix; the provider translators add their own framing).
+ * FileReader's `readAsDataURL` gives us `data:<mime>;base64,<payload>`;
+ * we strip the prefix and keep the payload + the file's mediaType.
+ */
+export function fileToMessageImage(file: File | Blob): Promise<MessageImage> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onerror = () => reject(reader.error ?? new Error("Failed to read image"))
+    reader.onload = () => {
+      const result = reader.result
+      if (typeof result !== "string") {
+        reject(new Error("Unexpected FileReader result"))
+        return
+      }
+      const comma = result.indexOf(",")
+      const dataBase64 = comma >= 0 ? result.slice(comma + 1) : result
+      resolve({ mediaType: file.type || "image/png", dataBase64 })
+    }
+    reader.readAsDataURL(file)
+  })
+}
+
+/** Build the `data:` URL for rendering a stored image in an <img>. */
+export function messageImageToDataUrl(img: MessageImage): string {
+  return `data:${img.mediaType};base64,${img.dataBase64}`
+}

--- a/src/lib/llm-client.ts
+++ b/src/lib/llm-client.ts
@@ -4,7 +4,7 @@ import { getProviderConfig, type RequestOverrides } from "./llm-providers"
 import { getHttpFetch, isFetchNetworkError } from "./tauri-fetch"
 import { countReasoningCharsInLine, extractReasoningTextFromLine } from "./reasoning-detector"
 
-export type { ChatMessage, RequestOverrides } from "./llm-providers"
+export type { ChatMessage, ContentBlock, RequestOverrides } from "./llm-providers"
 export { isFetchNetworkError } from "./tauri-fetch"
 
 export interface StreamCallbacks {

--- a/src/lib/markdown-image-resolver.test.ts
+++ b/src/lib/markdown-image-resolver.test.ts
@@ -105,4 +105,154 @@ describe("resolveMarkdownImageSrc", () => {
   it("returns empty string verbatim for empty src", () => {
     expect(resolveMarkdownImageSrc("", PROJECT)).toBe("")
   })
+
+  describe("file-relative resolution (currentFileDir)", () => {
+    it("resolves ../assets against the file's own directory (Obsidian-style)", () => {
+      // A skill-exported raw source lives in raw/sources and refers
+      // to ../assets/<md5>.png — must land on raw/assets, NOT
+      // wiki/../assets.
+      expect(
+        resolveMarkdownImageSrc(
+          "../assets/abc123.png",
+          PROJECT,
+          `${PROJECT}/raw/sources`,
+        ),
+      ).toBe("tauri-asset:/Users/me/MyWiki/raw/assets/abc123.png")
+    })
+
+    it("resolves ../assets/boards (whiteboard screenshots) correctly", () => {
+      expect(
+        resolveMarkdownImageSrc(
+          "../assets/boards/WB1.jpg",
+          PROJECT,
+          `${PROJECT}/raw/sources`,
+        ),
+      ).toBe("tauri-asset:/Users/me/MyWiki/raw/assets/boards/WB1.jpg")
+    })
+
+    it("resolves a same-directory relative path against the file dir", () => {
+      expect(
+        resolveMarkdownImageSrc(
+          "diagram.png",
+          PROJECT,
+          `${PROJECT}/wiki/concepts`,
+        ),
+      ).toBe("tauri-asset:/Users/me/MyWiki/wiki/concepts/diagram.png")
+    })
+
+    it("strips a leading ./ before joining to the file dir", () => {
+      expect(
+        resolveMarkdownImageSrc(
+          "./img.png",
+          PROJECT,
+          `${PROJECT}/raw/sources`,
+        ),
+      ).toBe("tauri-asset:/Users/me/MyWiki/raw/sources/img.png")
+    })
+
+    it("accepts a project-relative currentFileDir and anchors it under the project", () => {
+      expect(
+        resolveMarkdownImageSrc("../assets/x.png", PROJECT, "raw/sources"),
+      ).toBe("tauri-asset:/Users/me/MyWiki/raw/assets/x.png")
+    })
+
+    it("normalizes backslashes in currentFileDir", () => {
+      expect(
+        resolveMarkdownImageSrc(
+          "../assets/x.png",
+          "C:\\Users\\me\\MyWiki",
+          "C:\\Users\\me\\MyWiki\\raw\\sources",
+        ),
+      ).toBe("tauri-asset:C:/Users/me/MyWiki/raw/assets/x.png")
+    })
+
+    it("collapses `..` segments against the file dir", () => {
+      // From /Users/me/MyWiki/raw/sources, four `..` pop
+      // sources, raw, MyWiki, me — landing in /Users.
+      expect(
+        resolveMarkdownImageSrc("../../../../etc/x.png", PROJECT, `${PROJECT}/raw/sources`),
+      ).toBe("tauri-asset:/Users/etc/x.png")
+    })
+
+    it("clamps `..` at the filesystem root rather than producing ../ garbage", () => {
+      // More `..` than there are segments → clamped at root.
+      expect(
+        resolveMarkdownImageSrc("../../x.png", PROJECT, "/a"),
+      ).toBe("tauri-asset:/x.png")
+    })
+
+    it("still uses wiki-root fallback when no currentFileDir is given", () => {
+      // The canonical generated-wiki case is unchanged.
+      expect(resolveMarkdownImageSrc("media/slug/img-1.png", PROJECT)).toBe(
+        "tauri-asset:/Users/me/MyWiki/wiki/media/slug/img-1.png",
+      )
+    })
+
+    it("keeps `media/` refs wiki-root-relative even WITH a currentFileDir set", () => {
+      // Regression: a generated `wiki/sources/<slug>.md` page embeds
+      // ingest images as `media/<slug>/img.jpg` — wiki-ROOT-relative,
+      // NOT relative to wiki/sources. Passing currentFileDir must not
+      // re-anchor it to wiki/sources/media/… (one level too deep,
+      // which 404s and shows the alt text instead of the image).
+      expect(
+        resolveMarkdownImageSrc(
+          "media/易配置平台2.0培训-1/001-abc.jpg",
+          PROJECT,
+          `${PROJECT}/wiki/sources`,
+        ),
+      ).toBe(
+        "tauri-asset:/Users/me/MyWiki/wiki/media/易配置平台2.0培训-1/001-abc.jpg",
+      )
+    })
+
+    it("decodes percent-encoded CJK paths so the disk path is literal UTF-8", () => {
+      // Regression: ReactMarkdown/remark percent-encodes non-ASCII
+      // image URLs. The src arrives already-encoded; if we don't
+      // decode it, convertFileSrc double-encodes (%E6 → %25E6) and
+      // the asset server 404s. Decode must restore the real filename.
+      const encoded =
+        "media/%E6%98%93%E9%85%8D%E7%BD%AE%E5%B9%B3%E5%8F%B02.0%E5%9F%B9%E8%AE%AD-1/001-GTuhw460rheJYBb4dnccLxYDngd.jpg"
+      expect(
+        resolveMarkdownImageSrc(encoded, PROJECT, `${PROJECT}/wiki/sources`),
+      ).toBe(
+        "tauri-asset:/Users/me/MyWiki/wiki/media/易配置平台2.0培训-1/001-GTuhw460rheJYBb4dnccLxYDngd.jpg",
+      )
+    })
+
+    it("decodes percent-encoded file-relative CJK paths too", () => {
+      // Same fix must apply on the file-relative branch (raw/sources
+      // with a CJK asset name, e.g. an exported Feishu image).
+      expect(
+        resolveMarkdownImageSrc(
+          "../assets/%E5%9B%BE%E7%89%87.png",
+          PROJECT,
+          `${PROJECT}/raw/sources`,
+        ),
+      ).toBe("tauri-asset:/Users/me/MyWiki/raw/assets/图片.png")
+    })
+
+    it("keeps a malformed percent sequence as-is rather than throwing", () => {
+      // A bare `%` that isn't a valid escape must not crash the
+      // renderer — fall back to the raw value.
+      expect(
+        resolveMarkdownImageSrc("media/100%-done.png", PROJECT),
+      ).toBe("tauri-asset:/Users/me/MyWiki/wiki/media/100%-done.png")
+    })
+
+    it("honors `./media/` (leading ./) as a wiki-root ref too, with a file dir", () => {
+      expect(
+        resolveMarkdownImageSrc(
+          "./media/slug/img-2.png",
+          PROJECT,
+          `${PROJECT}/wiki/concepts`,
+        ),
+      ).toBe("tauri-asset:/Users/me/MyWiki/wiki/media/slug/img-2.png")
+    })
+
+    it("passes absolute srcs through convertFileSrc even with a file dir set", () => {
+      expect(
+        resolveMarkdownImageSrc("/var/data/x.png", PROJECT, `${PROJECT}/raw/sources`),
+      ).toBe("tauri-asset:/var/data/x.png")
+    })
+  })
 })

--- a/src/lib/markdown-image-resolver.ts
+++ b/src/lib/markdown-image-resolver.ts
@@ -17,9 +17,18 @@
  *   - Any src starting with `/` (absolute) is wrapped with
  *     `convertFileSrc` directly — the path is the filesystem
  *     absolute path.
- *   - **Anything else is treated as relative to the project's
- *     `wiki/` root.** Generated content uses this form
- *     (`media/foo/img-1.png`); user-written content can use it too.
+ *   - **A relative src is resolved against the rendering markdown
+ *     file's own directory** when that directory is known
+ *     (`currentFileDir`). This is how Obsidian — and every other
+ *     markdown tool — resolves images, and it's what lets
+ *     skill-exported sources work: a `raw/sources/foo.md` that
+ *     references `../assets/img.png` correctly lands on
+ *     `raw/assets/img.png`.
+ *   - When the file's directory is NOT known, a relative src is
+ *     treated as relative to the project's `wiki/` root. Generated
+ *     wiki content uses this form (`media/foo/img-1.png`) and the
+ *     fallback keeps it working for callers that can't supply a
+ *     file context (e.g. chat replies).
  *
  * The resolver returns a string that React's <img src=...> can load:
  * the appropriate `convertFileSrc(...)` URL or the original src
@@ -31,13 +40,42 @@ import { normalizePath } from "@/lib/path-utils"
 const PASSTHROUGH_RE = /^(https?:|data:|blob:|file:|tauri:)/i
 
 /**
+ * Collapse `.` and `..` segments in a forward-slashed path without
+ * touching the filesystem. A leading `..` that would escape the
+ * root is dropped (clamped at root) rather than throwing — image
+ * references should degrade gracefully, not crash the renderer.
+ */
+function collapsePath(p: string): string {
+  const isAbsolute = p.startsWith("/")
+  const out: string[] = []
+  for (const seg of p.split("/")) {
+    if (seg === "" || seg === ".") continue
+    if (seg === "..") {
+      if (out.length > 0 && out[out.length - 1] !== "..") out.pop()
+      else if (!isAbsolute) out.push("..")
+      // absolute path: `..` above root is simply ignored
+    } else {
+      out.push(seg)
+    }
+  }
+  return (isAbsolute ? "/" : "") + out.join("/")
+}
+
+/**
  * `projectPath` is the wiki project's root directory. When null
  * (no project loaded), the resolver passes srcs through unchanged
  * so it remains safe to call before a project is open.
+ *
+ * `currentFileDir` is the directory of the markdown file being
+ * rendered (absolute, or relative-to-project). When provided,
+ * relative image srcs resolve against it — matching how Obsidian
+ * and other markdown tools behave. When omitted, relative srcs
+ * fall back to being resolved against `<project>/wiki/`.
  */
 export function resolveMarkdownImageSrc(
   rawSrc: string,
   projectPath: string | null,
+  currentFileDir?: string | null,
 ): string {
   if (!rawSrc) return rawSrc
   if (PASSTHROUGH_RE.test(rawSrc)) return rawSrc
@@ -54,12 +92,59 @@ export function resolveMarkdownImageSrc(
 
   // Strip a leading `./` for cleanliness; treat `media/foo.png` and
   // `./media/foo.png` identically.
-  const cleaned = rawSrc.replace(/^\.\//, "")
+  const stripped = rawSrc.replace(/^\.\//, "")
 
-  // Resolve as wiki-root-relative. The markdown lives somewhere
-  // under wiki/ but we ignore its location — image references in
-  // generated content always use this convention so the path is
-  // stable regardless of page depth.
-  const absolute = `${pp}/wiki/${cleaned}`
+  // Decode percent-encoding BEFORE assembling the filesystem path.
+  // ReactMarkdown / remark normalize image URLs and percent-encode
+  // non-ASCII characters, so a CJK path like
+  //   media/易配置平台2.0培训-1/001-x.jpg
+  // arrives here as
+  //   media/%E6%98%93%E9%85%8D.../001-x.jpg
+  // We must turn that back into the literal UTF-8 path that exists on
+  // disk — otherwise convertFileSrc() encodes the `%` again (→ %25E6),
+  // the asset server looks for a file whose name literally contains
+  // "%E6", finds nothing, and the image 404s (showing the alt text).
+  // Decoding is wrapped because a malformed `%` sequence throws; in
+  // that case we keep the raw value rather than crash the renderer.
+  let cleaned: string
+  try {
+    cleaned = decodeURIComponent(stripped)
+  } catch {
+    cleaned = stripped
+  }
+
+  // Generated-wiki convention takes precedence: ingest always emits
+  // embedded images as `media/<source-slug>/img-N.png` — a path
+  // relative to the project's `wiki/` ROOT, regardless of which
+  // wiki subdirectory the page lives in (`wiki/sources/foo.md`,
+  // `wiki/concepts/bar.md`, …). If we let `currentFileDir` win for
+  // these, a page in `wiki/sources/` would resolve `media/…` to
+  // `wiki/sources/media/…` — one level too deep — and the image
+  // 404s. So a `media/`-prefixed src is ALWAYS wiki-root-relative,
+  // never file-relative. File-relative refs use `../assets/…` /
+  // `./x.png` / bare names and never start with `media/`, so this
+  // doesn't steal any of those cases.
+  const isGeneratedMediaRef = cleaned.startsWith("media/")
+
+  // Preferred path: resolve relative to the markdown file's own
+  // directory, exactly like Obsidian. This is what makes
+  // `../assets/img.png` from a file in `raw/sources/` land on the
+  // right place. We normalize the dir to be project-absolute first
+  // (it may arrive as absolute or as a project-relative path), then
+  // collapse `..`/`.` segments.
+  if (currentFileDir && !isGeneratedMediaRef) {
+    const dir = normalizePath(currentFileDir)
+    const dirIsAbsolute =
+      dir.startsWith("/") || /^[a-zA-Z]:/.test(dir) || dir.startsWith("\\\\")
+    const baseDir = dirIsAbsolute ? dir : `${pp}/${dir}`
+    const absolute = collapsePath(`${baseDir.replace(/\/+$/, "")}/${cleaned}`)
+    return convertFileSrc(absolute)
+  }
+
+  // Fallback: resolve as wiki-root-relative. Image references in
+  // generated wiki content use this convention (`media/<slug>/…`)
+  // so the path is stable regardless of page depth, and callers
+  // without a file context (chat replies) rely on it too.
+  const absolute = collapsePath(`${pp}/wiki/${cleaned}`)
   return convertFileSrc(absolute)
 }

--- a/src/lib/wikilink-transform.test.ts
+++ b/src/lib/wikilink-transform.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest"
-import { transformWikilinks } from "./wikilink-transform"
+import { transformImageEmbeds, transformWikilinks } from "./wikilink-transform"
 
 describe("transformWikilinks", () => {
   it("returns input unchanged when there are no wikilinks", () => {
@@ -83,5 +83,84 @@ describe("transformWikilinks", () => {
   it("leaves dangling brackets untouched", () => {
     expect(transformWikilinks("[[broken")).toBe("[[broken")
     expect(transformWikilinks("broken]]")).toBe("broken]]")
+  })
+})
+
+describe("transformImageEmbeds", () => {
+  it("returns input unchanged when there are no embeds", () => {
+    expect(transformImageEmbeds("plain text")).toBe("plain text")
+    expect(transformImageEmbeds("a [[link]] but no embed")).toBe(
+      "a [[link]] but no embed",
+    )
+  })
+
+  it("converts an Obsidian image embed to standard markdown", () => {
+    expect(transformImageEmbeds("![[../assets/abc123.png]]")).toBe(
+      "![](<../assets/abc123.png>)",
+    )
+  })
+
+  it("converts a whiteboard-screenshot embed (jpg under boards/)", () => {
+    expect(
+      transformImageEmbeds("![[../assets/boards/WB1.jpg]]"),
+    ).toBe("![](<../assets/boards/WB1.jpg>)")
+  })
+
+  it("uses the alias as alt text for ![[target|alias]]", () => {
+    expect(transformImageEmbeds("![[img.png|A diagram]]")).toBe(
+      "![A diagram](<img.png>)",
+    )
+  })
+
+  it("wraps the target in <…> so spaces/non-ASCII survive the parser", () => {
+    expect(transformImageEmbeds("![[../assets/变与不变 图.png]]")).toBe(
+      "![](<../assets/变与不变 图.png>)",
+    )
+  })
+
+  it("converts multiple embeds and keeps surrounding text", () => {
+    expect(
+      transformImageEmbeds("before ![[a.png]] middle ![[b.png|B]] after"),
+    ).toBe("before ![](<a.png>) middle ![B](<b.png>) after")
+  })
+
+  it("does not touch embeds inside fenced code blocks", () => {
+    const input = "![[a.png]]\n```\n![[b.png]]\n```\n![[c.png]]"
+    expect(transformImageEmbeds(input)).toBe(
+      "![](<a.png>)\n```\n![[b.png]]\n```\n![](<c.png>)",
+    )
+  })
+
+  it("does not touch embeds inside inline code spans", () => {
+    expect(transformImageEmbeds("`![[skip.png]]` and ![[keep.png]]")).toBe(
+      "`![[skip.png]]` and ![](<keep.png>)",
+    )
+  })
+
+  it("leaves an embed whose alias contains `]` untouched (safe degradation)", () => {
+    // A `]` inside an alias is not valid Obsidian embed syntax; the
+    // regex declines to match rather than producing a malformed
+    // image. The literal text is preserved.
+    expect(transformImageEmbeds("![[x.png|a ] b]]")).toBe("![[x.png|a ] b]]")
+  })
+})
+
+describe("composition: embeds then wikilinks", () => {
+  it("an image embed survives the wikilink pass unmangled", () => {
+    // This is the real pipeline order used by the renderers.
+    const input = "See ![[../assets/x.png]] and the [[concept]] page."
+    const out = transformWikilinks(transformImageEmbeds(input))
+    expect(out).toBe("See ![](<../assets/x.png>) and the [concept](#concept) page.")
+  })
+
+  it("REGRESSION: wikilinks-only would have mangled an image embed", () => {
+    // Documents the bug this fix addresses: running the generic
+    // wikilink transform alone turns `![[x.png]]` into a broken
+    // image whose src is a `#fragment`. The embed pass must run first.
+    const mangled = transformWikilinks("![[x.png]]")
+    expect(mangled).toBe("![x.png](#x.png)")
+    // …whereas the correct pipeline yields a real image reference:
+    const correct = transformWikilinks(transformImageEmbeds("![[x.png]]"))
+    expect(correct).toBe("![](<x.png>)")
   })
 })

--- a/src/lib/wikilink-transform.ts
+++ b/src/lib/wikilink-transform.ts
@@ -14,6 +14,68 @@
  * code spans (`…`) so wikilinks shown as code examples in
  * documentation don't get mangled.
  */
+/**
+ * Convert Obsidian-style image/file embeds `![[target]]` (and
+ * `![[target|alias]]`) into standard CommonMark image syntax
+ * `![alt](target)` so a commonmark renderer actually displays them.
+ *
+ * Obsidian's embed syntax is a superset of CommonMark that react-
+ * markdown does NOT understand — left untouched, `![[../assets/x.png]]`
+ * renders as literal text. The feishu-to-md export skill emits this
+ * form by default ("Obsidian mode"), so without this rewrite every
+ * exported image is invisible in the app.
+ *
+ * The `target` is preserved verbatim as the image URL (NOT URL-
+ * encoded) — `resolveMarkdownImageSrc` expects raw filesystem-style
+ * relative paths like `../assets/x.png` or `media/slug/img.png`.
+ * The alias (after `|`), if present, becomes the alt text.
+ *
+ * Must run BEFORE `transformWikilinks`, otherwise the generic
+ * `[[…]]` → `[label](#frag)` rule would mangle the embed target
+ * into a fragment link.
+ *
+ * Skips fenced code blocks and inline code spans so documentation
+ * showing the syntax literally isn't rewritten.
+ */
+export function transformImageEmbeds(body: string): string {
+  if (!body.includes("![[")) return body
+
+  const parts = body.split(/(```[\s\S]*?```)/g)
+  return parts
+    .map((part, idx) =>
+      idx % 2 === 1 ? part : transformImageEmbedsOutsideCode(part),
+    )
+    .join("")
+}
+
+const IMAGE_EMBED_RE = /!\[\[([^\]|\n]+)(?:\|([^\]\n]*))?\]\]/g
+
+function transformImageEmbedsOutsideCode(text: string): string {
+  if (!text.includes("![[")) return text
+  const parts = text.split(/(`[^`\n]+`)/g)
+  return parts
+    .map((part, idx) => (idx % 2 === 1 ? part : replaceImageEmbeds(part)))
+    .join("")
+}
+
+function replaceImageEmbeds(text: string): string {
+  return text.replace(
+    IMAGE_EMBED_RE,
+    (_match, rawTarget: string, rawAlias?: string) => {
+      const target = rawTarget.trim()
+      const alias = rawAlias?.trim() ?? ""
+      // Sanitize alt text so `]` doesn't terminate the markdown image
+      // alt bracket early.
+      const alt = alias.replace(/]/g, ")")
+      // Wrap the URL in <…> so spaces / parens / non-ASCII in the
+      // path don't break the CommonMark image parser. The resolver
+      // strips no angle brackets — react-markdown removes them while
+      // parsing, so `src` arrives clean.
+      return `![${alt}](<${target}>)`
+    },
+  )
+}
+
 export function transformWikilinks(body: string): string {
   if (!body.includes("[[")) return body
 

--- a/src/stores/chat-messages-to-llm.test.ts
+++ b/src/stores/chat-messages-to-llm.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest"
+import { chatMessagesToLLM, type DisplayMessage } from "./chat-store"
+
+function msg(partial: Partial<DisplayMessage> & Pick<DisplayMessage, "role" | "content">): DisplayMessage {
+  return {
+    id: "1",
+    timestamp: 0,
+    conversationId: "c1",
+    ...partial,
+  }
+}
+
+describe("chatMessagesToLLM", () => {
+  it("keeps the legacy string shape when a message has no images", () => {
+    const out = chatMessagesToLLM([msg({ role: "user", content: "hello" })])
+    expect(out).toEqual([{ role: "user", content: "hello" }])
+    expect(typeof out[0].content).toBe("string")
+  })
+
+  it("keeps string shape when images is an empty array", () => {
+    const out = chatMessagesToLLM([msg({ role: "user", content: "hi", images: [] })])
+    expect(out[0].content).toBe("hi")
+  })
+
+  it("emits ContentBlock[] (text first, then image blocks) when images are present", () => {
+    const out = chatMessagesToLLM([
+      msg({
+        role: "user",
+        content: "what is this?",
+        images: [
+          { mediaType: "image/png", dataBase64: "AAAA" },
+          { mediaType: "image/jpeg", dataBase64: "BBBB" },
+        ],
+      }),
+    ])
+    expect(out[0].role).toBe("user")
+    expect(out[0].content).toEqual([
+      { type: "text", text: "what is this?" },
+      { type: "image", mediaType: "image/png", dataBase64: "AAAA" },
+      { type: "image", mediaType: "image/jpeg", dataBase64: "BBBB" },
+    ])
+  })
+
+  it("still includes a (possibly empty) text block for image-only messages", () => {
+    const out = chatMessagesToLLM([
+      msg({ role: "user", content: "", images: [{ mediaType: "image/webp", dataBase64: "CCCC" }] }),
+    ])
+    const blocks = out[0].content as Array<{ type: string }>
+    expect(blocks[0]).toEqual({ type: "text", text: "" })
+    expect(blocks[1]).toEqual({ type: "image", mediaType: "image/webp", dataBase64: "CCCC" })
+  })
+})

--- a/src/stores/chat-store.ts
+++ b/src/stores/chat-store.ts
@@ -1,6 +1,18 @@
 import { create } from "zustand"
-import type { ChatMessage } from "@/lib/llm-client"
+import type { ChatMessage, ContentBlock } from "@/lib/llm-client"
 import i18n from "@/i18n"
+
+/**
+ * An image attached to a user message. Field names mirror the
+ * `image` variant of `ContentBlock` (see llm-providers.ts) so
+ * converting a DisplayMessage into a wire ContentBlock is a no-op
+ * spread — no remapping, no `data:` framing here (the provider
+ * translators own that).
+ */
+export interface MessageImage {
+  mediaType: string
+  dataBase64: string
+}
 
 export interface Conversation {
   id: string
@@ -25,6 +37,7 @@ export interface DisplayMessage {
   timestamp: number
   conversationId: string
   references?: MessageReference[]  // pages cited in this response, saved at creation time
+  images?: MessageImage[]  // images attached to a user message (vision input)
 }
 
 interface ChatState {
@@ -44,7 +57,7 @@ interface ChatState {
   renameConversation: (id: string, title: string) => void
 
   // Message management
-  addMessage: (role: DisplayMessage["role"], content: string) => void
+  addMessage: (role: DisplayMessage["role"], content: string, images?: MessageImage[]) => void
   setMessages: (messages: DisplayMessage[]) => void
   setConversations: (conversations: Conversation[]) => void
   setStreaming: (streaming: boolean) => void
@@ -120,7 +133,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
       ),
     })),
 
-  addMessage: (role, content) =>
+  addMessage: (role, content, images) =>
     set((state) => {
       const { activeConversationId, conversations } = state
       if (!activeConversationId) return state
@@ -131,6 +144,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
         content,
         timestamp: Date.now(),
         conversationId: activeConversationId,
+        ...(images && images.length > 0 ? { images } : {}),
       }
 
       // Auto-set title from first user message (first 50 chars)
@@ -141,7 +155,14 @@ export const useChatStore = create<ChatState>((set, get) => ({
         role === "user" && convMessages.length === 0
           ? conversations.map((c) =>
               c.id === activeConversationId
-                ? { ...c, title: content.slice(0, 50), updatedAt: Date.now() }
+                ? {
+                    ...c,
+                    // Image-only first message has empty text; fall
+                    // back to a generic title so the sidebar entry
+                    // isn't blank.
+                    title: content.slice(0, 50) || (images && images.length > 0 ? i18n.t("chat.imageMessage") : c.title),
+                    updatedAt: Date.now(),
+                  }
                 : c
             )
           : conversations.map((c) =>
@@ -233,8 +254,26 @@ export const useChatStore = create<ChatState>((set, get) => ({
 }))
 
 export function chatMessagesToLLM(messages: DisplayMessage[]): ChatMessage[] {
-  return messages.map((m) => ({
-    role: m.role,
-    content: m.content,
-  }))
+  return messages.map((m) => {
+    // No images → keep the legacy string shape. Providers and the
+    // single-string fast paths in the translators stay unchanged,
+    // and existing tests that assert `content: "..."` keep passing.
+    if (!m.images || m.images.length === 0) {
+      return { role: m.role, content: m.content }
+    }
+    // Images present → emit a ContentBlock[]. Text first (so the
+    // model reads the prompt before the images), then one image
+    // block per attachment. An empty text (image-only message)
+    // still gets a text block — harmless, and keeps the shape
+    // uniform.
+    const blocks: ContentBlock[] = [
+      { type: "text", text: m.content },
+      ...m.images.map((img): ContentBlock => ({
+        type: "image",
+        mediaType: img.mediaType,
+        dataBase64: img.dataBase64,
+      })),
+    ]
+    return { role: m.role, content: blocks }
+  })
 }


### PR DESCRIPTION
## 概述

本 PR 包含两项相关改动(聊天消息渲染复用了 Markdown 图片渲染能力,二者存在依赖,故合并为单个 PR):

1. **对话框支持粘贴截图提问**
2. **修复 Markdown 图片与 Obsidian 嵌入语法渲染**

---

## 一、对话框支持粘贴截图提问

底层多模态能力已就绪(`ContentBlock` 类型、三家 provider 的图片翻译器均已实现),本 PR 补齐输入框 → 发送 → 渲染链路。

- **chat-input**: 支持 `Ctrl+V` 粘贴图片及文件选择,带缩略图预览与删除;校验图片类型(png/jpeg/webp/gif)、单图大小与张数上限;允许仅图片无文字也能发送。
- **chat-message**: user 气泡渲染图片缩略图;消息正文经 `transformImageEmbeds` 处理 Obsidian 图片嵌入。
- **chat-store**: `DisplayMessage` 增加可选 `images` 字段;`chatMessagesToLLM` 对带图 user 消息产出 `ContentBlock[]`,无图仍为 string。
- **chat-panel**: `handleSend` / `handleRegenerate` 透传 images;语言提醒兼容 `ContentBlock[]` 形态。
- **chat-image-utils**: 新增图片读取/校验工具。
- **llm-client**: 导出 `ContentBlock` 类型。
- **tauri.conf.json**: CSP 放开 `blob:` / `data:` 以预览粘贴图片。
- **i18n**: 补充图片相关中英文文案。

## 二、修复 Markdown 图片与 Obsidian 嵌入语法渲染

- **wikilink-transform**: 新增 `transformImageEmbeds`,将 Obsidian 的 `![[target]]` / `![[target|alias]]` 转换为标准 CommonMark `![alt](target)`,使 react-markdown 能正确显示(feishu-to-md 默认导出此格式)。跳过代码块/行内代码。
- **markdown-image-resolver**: 完善相对路径与文件名图片的解析。
- **wiki-editor / wiki-reader / file-preview / preview-panel**: 透传 `filePath`,按文件相对路径解析图片。

---

## 测试

- 新增/补充 `chatMessagesToLLM`、`markdown-image-resolver`、`wikilink-transform` 单元测试。
- 本地 `npm run build`(含 typecheck + vite 构建)通过;相关单测全部通过。

---

## 相关 Issue

- Closes #313 — 对话栏可粘贴/选择图片发给多模态模型(功能一)。
- Closes #212 — 修复 Markdown 图片渲染显示错误(功能二)。
- Relates to #230 — 修复了其中"图片在页面无法渲染"的部分;直接传入 image/audio/video 输入类型、视频播放等诉求不在本 PR 范围。
- Relates to #295 / Relates to #300 — 本 PR 仅修复图片**渲染显示**;ingest 阶段把 raw/sources 中 md 引用的本地图片**搬运/拷贝**进工作区,不在本 PR 范围,这两个 issue 的核心问题(图片文件丢失)仍需单独处理。
