### PR TITLE
Fix: preserve review items when switching projects

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -290,6 +290,13 @@ function App() {
   }, [])
 
   async function handleProjectOpened(proj: WikiProject) {
+    // Flush the OUTGOING project's review/lint/chat state to disk and suspend
+    // auto-save before reset empties the stores — otherwise the debounced
+    // writers would persist empty arrays back over the old project's pending
+    // review / deep-research items.
+    const { flushAndSuspendAutoSave, resumeAutoSave } = await import("@/lib/auto-save")
+    await flushAndSuspendAutoSave()
+
     // Clear all per-project state BEFORE loading new project data
     // to prevent cross-project contamination. MUST be awaited so the
     // ingest queue / graph cache are actually cleared before the new
@@ -424,6 +431,9 @@ function App() {
     } catch {
       // ignore, start fresh
     }
+    // New project's persisted state is loaded — re-arm auto-save so further
+    // edits persist to THIS project.
+    resumeAutoSave()
   }
 
   async function handleSelectRecent(proj: WikiProject) {
@@ -462,6 +472,12 @@ function App() {
       const currentConfig = useWikiStore.getState().scheduledImportConfig
       saveScheduledImportConfig(currentProject.path, currentConfig).catch(() => {})
     }
+
+    // Flush outgoing project's review/lint/chat to disk and suspend auto-save
+    // before reset empties the stores. resumeAutoSave() runs when the next
+    // project opens via handleProjectOpened.
+    const { flushAndSuspendAutoSave } = await import("@/lib/auto-save")
+    await flushAndSuspendAutoSave()
 
     // Clear all per-project state BEFORE flipping back to the welcome screen
     // so old data cannot leak in via any async render pass.

--- a/src/lib/auto-save.test.ts
+++ b/src/lib/auto-save.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Regression test for the project-switch data-loss bug:
+ *
+ * When switching wiki projects, resetProjectState() empties the review/lint/chat
+ * stores. The auto-save subscriptions are debounced, so without a guard their
+ * timers fired AFTER the store was cleared but while project?.path still pointed
+ * at the OUTGOING project — persisting empty arrays over that project's pending
+ * review / deep-research items. Switching back then loaded an emptied review.json.
+ *
+ * flushAndSuspendAutoSave() must (1) persist the real current state to disk and
+ * (2) suspend the subscriptions so the subsequent clear-to-empty does not write.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest"
+
+const { saveReviewItems, saveLintItems, saveChatHistory } = vi.hoisted(() => ({
+  saveReviewItems: vi.fn().mockResolvedValue(undefined),
+  saveLintItems: vi.fn().mockResolvedValue(undefined),
+  saveChatHistory: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock("./persist", () => ({ saveReviewItems, saveLintItems, saveChatHistory }))
+
+import { setupAutoSave, flushAndSuspendAutoSave, resumeAutoSave } from "./auto-save"
+import { useReviewStore } from "@/stores/review-store"
+import { useLintStore } from "@/stores/lint-store"
+import { useChatStore } from "@/stores/chat-store"
+import { useWikiStore } from "@/stores/wiki-store"
+import type { ReviewItem } from "@/stores/review-store"
+
+function setProjectPath(path: string | null): void {
+  useWikiStore.setState({ project: path ? ({ id: "p", name: "p", path } as never) : null })
+}
+
+function review(id: string): ReviewItem {
+  return { id, type: "missing-page", title: id, description: "", options: [], resolved: false, createdAt: 0 }
+}
+
+let registered = false
+
+beforeEach(() => {
+  saveReviewItems.mockClear()
+  saveLintItems.mockClear()
+  saveChatHistory.mockClear()
+  useReviewStore.setState({ items: [] })
+  useLintStore.setState({ items: [] })
+  useChatStore.setState({ conversations: [], messages: [], isStreaming: false })
+  resumeAutoSave()
+  vi.useFakeTimers()
+  // setupAutoSave registers permanent subscriptions; only do it once.
+  if (!registered) {
+    setupAutoSave()
+    registered = true
+  }
+})
+
+describe("auto-save project-switch guard", () => {
+  it("flushes current review state to the outgoing project before suspend", async () => {
+    setProjectPath("/proj/A")
+    useReviewStore.setState({ items: [review("a1"), review("a2")] })
+
+    await flushAndSuspendAutoSave()
+
+    expect(saveReviewItems).toHaveBeenCalledWith("/proj/A", [review("a1"), review("a2")])
+  })
+
+  it("does NOT persist the empty store after suspend (the data-loss bug)", async () => {
+    setProjectPath("/proj/A")
+    useReviewStore.setState({ items: [review("a1")] })
+
+    await flushAndSuspendAutoSave()
+    saveReviewItems.mockClear()
+    saveLintItems.mockClear()
+
+    // resetProjectState would do this — clear stores while path is still A.
+    useReviewStore.setState({ items: [] })
+    useLintStore.setState({ items: [] })
+    vi.runAllTimers()
+
+    expect(saveReviewItems).not.toHaveBeenCalled()
+    expect(saveLintItems).not.toHaveBeenCalled()
+  })
+
+  it("resumes persisting after resumeAutoSave", () => {
+    setProjectPath("/proj/B")
+    flushAndSuspendAutoSave()
+    resumeAutoSave()
+
+    useReviewStore.setState({ items: [review("b1")] })
+    vi.runAllTimers()
+
+    expect(saveReviewItems).toHaveBeenCalledWith("/proj/B", [review("b1")])
+  })
+
+  it("skips chat flush while streaming", async () => {
+    setProjectPath("/proj/A")
+    useChatStore.setState({ isStreaming: true })
+
+    await flushAndSuspendAutoSave()
+
+    expect(saveChatHistory).not.toHaveBeenCalled()
+    expect(saveReviewItems).toHaveBeenCalled()
+  })
+})

--- a/src/lib/auto-save.ts
+++ b/src/lib/auto-save.ts
@@ -8,9 +8,50 @@ let reviewTimer: ReturnType<typeof setTimeout> | null = null
 let lintTimer: ReturnType<typeof setTimeout> | null = null
 let chatTimer: ReturnType<typeof setTimeout> | null = null
 
+// While suspended, the store subscriptions skip writing. This is essential
+// during a project switch: resetProjectState() clears every store to empty,
+// and without this guard the debounced callbacks would persist those empty
+// arrays back to the OUTGOING project's .llm-wiki/*.json — wiping its pending
+// review / deep-research items. The switch flow flushes real data to disk via
+// flushAndSuspendAutoSave() first, then resumes once the new project loads.
+let suspended = false
+
+function clearTimers(): void {
+  if (reviewTimer) { clearTimeout(reviewTimer); reviewTimer = null }
+  if (lintTimer) { clearTimeout(lintTimer); lintTimer = null }
+  if (chatTimer) { clearTimeout(chatTimer); chatTimer = null }
+}
+
+/**
+ * Immediately persist the current stores to the current project, then stop
+ * auto-save from firing until resumeAutoSave() is called. Must be invoked
+ * before resetProjectState() clears the stores on a project switch.
+ */
+export async function flushAndSuspendAutoSave(): Promise<void> {
+  suspended = true
+  clearTimers()
+  const projectPath = useWikiStore.getState().project?.path
+  if (!projectPath) return
+  const review = useReviewStore.getState().items
+  const lint = useLintStore.getState().items
+  const chat = useChatStore.getState()
+  await Promise.allSettled([
+    saveReviewItems(projectPath, review),
+    saveLintItems(projectPath, lint),
+    chat.isStreaming
+      ? Promise.resolve()
+      : saveChatHistory(projectPath, chat.conversations, chat.messages),
+  ])
+}
+
+export function resumeAutoSave(): void {
+  suspended = false
+}
+
 export function setupAutoSave(): void {
   // Auto-save review items (debounced 1s)
   useReviewStore.subscribe((state) => {
+    if (suspended) return
     const projectPath = useWikiStore.getState().project?.path
     if (reviewTimer) clearTimeout(reviewTimer)
     reviewTimer = setTimeout(() => {
@@ -22,6 +63,7 @@ export function setupAutoSave(): void {
 
   // Auto-save lint items (debounced 1s)
   useLintStore.subscribe((state) => {
+    if (suspended) return
     const projectPath = useWikiStore.getState().project?.path
     if (lintTimer) clearTimeout(lintTimer)
     lintTimer = setTimeout(() => {
@@ -33,6 +75,7 @@ export function setupAutoSave(): void {
 
   // Auto-save chat conversations and messages (debounced 2s, skip during streaming)
   useChatStore.subscribe((state) => {
+    if (suspended) return
     if (state.isStreaming) return
     const projectPath = useWikiStore.getState().project?.path
     if (chatTimer) clearTimeout(chatTimer)


### PR DESCRIPTION
## Problem

Switching wiki projects could silently wipe a project's pending review / deep-research items. Steps to reproduce:

1. In project **A**, ingest a file so it produces pending review items (the "待审核 / deep_research" points).
2. Switch to project **B**.
3. Switch back to **A** — the pending items are gone.

## Root cause

On project switch, `resetProjectState()` empties the review/lint/chat Zustand stores. The auto-save subscriptions (`src/lib/auto-save.ts`) are debounced (~1s), so their timers fire *after* the stores are cleared but while `useWikiStore.project.path` still points at the **outgoing** project. The debounced writers then persist the now-empty arrays over the old project's `.llm-wiki/review.json` (and `lint.json`), destroying its pending items. Switching back loads the emptied file.

## Fix

Add `flushAndSuspendAutoSave()` / `resumeAutoSave()` in `src/lib/auto-save.ts`:

- Before `resetProjectState()` runs, **flush** the real current store contents to the current project's disk, then **suspend** the subscriptions so the clear-to-empty does not write.
- **Resume** once the new project's persisted data has loaded.

Wired into both `handleProjectOpened` and `handleSwitchProject` in `src/App.tsx`. Chat flush is skipped while streaming, matching the existing auto-save guard.

## Tests

Added `src/lib/auto-save.test.ts` covering: flush to outgoing project, no write after suspend (the data-loss path), resume re-arms persistence, and streaming-skip. Full suite passes (`npm run test:mocks`), `tsc --noEmit` clean.