### PR TITLE
fix: pass login shell PATH to spawned codex CLI so its node shebang resolves

### DIFF
--- a/src-tauri/src/commands/cli_resolver.rs
+++ b/src-tauri/src/commands/cli_resolver.rs
@@ -9,6 +9,34 @@ const PATH_MARKER: char = '\x1e';
 
 static RESOLVED_COMMANDS: OnceLock<Mutex<HashMap<String, PathBuf>>> = OnceLock::new();
 
+#[cfg(not(windows))]
+static RESOLVED_SHELL_PATH: OnceLock<Option<String>> = OnceLock::new();
+
+/// PATH to hand a spawned CLI so its interpreter resolves.
+///
+/// On macOS a GUI launch (Finder/Dock) inherits launchd's minimal PATH, which
+/// omits version-manager dirs (nvm, etc.). Locating the binary already falls
+/// back to the login shell PATH; node-shim CLIs like `codex`
+/// (`#!/usr/bin/env node`) additionally need that PATH at *run* time so their
+/// shebang finds `node`. We prepend the login shell PATH to the inherited one
+/// (cached, so the shell is spawned at most once). Returns `None` when there is
+/// nothing to add, in which case the child should inherit PATH unchanged.
+#[cfg(not(windows))]
+pub(crate) fn child_path_env() -> Option<String> {
+    let shell_path = RESOLVED_SHELL_PATH
+        .get_or_init(|| login_shell_path(LOGIN_SHELL_PATH_TIMEOUT))
+        .clone()?;
+    match std::env::var("PATH") {
+        Ok(current) if !current.is_empty() => Some(format!("{shell_path}:{current}")),
+        _ => Some(shell_path),
+    }
+}
+
+#[cfg(windows)]
+pub(crate) fn child_path_env() -> Option<String> {
+    None
+}
+
 pub(crate) async fn find_cli_command(
     command: &str,
     windows_candidates: &[&str],

--- a/src-tauri/src/commands/codex_cli.rs
+++ b/src-tauri/src/commands/codex_cli.rs
@@ -19,7 +19,7 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, Command};
 use tokio::sync::Mutex;
 
-use super::cli_resolver::find_cli_command;
+use super::cli_resolver::{child_path_env, find_cli_command};
 
 #[derive(Default)]
 pub struct CodexCliState {
@@ -84,6 +84,12 @@ pub async fn codex_cli_detect() -> Result<DetectResult, String> {
     let path_str = path.to_string_lossy().to_string();
     let mut cmd = Command::new(&path);
     suppress_windows_console(&mut cmd);
+    // `codex` is a node shim (`#!/usr/bin/env node`); under a GUI launch the
+    // inherited PATH lacks node, so hand it the login shell PATH or its
+    // shebang fails with `env: node: No such file or directory`.
+    if let Some(path_env) = child_path_env() {
+        cmd.env("PATH", path_env);
+    }
     let output = tokio::time::timeout(Duration::from_secs(3), cmd.arg("--version").output()).await;
 
     match output {
@@ -140,6 +146,11 @@ pub async fn codex_cli_spawn(
     let codex = find_codex_command().await?;
     let mut cmd = Command::new(&codex);
     suppress_windows_console(&mut cmd);
+    // See `codex_cli_detect`: the node shim needs the login shell PATH at run
+    // time so its shebang resolves `node` under a GUI launch.
+    if let Some(path_env) = child_path_env() {
+        cmd.env("PATH", path_env);
+    }
     cmd.args(build_codex_cli_args(&model, isolate_local_config));
 
     cmd.stdin(Stdio::piped())


### PR DESCRIPTION
## Problem

On macOS, when the app is launched from Finder/Dock, the **Codex** model reports as not installed even though `codex` runs fine from a terminal. The underlying error is:

```
env: node: No such file or directory
```

## Root cause

`codex` ships as a Node script with a `#!/usr/bin/env node` shebang.

`cli_resolver` already handles a GUI launch's minimal PATH when **locating** the binary — it falls back to the login shell PATH (added in `fix: harden CLI command resolution`). But when we **spawn** codex, the child process still inherits the GUI launch's minimal PATH, which under a Finder/Dock launch omits version-manager directories (nvm, etc.). So codex starts, its shebang runs `/usr/bin/env node`, `node` isn't on PATH, and the process dies before producing any output.

`codex_cli_detect` then surfaces this as "codex not installed" / a spawn failure, despite codex working from a shell where nvm's `node` is on PATH.

This affects both `codex_cli_detect` and `codex_cli_spawn`.

## Fix

Add `child_path_env()` to `cli_resolver`:
- Reuses the cached login shell PATH (the same one already used to locate the binary — spawned at most once).
- Prepends it to the inherited PATH so version-manager `node` is found.
- No-op on Windows; returns `None` when there's nothing to add (child then inherits PATH unchanged).

`codex_cli_detect` and `codex_cli_spawn` set this as the child's `PATH` env before spawning, so the node shebang resolves.

## Notes

- `claude` is a native binary, so it doesn't have the node-shebang dependency and is left unchanged.
- Scoped to the two codex spawn sites; no behavior change when `which` already finds codex on the inherited PATH.

## Test plan

- `cargo check` + existing `codex` unit tests pass.
- Verified on macOS with codex installed via nvm (`~/.nvm/versions/node/<v>/bin/codex`, node at `~/.local/bin/node`): before the fix, detection fails with `env: node: No such file or directory` under a `.app` launch; after, detection reports the version and chat spawns correctly.