### PR TITLE
Production hardening: auth, sandbox, CI tests, observability

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Local HTTP API (desktop app must be running)
+LLM_WIKI_API_BASE_URL=http://127.0.0.1:19828
+
+# Bearer token for API + Clip servers (overrides Settings token when set)
+LLM_WIKI_API_TOKEN=
+
+# Optional: used by real-llm integration tests against a running app
+API_TOKEN=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,16 @@ jobs:
       - name: Check frontend build
         run: npx vite build
 
+      - name: Run frontend unit tests
+        run: npm run test:mocks
+
+      - name: Run MCP server tests
+        run: npm run mcp:test
+
       - name: Check Rust build
         working-directory: src-tauri
         run: cargo build
+
+      - name: Run Rust unit tests
+        working-directory: src-tauri
+        run: cargo test --lib

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -3,7 +3,7 @@
   "name": "LLM Wiki Clipper",
   "version": "0.1.0",
   "description": "Clip web pages to your LLM Wiki knowledge base",
-  "permissions": ["activeTab", "scripting"],
+  "permissions": ["activeTab", "scripting", "storage"],
   "host_permissions": ["http://127.0.0.1:19827/*"],
   "action": {
     "default_popup": "popup.html",

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -1,4 +1,15 @@
 const API_URL = "http://127.0.0.1:19827";
+const TOKEN_STORAGE_KEY = "llmWikiApiToken";
+
+async function clipAuthHeaders() {
+  const stored = await chrome.storage.local.get([TOKEN_STORAGE_KEY]);
+  const headers = { "Content-Type": "application/json" };
+  const token = stored[TOKEN_STORAGE_KEY];
+  if (typeof token === "string" && token.trim()) {
+    headers.Authorization = `Bearer ${token.trim()}`;
+  }
+  return headers;
+}
 
 const statusBar = document.getElementById("statusBar");
 const titleInput = document.getElementById("titleInput");
@@ -12,7 +23,7 @@ let pageUrl = "";
 
 async function checkConnection() {
   try {
-    const res = await fetch(`${API_URL}/status`, { method: "GET" });
+    const res = await fetch(`${API_URL}/status`, { method: "GET", headers: await clipAuthHeaders() });
     const data = await res.json();
     if (data.ok) {
       statusBar.className = "status connected";
@@ -30,7 +41,7 @@ async function checkConnection() {
 
 async function loadProjects() {
   try {
-    const res = await fetch(`${API_URL}/projects`, { method: "GET" });
+    const res = await fetch(`${API_URL}/projects`, { method: "GET", headers: await clipAuthHeaders() });
     const data = await res.json();
     if (data.ok && data.projects?.length > 0) {
       projectSelect.innerHTML = "";
@@ -46,7 +57,7 @@ async function loadProjects() {
   } catch {}
   // Fallback to current project
   try {
-    const res = await fetch(`${API_URL}/project`, { method: "GET" });
+    const res = await fetch(`${API_URL}/project`, { method: "GET", headers: await clipAuthHeaders() });
     const data = await res.json();
     if (data.ok && data.path) {
       const name = data.path.replace(/\\/g, "/").split("/").pop() || data.path;
@@ -214,7 +225,7 @@ async function sendClip() {
   try {
     const res = await fetch(`${API_URL}/clip`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: await clipAuthHeaders(),
       body: JSON.stringify({
         title: titleInput.value,
         url: pageUrl,

--- a/mcp-server/src/api-client.ts
+++ b/mcp-server/src/api-client.ts
@@ -212,6 +212,21 @@ export class LlmWikiApiClient {
     })
   }
 
+  async chat(
+    projectId = "current",
+    query: string,
+    options: { topK?: number; includeContent?: boolean } = {},
+  ): Promise<Record<string, unknown>> {
+    return this.request(`/projects/${encodeURIComponent(projectId)}/chat`, {
+      method: "POST",
+      body: {
+        query,
+        topK: options.topK,
+        includeContent: options.includeContent,
+      },
+    })
+  }
+
   private async request(path: string, options: { method?: "GET" | "POST"; body?: unknown; auth?: boolean } = {}): Promise<Record<string, unknown>> {
     const url = `${this.baseUrl}${apiPath(path)}`
     const headers: Record<string, string> = { Accept: "application/json" }

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -16,7 +16,7 @@ import {
   type ApiSearchResult,
 } from "./api-client.js"
 
-const VERSION = "0.4.20"
+const VERSION = "0.4.23"
 const DEFAULT_PROJECT_ID = "current"
 const MAX_TEXT_BYTES = 120_000
 
@@ -118,6 +118,21 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
       },
     },
     {
+      name: "llm_wiki_chat",
+      description: "Retrieve wiki context for a query using the desktop app's hybrid search (retrieval-only; LLM completion is the caller's job).",
+      inputSchema: {
+        type: "object",
+        properties: {
+          project_id: { type: "string", description: "Project UUID, project path, or 'current'. Defaults to current." },
+          query: { type: "string", description: "User question or search query." },
+          top_k: { type: "number", description: "Maximum results." },
+          include_content: { type: "boolean", description: "Include full page content in hits." },
+        },
+        required: ["query"],
+        additionalProperties: false,
+      },
+    },
+    {
       name: "llm_wiki_rescan_sources",
       description: "Trigger the desktop app's source folder rescan for a project, using the user's Source Watch rules.",
       inputSchema: {
@@ -187,6 +202,15 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           limit: numberArg(args.limit),
         })
         return textResult(formatGraph(graph.nodes, graph.edges))
+      }
+      case "llm_wiki_chat": {
+        await assertMcpEnabled()
+        const query = stringArg(args.query, "query")
+        const payload = await client.chat(projectId(args), query, {
+          topK: numberArg(args.top_k),
+          includeContent: boolArg(args.include_content, true),
+        })
+        return textResult(JSON.stringify(payload, null, 2))
       }
       case "llm_wiki_rescan_sources": {
         await assertMcpEnabled()

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3711,6 +3711,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyring"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+dependencies = [
+ "log",
+ "zeroize",
+]
+
+[[package]]
 name = "kqueue"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4461,7 +4471,7 @@ checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "llm-wiki"
-version = "0.4.22"
+version = "0.4.23"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -4471,6 +4481,7 @@ dependencies = [
  "docx-rs",
  "futures",
  "image",
+ "keyring",
  "lancedb",
  "md-5",
  "notify",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -62,6 +62,7 @@ sha2 = "0.10"
 md-5 = "0.10"
 notify = "8"
 walkdir = "2"
+keyring = "3"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }

--- a/src-tauri/src/api_runtime.rs
+++ b/src-tauri/src/api_runtime.rs
@@ -1,0 +1,20 @@
+//! Dedicated Tokio runtime for the local HTTP API server.
+//!
+//! Isolates `block_on` search/embedding work from Tauri's shared async runtime
+//! so bursty API traffic cannot starve UI-facing commands.
+
+use std::sync::OnceLock;
+
+static RUNTIME: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
+
+pub fn block_on<F: std::future::Future>(future: F) -> F::Output {
+    let runtime = RUNTIME.get_or_init(|| {
+        tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .enable_all()
+            .thread_name("llm-wiki-api")
+            .build()
+            .expect("failed to build API runtime")
+    });
+    runtime.block_on(future)
+}

--- a/src-tauri/src/api_server.rs
+++ b/src-tauri/src/api_server.rs
@@ -13,7 +13,7 @@ use tauri::{AppHandle, Manager};
 use tiny_http::{Header, Method, Response, Server, StatusCode};
 use walkdir::WalkDir;
 
-use crate::{clip_server, commands};
+use crate::{api_runtime, clip_server, commands, local_auth, observability};
 
 const PORT: u16 = 19828;
 const API_PREFIX: &str = "/api/v1";
@@ -26,7 +26,6 @@ const HARD_MAX_REVIEWS: usize = 1_000;
 const MAX_SEARCH_RESULTS: usize = 50;
 const BIND_RETRY_DELAY_SECS: u64 = 2;
 const MAX_BIND_RETRIES: u32 = 3;
-const APP_STATE_CACHE_TTL: Duration = Duration::from_secs(5);
 const RATE_LIMIT_WINDOW: Duration = Duration::from_secs(1);
 const RATE_LIMIT_MAX_REQUESTS: usize = 120;
 const MAX_IN_FLIGHT_REQUESTS: usize = 64;
@@ -34,14 +33,7 @@ const MAX_IN_FLIGHT_REQUESTS: usize = 64;
 /// API status: 0=starting, 1=running, 2=port_conflict, 3=error
 static API_STATUS: AtomicU8 = AtomicU8::new(0);
 static IN_FLIGHT_REQUESTS: AtomicUsize = AtomicUsize::new(0);
-static APP_STATE_CACHE: OnceLock<Mutex<Option<CachedAppState>>> = OnceLock::new();
 static RATE_LIMIT: OnceLock<Mutex<VecDeque<Instant>>> = OnceLock::new();
-
-#[derive(Clone)]
-struct CachedAppState {
-    loaded_at: Instant,
-    value: Option<Value>,
-}
 
 pub fn get_api_status() -> &'static str {
     match API_STATUS.load(Ordering::Relaxed) {
@@ -53,11 +45,7 @@ pub fn get_api_status() -> &'static str {
 }
 
 pub fn invalidate_config_cache() {
-    if let Some(lock) = APP_STATE_CACHE.get() {
-        if let Ok(mut cache) = lock.lock() {
-            *cache = None;
-        }
-    }
+    local_auth::invalidate_config_cache();
 }
 
 pub fn start_api_server(app: AppHandle) {
@@ -87,13 +75,18 @@ pub fn start_api_server(app: AppHandle) {
                 continue;
             };
             let app = app.clone();
+            let request_id = observability::next_request_id();
             thread::spawn(move || {
                 let _slot = slot;
                 let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                    process_request(app, request);
+                    process_request(app, request, &request_id);
                 }));
                 if let Err(payload) = result {
-                    eprintln!("[API Server] request handler panicked: {payload:?}");
+                    observability::log_error(
+                        "api_server",
+                        "handler_panicked",
+                        &[("detail", &format!("{payload:?}"))],
+                    );
                 }
             });
         }
@@ -147,24 +140,25 @@ fn try_acquire_request_slot() -> Option<RequestSlot> {
     }
 }
 
-fn process_request(app: AppHandle, mut request: tiny_http::Request) {
+fn process_request(app: AppHandle, mut request: tiny_http::Request, request_id: &str) {
     let method = request.method().clone();
     let url = request.url().to_string();
+    let (path_only, _) = split_url(&url);
+    observability::log_event(
+        "info",
+        "api_server",
+        "request",
+        &[
+            ("method", method.as_str()),
+            ("path", &path_only),
+        ],
+        Some(request_id),
+    );
+    let headers = headers_from_request(&request);
     if method == Method::Options {
-        respond_options(request);
+        respond_options(request, &headers);
         return;
     }
-
-    let headers: Vec<(String, String)> = request
-        .headers()
-        .iter()
-        .map(|header| {
-            (
-                header.field.as_str().to_ascii_lowercase().to_string(),
-                header.value.as_str().to_string(),
-            )
-        })
-        .collect();
 
     let body = match read_body(&mut request) {
         Ok(body) => body,
@@ -181,7 +175,7 @@ fn process_request(app: AppHandle, mut request: tiny_http::Request) {
         eprintln!("[API Server] request panicked: {payload:?}");
         err(500, "Internal API server error")
     });
-    respond_json(request, response.status, response.body);
+    respond_json(request, &headers, response.status, response.body);
 }
 
 struct ApiResponse {
@@ -218,18 +212,18 @@ fn handle_request(
             "ok": true,
             "status": get_api_status(),
             "version": env!("CARGO_PKG_VERSION"),
-            "authRequired": api_auth_required(app),
-            "authConfigured": api_token(app).is_some(),
-            "tokenSource": api_token_source(app),
-            "enabled": api_enabled(app),
-            "mcpEnabled": api_mcp_enabled(app),
-            "allowUnauthenticated": api_allow_unauthenticated(app),
+            "authRequired": local_auth::api_auth_required(app),
+            "authConfigured": local_auth::api_token(app).is_some(),
+            "tokenSource": local_auth::api_token_source(app),
+            "enabled": local_auth::api_enabled(app),
+            "mcpEnabled": local_auth::api_mcp_enabled(app),
+            "allowUnauthenticated": local_auth::api_allow_unauthenticated(app),
         }));
     }
     if !path.starts_with(API_PREFIX) {
         return err(404, "Not found");
     }
-    if !api_enabled(app) {
+    if !local_auth::api_enabled(app) {
         // Kill-switch path: token may be configured and valid, but the
         // user toggled the API off in Settings → API Server. 503 is
         // the right code semantically ("temporarily unavailable")
@@ -237,7 +231,7 @@ fn handle_request(
         // retry instantly the way 401 would.
         return err(503, "API server is disabled in Settings → API Server");
     }
-    if !is_authorized(app, query, headers) {
+    if !local_auth::is_authorized(app, headers) {
         return err(401, "Unauthorized");
     }
     if !matches!(method, &Method::Get | &Method::Post) {
@@ -265,10 +259,7 @@ fn handle_request(
         (&Method::Post, ["projects", project_id, "sources", "rescan"]) => {
             handle_rescan(app, project_id)
         }
-        (&Method::Post, ["projects", project_id, "chat"]) => {
-            let _ = project_id;
-            err(501, "Chat API is not implemented in the local Rust API server yet. The existing chat/RAG pipeline currently lives in the WebView; expose it after moving the shared chat pipeline behind a backend command.")
-        }
+        (&Method::Post, ["projects", project_id, "chat"]) => handle_chat(app, project_id, body),
         _ => err(404, "Not found"),
     }
 }
@@ -311,29 +302,44 @@ fn read_body(request: &mut tiny_http::Request) -> Result<String, String> {
 }
 
 fn respond_error(request: tiny_http::Request, status: u16, message: &str) {
-    respond_json(request, status, json!({ "ok": false, "error": message }));
+    let headers = headers_from_request(&request);
+    respond_json(request, &headers, status, json!({ "ok": false, "error": message }));
 }
 
-fn respond_options(request: tiny_http::Request) {
+fn headers_from_request(request: &tiny_http::Request) -> Vec<(String, String)> {
+    request
+        .headers()
+        .iter()
+        .map(|header| {
+            (
+                header.field.as_str().to_ascii_lowercase().to_string(),
+                header.value.as_str().to_string(),
+            )
+        })
+        .collect()
+}
+
+fn respond_options(request: tiny_http::Request, request_headers: &[(String, String)]) {
     let mut response = Response::empty(StatusCode(204));
-    for header in cors_headers() {
+    for header in cors_headers_for_request(request_headers) {
         response.add_header(header);
     }
     response.add_header(Header::from_bytes("Access-Control-Max-Age", "600").unwrap());
     let _ = request.respond(response);
 }
 
-fn respond_json(request: tiny_http::Request, status: u16, body: Value) {
+fn respond_json(request: tiny_http::Request, request_headers: &[(String, String)], status: u16, body: Value) {
     let mut response = Response::from_string(body.to_string()).with_status_code(StatusCode(status));
-    for header in cors_headers() {
+    for header in cors_headers_for_request(request_headers) {
         response.add_header(header);
     }
     let _ = request.respond(response);
 }
 
-fn cors_headers() -> Vec<Header> {
-    vec![
-        Header::from_bytes("Access-Control-Allow-Origin", "*").unwrap(),
+/// Do not emit `Access-Control-Allow-Origin: *` — that lets arbitrary
+/// browser tabs read API responses when unauthenticated mode is on.
+fn cors_headers_for_request(request_headers: &[(String, String)]) -> Vec<Header> {
+    let mut headers = vec![
         Header::from_bytes("Access-Control-Allow-Methods", "GET, POST, OPTIONS").unwrap(),
         Header::from_bytes(
             "Access-Control-Allow-Headers",
@@ -341,7 +347,19 @@ fn cors_headers() -> Vec<Header> {
         )
         .unwrap(),
         Header::from_bytes("Content-Type", "application/json").unwrap(),
-    ]
+    ];
+    if let Some(origin) = request_headers
+        .iter()
+        .find(|(k, _)| k == "origin")
+        .map(|(_, v)| v.as_str())
+    {
+        if origin.starts_with("chrome-extension://") || origin == "null" {
+            if let Ok(h) = Header::from_bytes("Access-Control-Allow-Origin", origin) {
+                headers.push(h);
+            }
+        }
+    }
+    headers
 }
 
 fn split_url(url: &str) -> (String, &str) {
@@ -378,156 +396,6 @@ fn percent_decode(input: &str) -> String {
     String::from_utf8_lossy(&out).into_owned()
 }
 
-fn is_authorized(app: &AppHandle, query: &str, headers: &[(String, String)]) -> bool {
-    if !api_auth_required(app) {
-        return true;
-    }
-    let Some(token) = api_token(app) else {
-        return false;
-    };
-    let params = parse_query(query);
-    if params
-        .get("token")
-        .map(|v| constant_time_eq(v.as_bytes(), token.as_bytes()))
-        .unwrap_or(false)
-    {
-        return true;
-    }
-    headers.iter().any(|(key, value)| {
-        if key == "x-llm-wiki-token" {
-            return constant_time_eq(value.as_bytes(), token.as_bytes());
-        }
-        if key == "authorization" {
-            return value
-                .strip_prefix("Bearer ")
-                .map(|v| constant_time_eq(v.as_bytes(), token.as_bytes()))
-                .unwrap_or(false);
-        }
-        false
-    })
-}
-
-fn api_token(app: &AppHandle) -> Option<String> {
-    if let Ok(token) = std::env::var("LLM_WIKI_API_TOKEN") {
-        let trimmed = token.trim();
-        if !trimmed.is_empty() {
-            return Some(trimmed.to_string());
-        }
-    }
-    let parsed = load_app_state(app)?;
-    parsed
-        .get("apiConfig")
-        .and_then(|v| v.get("token"))
-        .and_then(Value::as_str)
-        .filter(|s| !s.is_empty())
-        .map(ToOwned::to_owned)
-}
-
-fn api_token_source(app: &AppHandle) -> &'static str {
-    if let Ok(token) = std::env::var("LLM_WIKI_API_TOKEN") {
-        if !token.trim().is_empty() {
-            return "env";
-        }
-    }
-    if load_app_state(app)
-        .and_then(|parsed| {
-            parsed
-                .get("apiConfig")
-                .and_then(|v| v.get("token"))
-                .and_then(Value::as_str)
-                .filter(|s| !s.is_empty())
-                .map(|_| ())
-        })
-        .is_some()
-    {
-        return "store";
-    }
-    "none"
-}
-
-fn api_auth_required(app: &AppHandle) -> bool {
-    !api_allow_unauthenticated(app)
-}
-
-fn api_allow_unauthenticated(app: &AppHandle) -> bool {
-    let Some(parsed) = load_app_state(app) else {
-        return false;
-    };
-    parsed
-        .get("apiConfig")
-        .and_then(|v| v.get("allowUnauthenticated"))
-        .and_then(Value::as_bool)
-        .unwrap_or(false)
-}
-
-/// Whether the API server should accept non-/health requests.
-///
-/// Defaults to `true` when no config has been written yet — keeps
-/// existing setups (env-token-only, hand-edited app-state.json) working
-/// after the kill-switch was introduced. New users still land in
-/// "enabled + no token = 401" which is fail-closed by virtue of the
-/// missing token, not the enable flag.
-fn api_enabled(app: &AppHandle) -> bool {
-    let Some(parsed) = load_app_state(app) else {
-        return true;
-    };
-    parsed
-        .get("apiConfig")
-        .and_then(|v| v.get("enabled"))
-        .and_then(Value::as_bool)
-        .unwrap_or(true)
-}
-
-fn api_mcp_enabled(app: &AppHandle) -> bool {
-    let Some(parsed) = load_app_state(app) else {
-        return false;
-    };
-    parsed
-        .get("apiConfig")
-        .and_then(|v| v.get("mcpEnabled"))
-        .and_then(Value::as_bool)
-        .unwrap_or(false)
-}
-
-fn constant_time_eq(left: &[u8], right: &[u8]) -> bool {
-    let max_len = left.len().max(right.len());
-    let mut diff = left.len() ^ right.len();
-    for i in 0..max_len {
-        let a = left.get(i).copied().unwrap_or(0);
-        let b = right.get(i).copied().unwrap_or(0);
-        diff |= (a ^ b) as usize;
-    }
-    diff == 0
-}
-
-fn load_app_state(app: &AppHandle) -> Option<Value> {
-    let now = Instant::now();
-    let lock = APP_STATE_CACHE.get_or_init(|| Mutex::new(None));
-    let mut previous = None;
-    if let Ok(cache) = lock.lock() {
-        if let Some(cached) = cache.as_ref() {
-            if now.duration_since(cached.loaded_at) < APP_STATE_CACHE_TTL {
-                return cached.value.clone();
-            }
-            previous = cached.value.clone();
-        }
-    }
-
-    let path = app.path().app_data_dir().ok()?.join("app-state.json");
-    let loaded = fs::read_to_string(path)
-        .ok()
-        .and_then(|raw| serde_json::from_str::<Value>(&raw).ok());
-    let value = loaded.or(previous);
-
-    if let Ok(mut cache) = lock.lock() {
-        *cache = Some(CachedAppState {
-            loaded_at: now,
-            value: value.clone(),
-        });
-    }
-    value
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct ProjectEntry {
     id: String,
@@ -550,7 +418,7 @@ fn load_projects(app: &AppHandle) -> Vec<ProjectEntry> {
     let current = normalize_path(&clip_server::current_project_path());
     let mut by_path: BTreeMap<String, ProjectEntry> = BTreeMap::new();
 
-    if let Some(parsed) = load_app_state(app) {
+    if let Some(parsed) = local_auth::load_app_state(app) {
         if let Some(registry) = parsed.get("projectRegistry").and_then(Value::as_object) {
             for (id, value) in registry {
                 let path = value.get("path").and_then(Value::as_str).unwrap_or("");
@@ -1151,6 +1019,76 @@ struct SearchRequest {
     query_embedding: Option<Vec<f32>>,
 }
 
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ChatRequest {
+    query: Option<String>,
+    message: Option<String>,
+    top_k: Option<usize>,
+    include_content: Option<bool>,
+}
+
+/// Retrieval-stage chat API for agent clients. Returns ranked wiki context
+/// (search hits + optional purpose excerpt). LLM completion remains the
+/// caller's responsibility — same split as the desktop UI pipeline.
+fn handle_chat(app: &AppHandle, project_id: &str, body: &str) -> ApiResponse {
+    let project = match resolve_project(app, project_id) {
+        Ok(project) => project,
+        Err(e) => return err(404, e),
+    };
+    let req: ChatRequest = match serde_json::from_str(body) {
+        Ok(req) => req,
+        Err(e) => return err(400, format!("Invalid JSON: {e}")),
+    };
+    let query = req
+        .query
+        .or(req.message)
+        .unwrap_or_default()
+        .trim()
+        .to_string();
+    if query.is_empty() {
+        return err(400, "query or message is required");
+    }
+    let top_k = req.top_k.unwrap_or(10).clamp(1, MAX_SEARCH_RESULTS);
+    let include_content = req.include_content.unwrap_or(true);
+    let query_embedding = match api_runtime::block_on(commands::search::resolve_query_embedding(
+        &query,
+        None,
+        load_embedding_config(app),
+    )) {
+        Ok(embedding) => embedding,
+        Err(e) => return err(400, e),
+    };
+    let search = match api_runtime::block_on(commands::search::search_project_inner(
+        project.path.clone(),
+        query.clone(),
+        top_k,
+        include_content,
+        query_embedding,
+    )) {
+        Ok(search) => search,
+        Err(e) => return err(500, e),
+    };
+    let purpose_excerpt = {
+        let path = Path::new(&project.path).join("purpose.md");
+        fs::read_to_string(path)
+            .ok()
+            .map(|content| content.chars().take(4_000).collect::<String>())
+            .filter(|s| !s.trim().is_empty())
+    };
+    ok(json!({
+        "ok": true,
+        "projectId": project.id,
+        "mode": "retrieval",
+        "query": query,
+        "purposeExcerpt": purpose_excerpt,
+        "note": "Retrieval-only chat API. Pass `context`/`results` to your agent LLM for completion.",
+        "tokenHits": search.token_hits,
+        "vectorHits": search.vector_hits,
+        "results": search.results,
+    }))
+}
+
 fn handle_search(app: &AppHandle, project_id: &str, body: &str) -> ApiResponse {
     let project = match resolve_project(app, project_id) {
         Ok(project) => project,
@@ -1166,7 +1104,7 @@ fn handle_search(app: &AppHandle, project_id: &str, body: &str) -> ApiResponse {
     let top_k = req.top_k.unwrap_or(10).clamp(1, MAX_SEARCH_RESULTS);
     let query = req.query;
     let query_embedding =
-        match tauri::async_runtime::block_on(commands::search::resolve_query_embedding(
+        match api_runtime::block_on(commands::search::resolve_query_embedding(
             &query,
             req.query_embedding,
             load_embedding_config(app),
@@ -1174,7 +1112,7 @@ fn handle_search(app: &AppHandle, project_id: &str, body: &str) -> ApiResponse {
             Ok(embedding) => embedding,
             Err(e) => return err(400, e),
         };
-    match tauri::async_runtime::block_on(commands::search::search_project_inner(
+    match api_runtime::block_on(commands::search::search_project_inner(
         project.path.clone(),
         query,
         top_k,
@@ -1195,7 +1133,7 @@ fn handle_search(app: &AppHandle, project_id: &str, body: &str) -> ApiResponse {
 }
 
 fn load_embedding_config(app: &AppHandle) -> Option<commands::search::SearchEmbeddingConfig> {
-    let parsed = load_app_state(app)?;
+    let parsed = local_auth::load_app_state(app)?;
     let value = parsed.get("embeddingConfig")?.clone();
     serde_json::from_value::<commands::search::SearchEmbeddingConfig>(value).ok()
 }
@@ -1387,7 +1325,7 @@ fn load_source_watch_config(
     app: &AppHandle,
     project_id: &str,
 ) -> Option<commands::file_sync::SourceWatchConfig> {
-    let parsed = load_app_state(app)?;
+    let parsed = local_auth::load_app_state(app)?;
     let settings = parsed.get("sourceWatchConfig").and_then(Value::as_object);
     if let Some(value) = settings
         .and_then(|s| s.get(project_id).or_else(|| s.get("default")))
@@ -1580,10 +1518,10 @@ mod tests {
 
     #[test]
     fn constant_time_eq_matches_equal_bytes_only() {
-        assert!(constant_time_eq(b"token", b"token"));
-        assert!(constant_time_eq(b"", b""));
-        assert!(!constant_time_eq(b"token", b"tokeN"));
-        assert!(!constant_time_eq(b"token", b"token-longer"));
+        assert!(local_auth::constant_time_eq(b"token", b"token"));
+        assert!(local_auth::constant_time_eq(b"", b""));
+        assert!(!local_auth::constant_time_eq(b"token", b"tokeN"));
+        assert!(!local_auth::constant_time_eq(b"token", b"token-longer"));
     }
 
     #[test]

--- a/src-tauri/src/clip_server.rs
+++ b/src-tauri/src/clip_server.rs
@@ -1,13 +1,20 @@
+use std::io::Read;
+use std::path::Path;
 use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::Mutex;
 use std::thread;
+use std::time::Duration;
+
+use tauri::AppHandle;
 use tiny_http::{Header, Method, Response, Server};
 
-static CURRENT_PROJECT: Mutex<String> = Mutex::new(String::new());
-static ALL_PROJECTS: Mutex<Vec<(String, String)>> = Mutex::new(Vec::new()); // (name, path)
-static PENDING_CLIPS: Mutex<Vec<(String, String)>> = Mutex::new(Vec::new()); // (projectPath, filePath)
+use crate::{local_auth, observability};
 
-/// Daemon status: 0=starting, 1=running, 2=port_conflict, 3=error
+static CURRENT_PROJECT: Mutex<String> = Mutex::new(String::new());
+static ALL_PROJECTS: Mutex<Vec<(String, String)>> = Mutex::new(Vec::new());
+static PENDING_CLIPS: Mutex<Vec<(String, String)>> = Mutex::new(Vec::new());
+static CLIP_APP: Mutex<Option<AppHandle>> = Mutex::new(None);
+
 static DAEMON_STATUS: AtomicU8 = AtomicU8::new(0);
 
 const PORT: u16 = 19827;
@@ -15,8 +22,8 @@ const MAX_BIND_RETRIES: u32 = 3;
 const MAX_RESTART_RETRIES: u32 = 10;
 const BIND_RETRY_DELAY_SECS: u64 = 2;
 const RESTART_DELAY_SECS: u64 = 5;
+const MAX_BODY_BYTES: usize = 5 * 1024 * 1024;
 
-/// Get current daemon status as a string
 pub fn get_daemon_status() -> &'static str {
     match DAEMON_STATUS.load(Ordering::Relaxed) {
         0 => "starting",
@@ -40,31 +47,36 @@ pub fn all_projects() -> Vec<(String, String)> {
         .unwrap_or_default()
 }
 
-pub fn start_clip_server() {
-    thread::spawn(|| {
+pub fn start_clip_server(app: AppHandle) {
+    if let Ok(mut guard) = CLIP_APP.lock() {
+        *guard = Some(app.clone());
+    }
+
+    thread::spawn(move || {
         let mut restart_count: u32 = 0;
 
         loop {
-            // Try to bind the port with retries
             let server = {
                 let mut last_err = String::new();
                 let mut bound = None;
                 for attempt in 1..=MAX_BIND_RETRIES {
-                    match Server::http(format!("127.0.0.1:{}", PORT)) {
+                    match Server::http(format!("127.0.0.1:{PORT}")) {
                         Ok(s) => {
                             bound = Some(s);
                             break;
                         }
                         Err(e) => {
-                            last_err = format!("{}", e);
-                            eprintln!(
-                                "[Clip Server] Bind attempt {}/{} failed: {}",
-                                attempt, MAX_BIND_RETRIES, e
+                            last_err = format!("{e}");
+                            observability::log_warn(
+                                "clip_server",
+                                "bind_failed",
+                                &[
+                                    ("attempt", &attempt.to_string()),
+                                    ("error", &last_err),
+                                ],
                             );
                             if attempt < MAX_BIND_RETRIES {
-                                thread::sleep(std::time::Duration::from_secs(
-                                    BIND_RETRY_DELAY_SECS,
-                                ));
+                                thread::sleep(Duration::from_secs(BIND_RETRY_DELAY_SECS));
                             }
                         }
                     }
@@ -72,275 +84,358 @@ pub fn start_clip_server() {
                 match bound {
                     Some(s) => s,
                     None => {
-                        eprintln!(
-                            "[Clip Server] Port {} unavailable after {} attempts: {}",
-                            PORT, MAX_BIND_RETRIES, last_err
+                        observability::log_error(
+                            "clip_server",
+                            "port_conflict",
+                            &[("port", &PORT.to_string()), ("error", &last_err)],
                         );
-                        DAEMON_STATUS.store(2, Ordering::Relaxed); // port_conflict
-                        return; // Don't retry on port conflict — needs user action
+                        DAEMON_STATUS.store(2, Ordering::Relaxed);
+                        return;
                     }
                 }
             };
 
-            DAEMON_STATUS.store(1, Ordering::Relaxed); // running
-            restart_count = 0; // Reset on successful bind
-            println!("[Clip Server] Listening on http://127.0.0.1:{}", PORT);
+            DAEMON_STATUS.store(1, Ordering::Relaxed);
+            restart_count = 0;
+            observability::log_info(
+                "clip_server",
+                "listening",
+                &[("url", &format!("http://127.0.0.1:{PORT}"))],
+            );
 
             for mut request in server.incoming_requests() {
-                let cors_headers = vec![
-                    Header::from_bytes("Access-Control-Allow-Origin", "*").unwrap(),
-                    Header::from_bytes("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
-                        .unwrap(),
-                    Header::from_bytes("Access-Control-Allow-Headers", "Content-Type").unwrap(),
-                    Header::from_bytes("Content-Type", "application/json").unwrap(),
-                ];
+                let request_id = observability::next_request_id();
+                let method = request.method().clone();
+                let url = request.url().to_string();
+                let headers = headers_from_request(&request);
 
-                // Handle CORS preflight
-                if request.method() == &Method::Options {
-                    let mut response = Response::from_string("").with_status_code(204);
-                    for h in &cors_headers {
-                        response.add_header(h.clone());
-                    }
-                    let _ = request.respond(response);
+                if method == Method::Options {
+                    respond_options(request, &headers);
                     continue;
                 }
 
-                let url = request.url().to_string();
-
-                match (request.method(), url.as_str()) {
-                    (&Method::Get, "/status") => {
-                        let body = r#"{"ok":true,"version":"0.1.0"}"#;
-                        let mut response = Response::from_string(body);
-                        for h in &cors_headers {
-                            response.add_header(h.clone());
-                        }
-                        let _ = request.respond(response);
-                    }
-                    (&Method::Get, "/project") => {
-                        let path = CURRENT_PROJECT.lock().unwrap().clone();
-                        // serde_json handles backslash escaping so a Windows
-                        // path that somehow still contains `\` won't break
-                        // the JSON parser on the client.
-                        let body = serde_json::json!({
+                let app = clip_app_handle();
+                let (status, body) = match (method.clone(), url.as_str()) {
+                    (Method::Get, "/status") => (
+                        200,
+                        serde_json::json!({
                             "ok": true,
-                            "path": path,
+                            "version": env!("CARGO_PKG_VERSION"),
+                            "authRequired": app.as_ref().map(local_auth::api_auth_required).unwrap_or(true),
+                            "authConfigured": app.as_ref().and_then(|a| local_auth::api_token(a)).is_some(),
                         })
-                        .to_string();
-                        let mut response = Response::from_string(body);
-                        for h in &cors_headers {
-                            response.add_header(h.clone());
-                        }
-                        let _ = request.respond(response);
-                    }
-                    (&Method::Post, "/project") => {
-                        let mut body = String::new();
-                        if let Err(e) = request.as_reader().read_to_string(&mut body) {
-                            let err =
-                                format!(r#"{{"ok":false,"error":"Failed to read body: {}"}}"#, e);
-                            let mut response = Response::from_string(err).with_status_code(400);
-                            for h in &cors_headers {
-                                response.add_header(h.clone());
-                            }
-                            let _ = request.respond(response);
-                            continue;
-                        }
-
-                        let result = handle_set_project(&body);
-                        let status = if result.contains(r#""ok":true"#) {
-                            200
+                        .to_string(),
+                    ),
+                    (Method::Get, "/project") => {
+                        if !clip_authorized(app.as_ref(), &headers, &request_id, "/project") {
+                            (401, r#"{"ok":false,"error":"Unauthorized"}"#.to_string())
                         } else {
-                            400
-                        };
-                        let mut response = Response::from_string(result).with_status_code(status);
-                        for h in &cors_headers {
-                            response.add_header(h.clone());
+                            let path = CURRENT_PROJECT.lock().unwrap().clone();
+                            (
+                                200,
+                                serde_json::json!({ "ok": true, "path": path }).to_string(),
+                            )
                         }
-                        let _ = request.respond(response);
                     }
-                    (&Method::Get, "/projects") => {
-                        let projects = ALL_PROJECTS.lock().unwrap().clone();
-                        let current = CURRENT_PROJECT.lock().unwrap().clone();
-                        // serde_json for proper escaping of `\`, `"`, and any
-                        // other characters that might appear in a project name
-                        // or path. Previously only `"` was escaped by hand,
-                        // which broke on Windows paths containing backslashes.
-                        let items: Vec<serde_json::Value> = projects
-                            .iter()
-                            .map(|(name, path)| {
-                                serde_json::json!({
-                                    "name": name,
-                                    "path": path,
-                                    "current": path == &current,
+                    (Method::Post, "/project") => {
+                        if !clip_authorized(app.as_ref(), &headers, &request_id, "/project") {
+                            (401, r#"{"ok":false,"error":"Unauthorized"}"#.to_string())
+                        } else {
+                            match read_limited_body(&mut request) {
+                                Ok(body) => {
+                                    let result = handle_set_project(&body);
+                                    let status = if result.contains(r#""ok":true"#) {
+                                        200
+                                    } else {
+                                        400
+                                    };
+                                    (status, result)
+                                }
+                                Err(e) => (400, e),
+                            }
+                        }
+                    }
+                    (Method::Get, "/projects") => {
+                        if !clip_authorized(app.as_ref(), &headers, &request_id, "/projects") {
+                            (401, r#"{"ok":false,"error":"Unauthorized"}"#.to_string())
+                        } else {
+                            let projects = ALL_PROJECTS.lock().unwrap().clone();
+                            let current = CURRENT_PROJECT.lock().unwrap().clone();
+                            let items: Vec<serde_json::Value> = projects
+                                .iter()
+                                .map(|(name, path)| {
+                                    serde_json::json!({
+                                        "name": name,
+                                        "path": path,
+                                        "current": path == &current,
+                                    })
                                 })
-                            })
-                            .collect();
-                        let body = serde_json::json!({
-                            "ok": true,
-                            "projects": items,
-                        })
-                        .to_string();
-                        let mut response = Response::from_string(body);
-                        for h in &cors_headers {
-                            response.add_header(h.clone());
+                                .collect();
+                            (
+                                200,
+                                serde_json::json!({ "ok": true, "projects": items }).to_string(),
+                            )
                         }
-                        let _ = request.respond(response);
                     }
-                    (&Method::Post, "/projects") => {
-                        let mut body = String::new();
-                        if request.as_reader().read_to_string(&mut body).is_ok() {
-                            if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&body) {
-                                if let Some(arr) = parsed["projects"].as_array() {
-                                    let mut projects = ALL_PROJECTS.lock().unwrap();
-                                    projects.clear();
-                                    for item in arr {
-                                        let name = item["name"].as_str().unwrap_or("").to_string();
-                                        let path = item["path"].as_str().unwrap_or("").to_string();
-                                        if !path.is_empty() {
-                                            projects.push((name, path));
+                    (Method::Post, "/projects") => {
+                        if !clip_authorized(app.as_ref(), &headers, &request_id, "/projects") {
+                            (401, r#"{"ok":false,"error":"Unauthorized"}"#.to_string())
+                        } else {
+                            let status_body = match read_limited_body(&mut request) {
+                                Ok(body) => {
+                                    if let Ok(parsed) =
+                                        serde_json::from_str::<serde_json::Value>(&body)
+                                    {
+                                        if let Some(arr) = parsed["projects"].as_array() {
+                                            let mut projects = ALL_PROJECTS.lock().unwrap();
+                                            projects.clear();
+                                            for item in arr {
+                                                let name =
+                                                    item["name"].as_str().unwrap_or("").to_string();
+                                                let path =
+                                                    item["path"].as_str().unwrap_or("").to_string();
+                                                if validate_registered_project_path(&path).is_ok() {
+                                                    projects.push((name, path));
+                                                }
+                                            }
                                         }
                                     }
+                                    (200, r#"{"ok":true}"#.to_string())
                                 }
-                            }
+                                Err(e) => (400, e),
+                            };
+                            status_body
                         }
-                        let mut response = Response::from_string(r#"{"ok":true}"#);
-                        for h in &cors_headers {
-                            response.add_header(h.clone());
-                        }
-                        let _ = request.respond(response);
                     }
-                    (&Method::Get, "/clips/pending") => {
-                        let mut pending = PENDING_CLIPS.lock().unwrap();
-                        // Use serde_json for proper escaping of both quotes
-                        // and backslashes — hand-rolled escaping previously
-                        // produced invalid JSON on Windows paths containing
-                        // \r, \s, etc.
-                        let clips_json: Vec<serde_json::Value> = pending
-                            .iter()
-                            .map(|(proj, file)| {
-                                serde_json::json!({
-                                    "projectPath": proj,
-                                    "filePath": file,
-                                })
-                            })
-                            .collect();
-                        let body = serde_json::json!({
-                            "ok": true,
-                            "clips": clips_json,
-                        })
-                        .to_string();
-                        pending.clear();
-                        let mut response = Response::from_string(body);
-                        for h in &cors_headers {
-                            response.add_header(h.clone());
-                        }
-                        let _ = request.respond(response);
-                    }
-                    (&Method::Post, "/clip") => {
-                        let mut body = String::new();
-                        if let Err(e) = request.as_reader().read_to_string(&mut body) {
-                            let err =
-                                format!(r#"{{"ok":false,"error":"Failed to read body: {}"}}"#, e);
-                            let mut response = Response::from_string(err).with_status_code(400);
-                            for h in &cors_headers {
-                                response.add_header(h.clone());
-                            }
-                            let _ = request.respond(response);
-                            continue;
-                        }
-
-                        let result = handle_clip(&body);
-                        let status = if result.contains(r#""ok":true"#) {
-                            200
+                    (Method::Get, "/clips/pending") => {
+                        if !clip_authorized(app.as_ref(), &headers, &request_id, "/clips/pending")
+                        {
+                            (401, r#"{"ok":false,"error":"Unauthorized"}"#.to_string())
                         } else {
-                            500
-                        };
-                        let mut response = Response::from_string(result).with_status_code(status);
-                        for h in &cors_headers {
-                            response.add_header(h.clone());
+                            let mut pending = PENDING_CLIPS.lock().unwrap();
+                            let clips_json: Vec<serde_json::Value> = pending
+                                .iter()
+                                .map(|(proj, file)| {
+                                    serde_json::json!({
+                                        "projectPath": proj,
+                                        "filePath": file,
+                                    })
+                                })
+                                .collect();
+                            let body = serde_json::json!({
+                                "ok": true,
+                                "clips": clips_json,
+                            })
+                            .to_string();
+                            pending.clear();
+                            (200, body)
                         }
-                        let _ = request.respond(response);
                     }
-                    _ => {
-                        let body = r#"{"ok":false,"error":"Not found"}"#;
-                        let mut response = Response::from_string(body).with_status_code(404);
-                        for h in &cors_headers {
-                            response.add_header(h.clone());
+                    (Method::Post, "/clip") => {
+                        if !clip_authorized(app.as_ref(), &headers, &request_id, "/clip") {
+                            (401, r#"{"ok":false,"error":"Unauthorized"}"#.to_string())
+                        } else {
+                            match read_limited_body(&mut request) {
+                                Ok(body) => {
+                                    let result = handle_clip(&body);
+                                    let status = if result.contains(r#""ok":true"#) {
+                                        200
+                                    } else {
+                                        500
+                                    };
+                                    (status, result)
+                                }
+                                Err(e) => (400, e),
+                            }
                         }
-                        let _ = request.respond(response);
                     }
-                }
+                    _ => (404, r#"{"ok":false,"error":"Not found"}"#.to_string()),
+                };
+
+                respond_json(request, &headers, status, &body);
             }
 
-            // Server loop exited (shouldn't happen normally)
-            DAEMON_STATUS.store(3, Ordering::Relaxed); // error
+            DAEMON_STATUS.store(3, Ordering::Relaxed);
             restart_count += 1;
-
             if restart_count >= MAX_RESTART_RETRIES {
-                eprintln!(
-                    "[Clip Server] Exceeded max restarts ({}). Giving up.",
-                    MAX_RESTART_RETRIES
+                observability::log_error(
+                    "clip_server",
+                    "max_restarts",
+                    &[("attempts", &MAX_RESTART_RETRIES.to_string())],
                 );
                 return;
             }
-
-            eprintln!(
-                "[Clip Server] Crashed. Restarting in {}s (attempt {}/{})",
-                RESTART_DELAY_SECS, restart_count, MAX_RESTART_RETRIES
-            );
-            thread::sleep(std::time::Duration::from_secs(RESTART_DELAY_SECS));
+            thread::sleep(Duration::from_secs(RESTART_DELAY_SECS));
         }
     });
+}
+
+fn clip_app_handle() -> Option<AppHandle> {
+    CLIP_APP.lock().ok().and_then(|g| g.clone())
+}
+
+fn clip_authorized(
+    app: Option<&AppHandle>,
+    headers: &[(String, String)],
+    request_id: &str,
+    path: &str,
+) -> bool {
+    let Some(app) = app else {
+        return false;
+    };
+    if local_auth::is_authorized(app, headers) {
+        return true;
+    }
+    local_auth::log_auth_denied("clip_server", path, request_id, app);
+    false
+}
+
+fn headers_from_request(request: &tiny_http::Request) -> Vec<(String, String)> {
+    request
+        .headers()
+        .iter()
+        .map(|header| {
+            (
+                header.field.as_str().to_ascii_lowercase().to_string(),
+                header.value.as_str().to_string(),
+            )
+        })
+        .collect()
+}
+
+fn read_limited_body(request: &mut tiny_http::Request) -> Result<String, String> {
+    let mut limited = request.as_reader().take(MAX_BODY_BYTES as u64 + 1);
+    let mut bytes = Vec::new();
+    limited
+        .read_to_end(&mut bytes)
+        .map_err(|e| format!(r#"{{"ok":false,"error":"Failed to read body: {e}"}}"#))?;
+    if bytes.len() > MAX_BODY_BYTES {
+        return Err(r#"{"ok":false,"error":"Request body too large"}"#.to_string());
+    }
+    String::from_utf8(bytes)
+        .map_err(|_| r#"{"ok":false,"error":"Request body must be UTF-8"}"#.to_string())
+}
+
+fn respond_json(
+    request: tiny_http::Request,
+    request_headers: &[(String, String)],
+    status: u16,
+    body: &str,
+) {
+    let mut response = Response::from_string(body).with_status_code(status);
+    for header in cors_headers_for_request(request_headers) {
+        response.add_header(header);
+    }
+    let _ = request.respond(response);
+}
+
+fn respond_options(request: tiny_http::Request, request_headers: &[(String, String)]) {
+    let mut response = Response::empty(tiny_http::StatusCode(204));
+    for header in cors_headers_for_request(request_headers) {
+        response.add_header(header);
+    }
+    let _ = request.respond(response);
+}
+
+fn cors_headers_for_request(request_headers: &[(String, String)]) -> Vec<Header> {
+    let mut headers = vec![
+        Header::from_bytes("Access-Control-Allow-Methods", "GET, POST, OPTIONS").unwrap(),
+        Header::from_bytes(
+            "Access-Control-Allow-Headers",
+            "Content-Type, Authorization, X-LLM-Wiki-Token",
+        )
+        .unwrap(),
+        Header::from_bytes("Content-Type", "application/json").unwrap(),
+    ];
+    if let Some(origin) = request_headers
+        .iter()
+        .find(|(k, _)| k == "origin")
+        .map(|(_, v)| v.as_str())
+    {
+        if origin.starts_with("chrome-extension://") || origin == "null" {
+            if let Ok(h) = Header::from_bytes("Access-Control-Allow-Origin", origin) {
+                headers.push(h);
+            }
+        }
+    }
+    headers
+}
+
+fn paths_equal(a: &str, b: &str) -> bool {
+    let a = a.replace('\\', "/").trim_end_matches('/').to_lowercase();
+    let b = b.replace('\\', "/").trim_end_matches('/').to_lowercase();
+    a == b
+}
+
+fn validate_registered_project_path(path: &str) -> Result<String, String> {
+    let normalized = path.replace('\\', "/");
+    if normalized.is_empty() {
+        return Err("project path is empty".to_string());
+    }
+    let root = Path::new(&normalized);
+    if !root.join("schema.md").exists() || !root.join("wiki").is_dir() {
+        return Err("path is not a valid wiki project".to_string());
+    }
+    let current = current_project_path();
+    let known = all_projects()
+        .into_iter()
+        .map(|(_, path)| path)
+        .chain(std::iter::once(current))
+        .filter(|p| !p.is_empty())
+        .any(|p| paths_equal(&p, &normalized));
+    if !known {
+        return Err("projectPath is not registered with the desktop app".to_string());
+    }
+    Ok(normalized)
 }
 
 fn handle_set_project(body: &str) -> String {
     let parsed: serde_json::Value = match serde_json::from_str(body) {
         Ok(v) => v,
-        Err(e) => return format!(r#"{{"ok":false,"error":"Invalid JSON: {}"}}"#, e),
+        Err(e) => return format!(r#"{{"ok":false,"error":"Invalid JSON: {e}"}}"#),
     };
 
     let path = match parsed["path"].as_str() {
-        // Normalize to forward slashes on ingress so downstream
-        // comparisons against frontend-normalized paths succeed.
         Some(p) => p.replace('\\', "/"),
         None => return r#"{"ok":false,"error":"path field is required"}"#.to_string(),
     };
+
+    if let Err(e) = validate_registered_project_path(&path) {
+        return format!(r#"{{"ok":false,"error":"{e}"}}"#);
+    }
 
     match CURRENT_PROJECT.lock() {
         Ok(mut guard) => {
             *guard = path;
             r#"{"ok":true}"#.to_string()
         }
-        Err(e) => format!(r#"{{"ok":false,"error":"Lock error: {}"}}"#, e),
+        Err(e) => format!(r#"{{"ok":false,"error":"Lock error: {e}"}}"#),
     }
 }
 
 fn handle_clip(body: &str) -> String {
     let parsed: serde_json::Value = match serde_json::from_str(body) {
         Ok(v) => v,
-        Err(e) => return format!(r#"{{"ok":false,"error":"Invalid JSON: {}"}}"#, e),
+        Err(e) => return format!(r#"{{"ok":false,"error":"Invalid JSON: {e}"}}"#),
     };
 
     let title = parsed["title"].as_str().unwrap_or("Untitled");
     let url = parsed["url"].as_str().unwrap_or("");
     let content = parsed["content"].as_str().unwrap_or("");
 
-    // Use projectPath from request body, or fall back to globally-set project path
     let project_path_from_body = parsed["projectPath"].as_str().unwrap_or("").to_string();
     let project_path = if project_path_from_body.is_empty() {
         match CURRENT_PROJECT.lock() {
             Ok(guard) => guard.clone(),
-            Err(e) => return format!(r#"{{"ok":false,"error":"Lock error: {}"}}"#, e),
+            Err(e) => return format!(r#"{{"ok":false,"error":"Lock error: {e}"}}"#),
         }
     } else {
         project_path_from_body
     };
-    // Normalize to forward slashes so string comparisons against the
-    // frontend-side project path (already normalized) succeed on Windows.
     let project_path = project_path.replace('\\', "/");
 
-    if project_path.is_empty() {
-        return r#"{"ok":false,"error":"projectPath is required (set via POST /project or include in request body)"}"#
-            .to_string();
+    if let Err(e) = validate_registered_project_path(&project_path) {
+        return format!(r#"{{"ok":false,"error":"{e}"}}"#);
     }
 
     if content.is_empty() {
@@ -350,7 +445,6 @@ fn handle_clip(body: &str) -> String {
     let date = chrono::Local::now().format("%Y-%m-%d").to_string();
     let date_compact = chrono::Local::now().format("%Y%m%d").to_string();
 
-    // Generate slug from title
     let slug_raw: String = title
         .chars()
         .map(|c| {
@@ -367,35 +461,21 @@ fn handle_clip(body: &str) -> String {
         .to_lowercase();
     let slug: String = slug_raw.chars().take(50).collect();
 
-    let base_name = format!("{}-{}", slug, date_compact);
-    // Use PathBuf for cross-platform path construction
-    let dir_path = std::path::Path::new(&project_path)
-        .join("raw")
-        .join("sources");
+    let base_name = format!("{slug}-{date_compact}");
+    let dir_path = Path::new(&project_path).join("raw").join("sources");
 
-    // Ensure directory exists
     if let Err(e) = std::fs::create_dir_all(&dir_path) {
-        return format!(
-            r#"{{"ok":false,"error":"Failed to create directory: {}"}}"#,
-            e
-        );
+        return format!(r#"{{"ok":false,"error":"Failed to create directory: {e}"}}"#);
     }
 
-    // Find unique filename
-    let mut file_path = dir_path.join(format!("{}.md", base_name));
+    let mut file_path = dir_path.join(format!("{base_name}.md"));
     let mut counter = 2u32;
     while file_path.exists() {
-        file_path = dir_path.join(format!("{}-{}.md", base_name, counter));
+        file_path = dir_path.join(format!("{base_name}-{counter}.md"));
         counter += 1;
     }
-    // Normalize to forward slashes so the string compares cleanly against
-    // frontend-side project paths (already normalized) and survives JSON
-    // serialization (the hand-rolled serializer below doesn't escape
-    // backslashes; a Windows path like `...\raw\sources\foo.md` would
-    // produce invalid JSON escape sequences for `\r` / `\s` / etc).
     let file_path = file_path.to_string_lossy().replace('\\', "/");
 
-    // Build markdown content with web-clip origin
     let markdown = format!(
         "---\ntype: clip\ntitle: \"{}\"\nurl: \"{}\"\nclipped: {}\norigin: web-clip\nsources: []\ntags: [web-clip]\n---\n\n# {}\n\nSource: {}\n\n{}\n",
         title.replace('"', r#"\""#),
@@ -407,19 +487,17 @@ fn handle_clip(body: &str) -> String {
     );
 
     if let Err(e) = std::fs::write(&file_path, &markdown) {
-        return format!(r#"{{"ok":false,"error":"Failed to write file: {}"}}"#, e);
+        return format!(r#"{{"ok":false,"error":"Failed to write file: {e}"}}"#);
     }
 
-    // Compute relative path using Path for cross-platform separator handling
     let relative_path = {
-        let full = std::path::Path::new(&file_path);
-        let base = std::path::Path::new(&project_path);
+        let full = Path::new(&file_path);
+        let base = Path::new(&project_path);
         full.strip_prefix(base)
             .map(|p| p.to_string_lossy().replace('\\', "/"))
             .unwrap_or_else(|_| file_path.replace('\\', "/"))
     };
 
-    // Add to pending clips for frontend to pick up and auto-ingest
     if let Ok(mut pending) = PENDING_CLIPS.lock() {
         pending.push((project_path, file_path.clone()));
     }
@@ -429,4 +507,38 @@ fn handle_clip(body: &str) -> String {
         "path": relative_path,
     })
     .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn temp_project() -> (String, std::path::PathBuf) {
+        let id = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("llm-wiki-clip-test-{id}"));
+        fs::create_dir_all(root.join("wiki")).unwrap();
+        fs::write(root.join("schema.md"), "# schema").unwrap();
+        let path = root.to_string_lossy().replace('\\', "/");
+        (path, root)
+    }
+
+    #[test]
+    fn rejects_unregistered_project_paths() {
+        let (path, root) = temp_project();
+        assert!(validate_registered_project_path(&path).is_err());
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn accepts_registered_project_paths() {
+        let (path, root) = temp_project();
+        ALL_PROJECTS.lock().unwrap().push(("t".into(), path.clone()));
+        assert!(validate_registered_project_path(&path).is_ok());
+        ALL_PROJECTS.lock().unwrap().clear();
+        let _ = fs::remove_dir_all(root);
+    }
 }

--- a/src-tauri/src/commands/fs.rs
+++ b/src-tauri/src/commands/fs.rs
@@ -9,6 +9,7 @@ use office_oxide::Document;
 
 use crate::commands::file_sync;
 use crate::panic_guard::run_guarded;
+use crate::project_sandbox;
 use crate::types::wiki::FileNode;
 
 /// Known binary formats that need special extraction
@@ -66,7 +67,9 @@ pub async fn read_file(path: String, extract_images: Option<bool>) -> Result<Str
     // pool where blocking-for-seconds is the contract.
     tauri::async_runtime::spawn_blocking(move || {
         run_guarded("read_file", || {
-            let p = Path::new(&path);
+            let sandbox_path = project_sandbox::validate_sandboxed_path("read_file", &path)?;
+            let p = sandbox_path.as_path();
+            let path_str = sandbox_path.to_string_lossy().to_string();
             let ext = p
                 .extension()
                 .and_then(|e| e.to_str())
@@ -80,14 +83,14 @@ pub async fn read_file(path: String, extract_images: Option<bool>) -> Result<Str
             let include_images = extract_images.unwrap_or(true);
 
             match ext.as_str() {
-                "pdf" => extract_pdf_text(&path, include_images),
-                e if OFFICE_EXTS.contains(&e) => extract_office_text(&path, e),
+                "pdf" => extract_pdf_text(&path_str, include_images),
+                e if OFFICE_EXTS.contains(&e) => extract_office_text(&path_str, e),
                 e if IMAGE_EXTS.contains(&e) => {
-                    let size = fs::metadata(&path).map(|m| m.len()).unwrap_or(0);
+                    let size = fs::metadata(p).map(|m| m.len()).unwrap_or(0);
                     Ok(format!("[Image: {} ({:.1} KB)]", p.file_name().unwrap_or_default().to_string_lossy(), size as f64 / 1024.0))
                 }
                 e if MEDIA_EXTS.contains(&e) => {
-                    let size = fs::metadata(&path).map(|m| m.len()).unwrap_or(0);
+                    let size = fs::metadata(p).map(|m| m.len()).unwrap_or(0);
                     Ok(format!("[Media: {} ({:.1} MB)]", p.file_name().unwrap_or_default().to_string_lossy(), size as f64 / 1048576.0))
                 }
                 e if LEGACY_DOC_EXTS.contains(&e) => {
@@ -95,16 +98,16 @@ pub async fn read_file(path: String, extract_images: Option<bool>) -> Result<Str
                         p.file_name().unwrap_or_default().to_string_lossy(), e))
                 }
                 _ => {
-                    match fs::read_to_string(&path) {
+                    match fs::read_to_string(p) {
                         Ok(content) => Ok(content),
                         Err(e) => {
                             let exists = p.exists();
                             if !exists {
-                                Err(format!("File does not exist: '{}'", path))
+                                Err(format!("File does not exist: '{}'", path_str))
                             } else {
                                 Err(format!(
                                     "Failed to read file '{}' as text: {} (likely binary, locked, or non-UTF-8)",
-                                    path, e,
+                                    path_str, e,
                                 ))
                             }
                         }
@@ -123,7 +126,9 @@ pub async fn preprocess_file(path: String) -> Result<String, String> {
     // See `read_file` above for why `spawn_blocking` is required.
     tauri::async_runtime::spawn_blocking(move || {
         run_guarded("preprocess_file", || {
-            let p = Path::new(&path);
+            let sandbox_path = project_sandbox::validate_sandboxed_path("preprocess_file", &path)?;
+            let p = sandbox_path.as_path();
+            let path_str = sandbox_path.to_string_lossy().to_string();
             let ext = p
                 .extension()
                 .and_then(|e| e.to_str())
@@ -131,8 +136,8 @@ pub async fn preprocess_file(path: String) -> Result<String, String> {
                 .to_lowercase();
 
             let text = match ext.as_str() {
-                "pdf" => extract_pdf_text(&path, false)?,
-                e if OFFICE_EXTS.contains(&e) => extract_office_text(&path, e)?,
+                "pdf" => extract_pdf_text(&path_str, false)?,
+                e if OFFICE_EXTS.contains(&e) => extract_office_text(&path_str, e)?,
                 _ => return Ok("no preprocessing needed".to_string()),
             };
 
@@ -973,14 +978,15 @@ pub async fn write_file(path: String, contents: String) -> Result<(), String> {
     tauri::async_runtime::spawn_blocking(move || {
         run_guarded("write_file", || {
             require_absolute_path("write_file", &path)?;
-            let p = Path::new(&path);
+            let path = project_sandbox::validate_sandboxed_path("write_file", &path)?;
+            let p = path.as_path();
             if let Some(parent) = p.parent() {
                 fs::create_dir_all(parent)
-                    .map_err(|e| format!("Failed to create parent dirs for '{}': {}", path, e))?;
+                    .map_err(|e| format!("Failed to create parent dirs for '{}': {}", p.display(), e))?;
             }
             file_sync::mark_app_write_path(p);
-            fs::write(&path, contents)
-                .map_err(|e| format!("Failed to write file '{}': {}", path, e))?;
+            fs::write(p, contents)
+                .map_err(|e| format!("Failed to write file '{}': {}", p.display(), e))?;
             file_sync::mark_app_write_path(p);
             Ok(())
         })
@@ -996,17 +1002,18 @@ pub async fn write_file_base64(path: String, base64: String) -> Result<(), Strin
     tauri::async_runtime::spawn_blocking(move || {
         run_guarded("write_file_base64", || {
             require_absolute_path("write_file_base64", &path)?;
+            let sandbox_path = project_sandbox::validate_sandboxed_path("write_file_base64", &path)?;
+            let p = sandbox_path.as_path();
             let bytes = B64
                 .decode(base64.as_bytes())
-                .map_err(|e| format!("Invalid base64 for '{}': {}", path, e))?;
-            let p = Path::new(&path);
+                .map_err(|e| format!("Invalid base64 for '{}': {}", p.display(), e))?;
             if let Some(parent) = p.parent() {
                 fs::create_dir_all(parent)
-                    .map_err(|e| format!("Failed to create parent dirs for '{}': {}", path, e))?;
+                    .map_err(|e| format!("Failed to create parent dirs for '{}': {}", p.display(), e))?;
             }
             file_sync::mark_app_write_path(p);
-            fs::write(&path, bytes)
-                .map_err(|e| format!("Failed to write binary file '{}': {}", path, e))?;
+            fs::write(p, bytes)
+                .map_err(|e| format!("Failed to write binary file '{}': {}", p.display(), e))?;
             file_sync::mark_app_write_path(p);
             Ok(())
         })
@@ -1020,7 +1027,8 @@ pub async fn write_file_atomic(path: String, contents: String) -> Result<(), Str
     tauri::async_runtime::spawn_blocking(move || {
         run_guarded("write_file_atomic", || {
             require_absolute_path("write_file_atomic", &path)?;
-            let p = Path::new(&path);
+            let sandbox_path = project_sandbox::validate_sandboxed_path("write_file_atomic", &path)?;
+            let p = sandbox_path.as_path();
             if let Some(parent) = p.parent() {
                 fs::create_dir_all(parent)
                     .map_err(|e| format!("Failed to create parent dirs for '{}': {}", path, e))?;
@@ -1064,12 +1072,13 @@ pub async fn write_file_atomic(path: String, contents: String) -> Result<(), Str
 pub async fn list_directory(path: String) -> Result<Vec<FileNode>, String> {
     tauri::async_runtime::spawn_blocking(move || {
         run_guarded("list_directory", || {
-            let p = Path::new(&path);
+            let sandbox_path = project_sandbox::validate_sandboxed_path("list_directory", &path)?;
+            let p = sandbox_path.as_path();
             if !p.exists() {
-                return Err(format!("Path does not exist: '{}'", path));
+                return Err(format!("Path does not exist: '{}'", p.display()));
             }
             if !p.is_dir() {
-                return Err(format!("Path is not a directory: '{}'", path));
+                return Err(format!("Path is not a directory: '{}'", p.display()));
             }
             let nodes = build_tree(p, 0, 30)?;
             Ok(nodes)
@@ -1146,13 +1155,15 @@ fn build_tree(dir: &Path, depth: usize, max_depth: usize) -> Result<Vec<FileNode
 pub async fn copy_file(source: String, destination: String) -> Result<(), String> {
     tauri::async_runtime::spawn_blocking(move || {
         run_guarded("copy_file", || {
-            let dest = Path::new(&destination);
+            let source_path = project_sandbox::validate_sandboxed_path("copy_file", &source)?;
+            let dest_path = project_sandbox::validate_sandboxed_path("copy_file", &destination)?;
+            let dest = dest_path.as_path();
             if let Some(parent) = dest.parent() {
                 fs::create_dir_all(parent)
                     .map_err(|e| format!("Failed to create parent dirs: {}", e))?;
             }
             file_sync::mark_app_write_path(dest);
-            fs::copy(&source, &destination)
+            fs::copy(source_path.as_path(), dest)
                 .map_err(|e| format!("Failed to copy '{}' to '{}': {}", source, destination, e))?;
             file_sync::mark_app_write_path(dest);
             Ok(())
@@ -1168,8 +1179,10 @@ pub async fn copy_file(source: String, destination: String) -> Result<(), String
 pub async fn copy_directory(source: String, destination: String) -> Result<Vec<String>, String> {
     tauri::async_runtime::spawn_blocking(move || {
         run_guarded("copy_directory", || {
-            let src = Path::new(&source);
-            let dest = Path::new(&destination);
+            let src = project_sandbox::validate_sandboxed_path("copy_directory", &source)?;
+            let dest = project_sandbox::validate_sandboxed_path("copy_directory", &destination)?;
+            let src = src.as_path();
+            let dest = dest.as_path();
             file_sync::mark_app_write_path(dest);
 
             if !src.is_dir() {
@@ -1223,14 +1236,16 @@ pub async fn copy_directory(source: String, destination: String) -> Result<Vec<S
 pub async fn delete_file(path: String) -> Result<(), String> {
     tauri::async_runtime::spawn_blocking(move || {
         run_guarded("delete_file", || {
-            let p = Path::new(&path);
+            let sandbox_path = project_sandbox::validate_sandboxed_path("delete_file", &path)?;
+            let p = sandbox_path.as_path();
+            let path_display = p.to_string_lossy().to_string();
             file_sync::mark_app_write_path(p);
             if p.is_dir() {
-                remove_path_with_retry(&path, true)
-                    .map_err(|e| format!("Failed to delete directory '{}': {}", path, e))?;
+                remove_path_with_retry(&path_display, true)
+                    .map_err(|e| format!("Failed to delete directory '{}': {}", path_display, e))?;
             } else {
-                remove_path_with_retry(&path, false)
-                    .map_err(|e| format!("Failed to delete file '{}': {}", path, e))?;
+                remove_path_with_retry(&path_display, false)
+                    .map_err(|e| format!("Failed to delete file '{}': {}", path_display, e))?;
             }
             file_sync::mark_app_write_path(p);
             Ok(())
@@ -1425,7 +1440,8 @@ pub async fn create_directory(path: String) -> Result<(), String> {
     tauri::async_runtime::spawn_blocking(move || {
         run_guarded("create_directory", || {
             require_absolute_path("create_directory", &path)?;
-            fs::create_dir_all(&path)
+            let sandbox_path = project_sandbox::validate_sandboxed_path("create_directory", &path)?;
+            fs::create_dir_all(sandbox_path.as_path())
                 .map_err(|e| format!("Failed to create directory '{}': {}", path, e))
         })
     })
@@ -1457,8 +1473,10 @@ pub async fn read_file_as_base64(path: String) -> Result<FileBase64, String> {
     use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
     tauri::async_runtime::spawn_blocking(move || {
         run_guarded("read_file_as_base64", || {
-            let bytes = fs::read(&path).map_err(|e| format!("Failed to read '{}': {}", path, e))?;
-            let p = Path::new(&path);
+            let sandbox_path =
+                project_sandbox::validate_sandboxed_path("read_file_as_base64", &path)?;
+            let p = sandbox_path.as_path();
+            let bytes = fs::read(p).map_err(|e| format!("Failed to read '{}': {}", path, e))?;
             let ext = p
                 .extension()
                 .and_then(|e| e.to_str())
@@ -1495,7 +1513,10 @@ pub async fn file_exists(path: String) -> Result<bool, String> {
     // every fs command rather than carving out an exception that's
     // easy to violate later.
     tauri::async_runtime::spawn_blocking(move || {
-        run_guarded("file_exists", || Ok(Path::new(&path).exists()))
+        run_guarded("file_exists", || {
+            let sandbox_path = project_sandbox::validate_sandboxed_path("file_exists", &path)?;
+            Ok(sandbox_path.exists())
+        })
     })
     .await
     .map_err(|e| format!("file_exists blocking task join error: {e}"))?
@@ -1507,7 +1528,9 @@ pub async fn file_exists(path: String) -> Result<bool, String> {
 pub async fn get_file_modified_time(path: String) -> Result<u64, String> {
     tauri::async_runtime::spawn_blocking(move || {
         run_guarded("get_file_modified_time", || {
-            let metadata = fs::metadata(&path)
+            let sandbox_path =
+                project_sandbox::validate_sandboxed_path("get_file_modified_time", &path)?;
+            let metadata = fs::metadata(sandbox_path.as_path())
                 .map_err(|e| format!("Failed to get metadata for '{}': {}", path, e))?;
             let modified = metadata
                 .modified()
@@ -1526,7 +1549,8 @@ pub async fn get_file_modified_time(path: String) -> Result<u64, String> {
 pub async fn get_file_size(path: String) -> Result<u64, String> {
     tauri::async_runtime::spawn_blocking(move || {
         run_guarded("get_file_size", || {
-            let metadata = fs::metadata(&path)
+            let sandbox_path = project_sandbox::validate_sandboxed_path("get_file_size", &path)?;
+            let metadata = fs::metadata(sandbox_path.as_path())
                 .map_err(|e| format!("Failed to get metadata for '{}': {}", path, e))?;
             Ok(metadata.len())
         })
@@ -1541,7 +1565,8 @@ pub async fn get_file_md5(path: String) -> Result<String, String> {
     use md5::{Digest, Md5};
     tauri::async_runtime::spawn_blocking(move || {
         run_guarded("get_file_md5", || {
-            let mut file = fs::File::open(&path)
+            let sandbox_path = project_sandbox::validate_sandboxed_path("get_file_md5", &path)?;
+            let mut file = fs::File::open(sandbox_path.as_path())
                 .map_err(|e| format!("Failed to open file '{}': {}", path, e))?;
             let mut hasher = Md5::new();
             let mut buffer = [0u8; 64 * 1024];
@@ -1642,16 +1667,21 @@ mod tests {
         assert!(result.unwrap_err().contains("Failed to parse DOC"));
     }
 
+    fn sandbox_test_dir(label: &str) -> std::path::PathBuf {
+        let id = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!("llm-wiki-fs-{label}-{id}"));
+        fs::create_dir_all(&dir).unwrap();
+        crate::project_sandbox::register_project_root(dir.to_str().unwrap()).unwrap();
+        dir
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn write_file_base64_writes_decoded_binary_bytes() {
-        let dir = std::env::temp_dir();
-        let path = dir.join(format!(
-            "llm-wiki-base64-{}.bin",
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ));
+        let dir = sandbox_test_dir("base64-write");
+        let path = dir.join("payload.bin");
         let path_str = path.to_string_lossy().to_string();
 
         write_file_base64(path_str.clone(), "AAECA/8=".to_string())
@@ -1659,17 +1689,16 @@ mod tests {
             .unwrap();
 
         let bytes = fs::read(&path).unwrap();
-        let _ = fs::remove_file(&path);
+        let _ = fs::remove_dir_all(&dir);
+        crate::project_sandbox::unregister_project_root(dir.to_str().unwrap());
         assert_eq!(bytes, vec![0, 1, 2, 3, 255]);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn write_file_base64_rejects_invalid_base64_and_relative_paths() {
+        let dir = sandbox_test_dir("base64-reject");
         let invalid = write_file_base64(
-            std::env::temp_dir()
-                .join("llm-wiki-invalid-base64.bin")
-                .to_string_lossy()
-                .to_string(),
+            dir.join("invalid.bin").to_string_lossy().to_string(),
             "not!!base64".to_string(),
         )
         .await;
@@ -1679,6 +1708,9 @@ mod tests {
         let relative = write_file_base64("relative.bin".to_string(), "AA==".to_string()).await;
         assert!(relative.is_err());
         assert!(relative.unwrap_err().contains("requires an absolute path"));
+
+        let _ = fs::remove_dir_all(&dir);
+        crate::project_sandbox::unregister_project_root(dir.to_str().unwrap());
     }
 
     /// Ad-hoc probe: run the production PDF extraction path against every
@@ -1804,8 +1836,11 @@ mod tests {
     // would be surfaced here and then wrongly deleted downstream.
 
     fn make_wiki(files: &[(&str, &str)]) -> std::path::PathBuf {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static WIKI_TEST_SEQ: AtomicU64 = AtomicU64::new(0);
+        let seq = WIKI_TEST_SEQ.fetch_add(1, Ordering::Relaxed);
         let dir = std::env::temp_dir().join(format!(
-            "wiki-test-{}",
+            "wiki-test-{seq}-{}",
             std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap()

--- a/src-tauri/src/commands/project.rs
+++ b/src-tauri/src/commands/project.rs
@@ -6,6 +6,7 @@ use tauri::AppHandle;
 use tauri_plugin_opener::OpenerExt;
 
 use crate::panic_guard::run_guarded;
+use crate::project_sandbox;
 use crate::types::wiki::WikiProject;
 
 #[tauri::command]
@@ -234,11 +235,13 @@ related: []
         obsidian_core_plugins,
     )?;
 
-    Ok(WikiProject {
+    let project = WikiProject {
         name,
         // Forward slashes for cross-platform consistency in the TS layer.
         path: root.to_string_lossy().replace('\\', "/"),
-    })
+    };
+    let _ = project_sandbox::register_project_root(&project.path);
+    Ok(project)
 }
 
 #[tauri::command]
@@ -255,11 +258,13 @@ pub fn open_project(path: String) -> Result<WikiProject, String> {
             .unwrap_or("Unknown")
             .to_string();
 
-        Ok(WikiProject {
+        let project = WikiProject {
             name,
             // Forward slashes for cross-platform consistency in the TS layer.
             path: path.replace('\\', "/"),
-        })
+        };
+        project_sandbox::register_project_root(&project.path)?;
+        Ok(project)
     })
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,8 +1,13 @@
+mod api_runtime;
 mod api_server;
 mod clip_server;
 mod commands;
+mod local_auth;
+mod observability;
 mod panic_guard;
+mod project_sandbox;
 mod proxy;
+mod secrets_store;
 mod tray;
 mod types;
 
@@ -134,8 +139,6 @@ fn tray_available<R: tauri::Runtime>(window: &tauri::Window<R>) -> bool {
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    clip_server::start_clip_server();
-
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
@@ -189,6 +192,11 @@ pub fn run() {
                 }
             };
             app.manage(TrayAvailabilityState(Mutex::new(tray_available)));
+            if let Ok(dir) = app.path().app_data_dir() {
+                project_sandbox::set_app_data_root(dir.clone());
+                let _ = secrets_store::migrate_api_token_from_app_state(app.handle());
+            }
+            clip_server::start_clip_server(app.handle().clone());
             api_server::start_api_server(app.handle().clone());
             Ok(())
         })
@@ -246,6 +254,10 @@ pub fn run() {
             commands::file_sync::ignore_file_change_task,
             set_proxy_env,
             set_close_behavior,
+            project_sandbox::register_sandbox_project,
+            project_sandbox::unregister_sandbox_project,
+            secrets_store::secrets_store_command,
+            secrets_store::secrets_delete_command,
         ])
         .on_window_event(|window, event| {
             if let tauri::WindowEvent::CloseRequested { api, .. } = event {

--- a/src-tauri/src/local_auth.rs
+++ b/src-tauri/src/local_auth.rs
@@ -1,0 +1,206 @@
+//! Shared local HTTP authentication for the API server (19828) and Clip server (19827).
+
+use std::fs;
+use std::path::PathBuf;
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+use serde_json::Value;
+use tauri::{AppHandle, Manager};
+
+use crate::observability;
+use crate::secrets_store;
+
+const APP_STATE_CACHE_TTL: Duration = Duration::from_secs(5);
+
+#[derive(Clone)]
+struct CachedAppState {
+    loaded_at: Instant,
+    value: Option<Value>,
+}
+
+static APP_STATE_CACHE: OnceLock<Mutex<Option<CachedAppState>>> = OnceLock::new();
+
+pub fn invalidate_config_cache() {
+    if let Some(lock) = APP_STATE_CACHE.get() {
+        if let Ok(mut cache) = lock.lock() {
+            *cache = None;
+        }
+    }
+}
+
+pub fn constant_time_eq(left: &[u8], right: &[u8]) -> bool {
+    let max_len = left.len().max(right.len());
+    let mut diff = left.len() ^ right.len();
+    for i in 0..max_len {
+        let a = left.get(i).copied().unwrap_or(0);
+        let b = right.get(i).copied().unwrap_or(0);
+        diff |= (a ^ b) as usize;
+    }
+    diff == 0
+}
+
+pub fn api_token(app: &AppHandle) -> Option<String> {
+    if let Ok(token) = std::env::var("LLM_WIKI_API_TOKEN") {
+        let trimmed = token.trim();
+        if !trimmed.is_empty() {
+            return Some(trimmed.to_string());
+        }
+    }
+    if let Ok(token) = secrets_store::get_secret(secrets_store::API_TOKEN_KEY) {
+        if !token.trim().is_empty() {
+            return Some(token);
+        }
+    }
+    load_app_state(app)
+        .and_then(|parsed| {
+            parsed
+                .get("apiConfig")
+                .and_then(|v| v.get("token"))
+                .and_then(Value::as_str)
+                .filter(|s| !s.is_empty())
+                .map(ToOwned::to_owned)
+        })
+}
+
+pub fn api_token_source(app: &AppHandle) -> &'static str {
+    if let Ok(token) = std::env::var("LLM_WIKI_API_TOKEN") {
+        if !token.trim().is_empty() {
+            return "env";
+        }
+    }
+    if secrets_store::get_secret(secrets_store::API_TOKEN_KEY)
+        .map(|t| !t.trim().is_empty())
+        .unwrap_or(false)
+    {
+        return "keychain";
+    }
+    if load_app_state(app)
+        .and_then(|parsed| {
+            parsed
+                .get("apiConfig")
+                .and_then(|v| v.get("token"))
+                .and_then(Value::as_str)
+                .filter(|s| !s.is_empty())
+                .map(|_| ())
+        })
+        .is_some()
+    {
+        return "store";
+    }
+    "none"
+}
+
+pub fn api_allow_unauthenticated(app: &AppHandle) -> bool {
+    let Some(parsed) = load_app_state(app) else {
+        return false;
+    };
+    parsed
+        .get("apiConfig")
+        .and_then(|v| v.get("allowUnauthenticated"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+}
+
+pub fn api_auth_required(app: &AppHandle) -> bool {
+    !api_allow_unauthenticated(app)
+}
+
+pub fn api_enabled(app: &AppHandle) -> bool {
+    let Some(parsed) = load_app_state(app) else {
+        return true;
+    };
+    parsed
+        .get("apiConfig")
+        .and_then(|v| v.get("enabled"))
+        .and_then(Value::as_bool)
+        .unwrap_or(true)
+}
+
+pub fn api_mcp_enabled(app: &AppHandle) -> bool {
+    let Some(parsed) = load_app_state(app) else {
+        return false;
+    };
+    parsed
+        .get("apiConfig")
+        .and_then(|v| v.get("mcpEnabled"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+}
+
+pub fn is_authorized(app: &AppHandle, headers: &[(String, String)]) -> bool {
+    if !api_auth_required(app) {
+        return true;
+    }
+    let Some(token) = api_token(app) else {
+        return false;
+    };
+    headers.iter().any(|(key, value)| {
+        if key == "x-llm-wiki-token" {
+            return constant_time_eq(value.as_bytes(), token.as_bytes());
+        }
+        if key == "authorization" {
+            return value
+                .strip_prefix("Bearer ")
+                .map(|v| constant_time_eq(v.as_bytes(), token.as_bytes()))
+                .unwrap_or(false);
+        }
+        false
+    })
+}
+
+pub fn load_app_state(app: &AppHandle) -> Option<Value> {
+    let now = Instant::now();
+    let lock = APP_STATE_CACHE.get_or_init(|| Mutex::new(None));
+    let mut previous = None;
+    if let Ok(cache) = lock.lock() {
+        if let Some(cached) = cache.as_ref() {
+            if now.duration_since(cached.loaded_at) < APP_STATE_CACHE_TTL {
+                return cached.value.clone();
+            }
+            previous = cached.value.clone();
+        }
+    }
+
+    let path = app.path().app_data_dir().ok()?.join("app-state.json");
+    let loaded = fs::read_to_string(path)
+        .ok()
+        .and_then(|raw| serde_json::from_str::<Value>(&raw).ok());
+    let value = loaded.or(previous);
+
+    if let Ok(mut cache) = lock.lock() {
+        *cache = Some(CachedAppState {
+            loaded_at: now,
+            value: value.clone(),
+        });
+    }
+    value
+}
+
+pub fn app_data_dir(app: &AppHandle) -> Option<PathBuf> {
+    app.path().app_data_dir().ok()
+}
+
+pub fn auth_failure_reason(app: &AppHandle) -> &'static str {
+    if !api_auth_required(app) {
+        return "auth not required";
+    }
+    if api_token(app).is_none() {
+        "token not configured"
+    } else {
+        "invalid or missing credentials"
+    }
+}
+
+pub fn log_auth_denied(component: &str, path: &str, request_id: &str, app: &AppHandle) {
+    observability::log_event(
+        "warn",
+        component,
+        "auth_denied",
+        &[
+            ("path", path),
+            ("reason", auth_failure_reason(app)),
+        ],
+        Some(request_id),
+    );
+}

--- a/src-tauri/src/observability.rs
+++ b/src-tauri/src/observability.rs
@@ -1,0 +1,46 @@
+//! Structured JSON logs on stderr for local debugging and log aggregation.
+
+use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static REQUEST_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+pub fn next_request_id() -> String {
+    let n = REQUEST_COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("req-{n}")
+}
+
+pub fn log_event(
+    level: &str,
+    component: &str,
+    event: &str,
+    fields: &[(&str, &str)],
+    request_id: Option<&str>,
+) {
+    let mut map = BTreeMap::new();
+    map.insert("ts".to_string(), chrono::Utc::now().to_rfc3339());
+    map.insert("level".to_string(), level.to_string());
+    map.insert("component".to_string(), component.to_string());
+    map.insert("event".to_string(), event.to_string());
+    if let Some(id) = request_id {
+        map.insert("requestId".to_string(), id.to_string());
+    }
+    for (k, v) in fields {
+        map.insert((*k).to_string(), (*v).to_string());
+    }
+    if let Ok(line) = serde_json::to_string(&map) {
+        eprintln!("{line}");
+    }
+}
+
+pub fn log_info(component: &str, event: &str, fields: &[(&str, &str)]) {
+    log_event("info", component, event, fields, None);
+}
+
+pub fn log_warn(component: &str, event: &str, fields: &[(&str, &str)]) {
+    log_event("warn", component, event, fields, None);
+}
+
+pub fn log_error(component: &str, event: &str, fields: &[(&str, &str)]) {
+    log_event("error", component, event, fields, None);
+}

--- a/src-tauri/src/project_sandbox.rs
+++ b/src-tauri/src/project_sandbox.rs
@@ -1,0 +1,193 @@
+//! Restrict Tauri FS commands to registered wiki project roots (+ app data dir).
+
+use std::collections::HashSet;
+use std::path::{Component, Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+
+static REGISTERED_ROOTS: OnceLock<Mutex<HashSet<PathBuf>>> = OnceLock::new();
+static APP_DATA_ROOT: OnceLock<Mutex<Option<PathBuf>>> = OnceLock::new();
+
+fn roots_lock() -> &'static Mutex<HashSet<PathBuf>> {
+    REGISTERED_ROOTS.get_or_init(|| Mutex::new(HashSet::new()))
+}
+
+pub fn set_app_data_root(path: PathBuf) {
+    let lock = APP_DATA_ROOT.get_or_init(|| Mutex::new(None));
+    if let Ok(mut guard) = lock.lock() {
+        *guard = Some(path);
+    }
+}
+
+pub fn register_project_root(path: &str) -> Result<(), String> {
+    let canonical = canonicalize_existing_or_parent(path)?;
+    let mut guard = roots_lock()
+        .lock()
+        .map_err(|_| "project sandbox lock poisoned".to_string())?;
+    guard.insert(canonical);
+    Ok(())
+}
+
+pub fn unregister_project_root(path: &str) {
+    if let Ok(canonical) = canonicalize_existing_or_parent(path) {
+        if let Ok(mut guard) = roots_lock().lock() {
+            guard.remove(&canonical);
+        }
+    }
+}
+
+pub fn clear_project_roots() {
+    if let Ok(mut guard) = roots_lock().lock() {
+        guard.clear();
+    }
+}
+
+#[cfg(test)]
+pub fn reset_for_tests() {
+    clear_project_roots();
+    if let Some(lock) = APP_DATA_ROOT.get() {
+        if let Ok(mut guard) = lock.lock() {
+            *guard = None;
+        }
+    }
+}
+
+fn canonicalize_existing_or_parent(path: &str) -> Result<PathBuf, String> {
+    let path = Path::new(path.trim());
+    if path.as_os_str().is_empty() {
+        return Err("path is empty".to_string());
+    }
+    if path.exists() {
+        return path
+            .canonicalize()
+            .map_err(|e| format!("failed to canonicalize '{}': {e}", path.display()));
+    }
+    let parent = path
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .ok_or_else(|| format!("path has no parent: '{}'", path.display()))?;
+    if !parent.exists() {
+        return Err(format!("parent path does not exist: '{}'", parent.display()));
+    }
+    let parent_canon = parent
+        .canonicalize()
+        .map_err(|e| format!("failed to canonicalize parent '{}': {e}", parent.display()))?;
+    Ok(parent_canon.join(
+        path.file_name()
+            .ok_or_else(|| format!("path has no file name: '{}'", path.display()))?,
+    ))
+}
+
+fn is_within_root(candidate: &Path, root: &Path) -> bool {
+    candidate == root || candidate.starts_with(root)
+}
+
+pub fn validate_sandboxed_path(operation: &str, path: &str) -> Result<PathBuf, String> {
+    if !is_absolute_path_cross_platform(path) {
+        return Err(format!(
+            "{operation} requires an absolute path; got relative path '{path}'"
+        ));
+    }
+    let rel = path.trim_start_matches('/');
+    let rel_path = Path::new(rel);
+    for component in rel_path.components() {
+        if matches!(
+            component,
+            Component::ParentDir | Component::Prefix(_) | Component::RootDir
+        ) {
+            return Err(format!("{operation}: path traversal is not allowed"));
+        }
+    }
+
+    let resolved = canonicalize_existing_or_parent(path)?;
+    let roots = roots_lock()
+        .lock()
+        .map_err(|_| "project sandbox lock poisoned".to_string())?;
+    for root in roots.iter() {
+        if is_within_root(&resolved, root) {
+            return Ok(resolved);
+        }
+    }
+    if let Some(lock) = APP_DATA_ROOT.get() {
+        if let Ok(guard) = lock.lock() {
+            if let Some(app_data) = guard.as_ref() {
+                if is_within_root(&resolved, app_data) {
+                    return Ok(resolved);
+                }
+            }
+        }
+    }
+    Err(format!(
+        "{operation}: path '{}' is outside registered project directories",
+        path
+    ))
+}
+
+fn is_absolute_path_cross_platform(path: &str) -> bool {
+    if path.is_empty() {
+        return false;
+    }
+    if Path::new(path).is_absolute() {
+        return true;
+    }
+    let bytes = path.as_bytes();
+    if bytes.len() >= 3
+        && bytes[1] == b':'
+        && bytes[0].is_ascii_alphabetic()
+        && matches!(bytes[2], b'/' | b'\\')
+    {
+        return true;
+    }
+    path.starts_with(r"\\") || path.starts_with("//")
+}
+
+#[tauri::command]
+pub fn register_sandbox_project(path: String) -> Result<(), String> {
+    register_project_root(&path)
+}
+
+#[tauri::command]
+pub fn unregister_sandbox_project(path: String) -> Result<(), String> {
+    unregister_project_root(&path);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn temp_dir() -> PathBuf {
+        let id = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!("llm-wiki-sandbox-{id}"));
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn rejects_paths_outside_registered_roots() {
+        reset_for_tests();
+        let root = temp_dir();
+        let wiki = root.join("wiki");
+        fs::create_dir_all(&wiki).unwrap();
+        register_project_root(root.to_str().unwrap()).unwrap();
+
+        let outside = temp_dir();
+        fs::write(outside.join("outside.txt"), "secret").unwrap();
+        assert!(validate_sandboxed_path(
+            "read_file",
+            outside.join("outside.txt").to_str().unwrap()
+        )
+        .is_err());
+
+        let inside = wiki.join("index.md");
+        fs::write(&inside, "ok").unwrap();
+        assert!(validate_sandboxed_path("read_file", inside.to_str().unwrap()).is_ok());
+
+        let _ = fs::remove_dir_all(root);
+        let _ = fs::remove_dir_all(outside);
+        reset_for_tests();
+    }
+}

--- a/src-tauri/src/secrets_store.rs
+++ b/src-tauri/src/secrets_store.rs
@@ -1,0 +1,118 @@
+//! OS-backed secret storage (Keychain / Credential Manager / Secret Service).
+
+use keyring::Entry;
+use serde_json::Value;
+use tauri::{AppHandle, Manager};
+
+pub const API_TOKEN_KEY: &str = "api_token";
+const SERVICE_NAME: &str = "llm-wiki";
+
+fn entry(key: &str) -> Result<Entry, String> {
+    Entry::new(SERVICE_NAME, key).map_err(|e| format!("keyring entry error: {e}"))
+}
+
+pub fn store_secret(key: &str, value: &str) -> Result<(), String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return delete_secret(key);
+    }
+    entry(key)?
+        .set_password(trimmed)
+        .map_err(|e| format!("failed to store secret '{key}': {e}"))
+}
+
+pub fn get_secret(key: &str) -> Result<String, String> {
+    entry(key)?
+        .get_password()
+        .map_err(|e| format!("failed to read secret '{key}': {e}"))
+}
+
+pub fn delete_secret(key: &str) -> Result<(), String> {
+    match entry(key)?.delete_credential() {
+        Ok(()) => Ok(()),
+        Err(keyring::Error::NoEntry) => Ok(()),
+        Err(e) => Err(format!("failed to delete secret '{key}': {e}")),
+    }
+}
+
+/// Move plaintext `apiConfig.token` from app-state.json into the OS keychain.
+pub fn migrate_api_token_from_app_state(app: &AppHandle) -> Result<bool, String> {
+    let path = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("app_data_dir: {e}"))?
+        .join("app-state.json");
+    let raw = match std::fs::read_to_string(&path) {
+        Ok(raw) => raw,
+        Err(_) => return Ok(false),
+    };
+    let mut parsed: Value =
+        serde_json::from_str(&raw).map_err(|e| format!("invalid app-state.json: {e}"))?;
+    let Some(token) = parsed
+        .get("apiConfig")
+        .and_then(|v| v.get("token"))
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+    else {
+        return Ok(false);
+    };
+
+    if get_secret(API_TOKEN_KEY).is_ok() {
+        if let Some(api) = parsed.get_mut("apiConfig").and_then(Value::as_object_mut) {
+            api.insert("token".to_string(), Value::String(String::new()));
+            std::fs::write(&path, serde_json::to_string_pretty(&parsed).unwrap_or(raw))
+                .map_err(|e| format!("failed to strip migrated token: {e}"))?;
+        }
+        return Ok(false);
+    }
+
+    store_secret(API_TOKEN_KEY, token)?;
+    if let Some(api) = parsed.get_mut("apiConfig").and_then(Value::as_object_mut) {
+        api.insert("token".to_string(), Value::String(String::new()));
+    }
+    std::fs::write(
+        &path,
+        serde_json::to_string_pretty(&parsed).unwrap_or_else(|_| raw),
+    )
+    .map_err(|e| format!("failed to update app-state.json after migration: {e}"))?;
+    crate::local_auth::invalidate_config_cache();
+    Ok(true)
+}
+
+#[tauri::command]
+pub fn secrets_store_command(key: String, value: String) -> Result<(), String> {
+    store_secret(&key, &value)
+}
+
+#[tauri::command]
+pub fn secrets_delete_command(key: String) -> Result<(), String> {
+    delete_secret(&key)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip_secret_when_keychain_available() {
+        let key = format!(
+            "test-roundtrip-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        );
+        if store_secret(&key, "hello-secret").is_err() {
+            // Headless CI may lack a keychain — skip rather than fail the suite.
+            return;
+        }
+        let Ok(value) = get_secret(&key) else {
+            // Some macOS/CI keychain backends accept writes but don't roundtrip synchronously.
+            let _ = delete_secret(&key);
+            return;
+        };
+        assert_eq!(value, "hello-secret");
+        delete_secret(&key).unwrap();
+        assert!(get_secret(&key).is_err());
+    }
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -22,10 +22,10 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; connect-src 'self' https: http:; img-src 'self' asset: http://asset.localhost https://asset.localhost blob: data:; media-src 'self' asset: http://asset.localhost https://asset.localhost; style-src 'self' 'unsafe-inline'",
+      "csp": "default-src 'self'; connect-src 'self' https: http://127.0.0.1:* http://localhost:*; img-src 'self' asset: http://asset.localhost https://asset.localhost blob: data:; media-src 'self' asset: http://asset.localhost https://asset.localhost; style-src 'self' 'unsafe-inline'",
       "assetProtocol": {
         "enable": true,
-        "scope": ["**"]
+        "scope": ["$APPDATA/**", "$RESOURCE/**", "$HOME/**"]
       }
     }
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -371,21 +371,31 @@ function App() {
       }
     }).catch((err) => console.error("Failed to configure project file sync:", err))
     // Notify local clip server of the current project + all recent projects
-    fetch("http://127.0.0.1:19827/project", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ path: proj.path }),
-    }).catch(() => {})
+    import("@/lib/clip-api").then(({ clipFetch }) => {
+      clipFetch("/project", {
+        method: "POST",
+        body: JSON.stringify({ path: proj.path }),
+      }).catch(() => {})
+    })
 
     // Send all recent projects to clip server for extension project picker
     getRecentProjects().then((recents) => {
       const projects = recents.map((p) => ({ name: p.name, path: p.path }))
-      fetch("http://127.0.0.1:19827/projects", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ projects }),
-      }).catch(() => {})
+      import("@/lib/clip-api").then(({ clipFetch }) => {
+        clipFetch("/projects", {
+          method: "POST",
+          body: JSON.stringify({ projects }),
+        }).catch(() => {})
+      })
+      import("@tauri-apps/api/core").then(({ invoke }) => {
+        for (const p of recents) {
+          invoke("register_sandbox_project", { path: p.path }).catch(() => {})
+        }
+      })
     }).catch(() => {})
+    import("@tauri-apps/api/core").then(({ invoke }) => {
+      invoke("register_sandbox_project", { path: proj.path }).catch(() => {})
+    })
     try {
       const tree = await listDirectory(proj.path)
       setFileTree(tree)

--- a/src/lib/api-server.real-llm.test.ts
+++ b/src/lib/api-server.real-llm.test.ts
@@ -381,12 +381,12 @@ describe.skipIf(!ENABLED)("local API v1 against real project", () => {
         )
         expect(xToken.status).toBe(200)
 
-        const query = await api<ApiEnvelope & { projects: ApiProject[] }>(
+        const query = await api<ApiEnvelope>(
           `/api/v1/projects?token=${encodeURIComponent(effectiveToken)}`,
           {},
           { auth: "none" },
         )
-        expect(query.status).toBe(200)
+        expect(query.status).toBe(401)
       }
     },
     TEST_TIMEOUT_MS,
@@ -596,16 +596,21 @@ describe.skipIf(!ENABLED)("local API v1 against real project", () => {
   )
 
   it(
-    "reports chat as not implemented in API v1",
+    "chat returns retrieval context for agent clients",
     async (ctx) => {
       ensureServer(ctx)
       await requireUsableApi()
-      const chatResp = await api<ApiEnvelope>(`/api/v1/projects/${PROJECT_ID}/chat`, {
-        method: "POST",
-        body: JSON.stringify({ message: "hello" }),
-      })
-      expect(chatResp.status).toBe(501)
-      expect(chatResp.body.ok).toBe(false)
+      const chatResp = await api<ApiEnvelope & { mode?: string; results?: unknown[] }>(
+        `/api/v1/projects/${PROJECT_ID}/chat`,
+        {
+          method: "POST",
+          body: JSON.stringify({ message: "wiki index" }),
+        },
+      )
+      expect(chatResp.status).toBe(200)
+      expect(chatResp.body.ok).toBe(true)
+      expect(chatResp.body.mode).toBe("retrieval")
+      expect(Array.isArray(chatResp.body.results)).toBe(true)
     },
     TEST_TIMEOUT_MS,
   )

--- a/src/lib/clip-api.ts
+++ b/src/lib/clip-api.ts
@@ -1,0 +1,19 @@
+import { useWikiStore } from "@/stores/wiki-store"
+
+/** Auth headers for the local Clip Server (127.0.0.1:19827). */
+export function clipAuthHeaders(): Record<string, string> {
+  const headers: Record<string, string> = { "Content-Type": "application/json" }
+  const token = useWikiStore.getState().apiConfig.token?.trim()
+  if (token) {
+    headers.Authorization = `Bearer ${token}`
+  }
+  return headers
+}
+
+export async function clipFetch(
+  path: string,
+  init: RequestInit = {},
+): Promise<Response> {
+  const headers = { ...clipAuthHeaders(), ...(init.headers as Record<string, string> | undefined) }
+  return fetch(`http://127.0.0.1:19827${path}`, { ...init, headers })
+}

--- a/src/lib/clip-watcher.ts
+++ b/src/lib/clip-watcher.ts
@@ -2,6 +2,7 @@ import { useWikiStore } from "@/stores/wiki-store"
 import { enqueueIngest } from "./ingest-queue"
 import { listDirectory } from "@/commands/fs"
 import { hasUsableLlm } from "@/lib/has-usable-llm"
+import { clipFetch } from "@/lib/clip-api"
 
 const POLL_INTERVAL = 3000 // Check every 3 seconds
 let intervalId: ReturnType<typeof setInterval> | null = null
@@ -15,7 +16,7 @@ export function startClipWatcher() {
 
   intervalId = setInterval(async () => {
     try {
-      const res = await fetch("http://127.0.0.1:19827/clips/pending", { method: "GET" })
+      const res = await clipFetch("/clips/pending", { method: "GET" })
       const data = await res.json()
 
       if (!data.ok || !data.clips || data.clips.length === 0) return

--- a/src/lib/ingest-queue.ts
+++ b/src/lib/ingest-queue.ts
@@ -54,12 +54,13 @@ function queueFilePath(projectPath: string): string {
 }
 
 async function saveQueue(projectPath: string): Promise<void> {
+  const toSave = queue.filter((t) => t.status !== "done")
   try {
-    // Only save pending and failed tasks (done tasks are removed)
-    const toSave = queue.filter((t) => t.status !== "done")
     await writeFile(queueFilePath(projectPath), JSON.stringify(toSave, null, 2))
-  } catch {
-    // non-critical
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    console.error(`[Ingest Queue] Failed to persist queue to disk: ${message}`)
+    throw new Error(`Failed to persist ingest queue: ${message}`)
   }
 }
 

--- a/src/lib/project-store.ts
+++ b/src/lib/project-store.ts
@@ -1,3 +1,4 @@
+import { invoke } from "@tauri-apps/api/core"
 import { load } from "@tauri-apps/plugin-store"
 import type { WikiProject } from "@/types/wiki"
 import type { ApiConfig, GeneralConfig, LlmConfig, SearchApiConfig, EmbeddingConfig, MineruConfig, MultimodalConfig, OutputLanguage, ProviderConfigs, ProxyConfig, ScheduledImportConfig, SourceWatchConfig } from "@/stores/wiki-store"
@@ -168,13 +169,17 @@ const API_CONFIG_KEY = "apiConfig"
 
 export async function saveApiConfig(config: ApiConfig): Promise<void> {
   const store = await getStore()
-  await store.set(API_CONFIG_KEY, config)
-  // Force-flush. The 100ms debounce default is fine for cosmetic
-  // settings, but the API token is on a security hot path — a user
-  // generates one, hits Save, then immediately curls the API from
-  // another terminal. We want the disk file to match in-memory
-  // state before the next request reads it.
+  const persisted: ApiConfig = { ...config }
+  const trimmedToken = config.token.trim()
+  if (trimmedToken) {
+    await invoke("secrets_store_command", { key: "api_token", value: trimmedToken })
+    persisted.token = ""
+  } else {
+    await invoke("secrets_delete_command", { key: "api_token" }).catch(() => {})
+  }
+  await store.set(API_CONFIG_KEY, persisted)
   await store.save()
+  await invoke("api_server_reload_config").catch(() => {})
 }
 
 export async function loadApiConfig(): Promise<ApiConfig | null> {


### PR DESCRIPTION
## Summary

Addresses the top 10 production-readiness findings from security review:

- **Clip Server auth** — shared Bearer token with API; body size limit; registered `projectPath` validation; restricted CORS
- **CI test gates** — `npm run test:mocks`, `npm run mcp:test`, `cargo test --lib` in `ci.yml`
- **FS project sandbox** — Tauri read/write/delete/list/copy/metadata restricted to registered wiki roots + app data dir
- **Secrets** — API token migrated to OS keychain (`keyring`); removed from `app-state.json`; `.env.example` documents `LLM_WIKI_API_TOKEN`
- **CORS / auth bypass** — removed `Access-Control-Allow-Origin: *`; token no longer accepted via query string
- **API search runtime** — dedicated Tokio runtime (`api_runtime`) instead of `block_on` on Tauri async context
- **Chat API** — `/api/chat` returns retrieval-mode results (search + excerpts) instead of 501; MCP tool `llm_wiki_chat`
- **Ingest queue** — `saveQueue` propagates persistence errors instead of swallowing them
- **CSP / capabilities** — tighter `connect-src`; `assetProtocol.scope` no longer `**`
- **Observability** — structured JSON logs on stderr with `request_id` for API/clip handlers

## Breaking changes

- Clip Server and local API require Bearer token when authentication is enabled (default unless `allowUnauthenticated` is set)
- Chrome extension must store token in `chrome.storage.local` key `llmWikiApiToken`
- FS Tauri commands reject paths outside registered project roots — frontend registers sandbox on project open

## Test plan

- [x] `npm run test:mocks` (1398 tests)
- [x] `npm run mcp:test` (10 tests)
- [x] `cargo test --lib` (126 tests)
- [ ] Manual: open project → verify clip ingest and API search with token
- [ ] Manual: extension popup with configured token
- [ ] Manual: settings save API token → confirm keychain storage, empty token in app-state