### PR TITLE
fix: strip think tags before extracting title when saving to wiki

### DIFF
--- a/src/components/chat/chat-message.tsx
+++ b/src/components/chat/chat-message.tsx
@@ -188,21 +188,24 @@ function SaveToWikiButton({ content, visible }: { content: string; visible: bool
     const pp = normalizePath(project.path)
     setSaving(true)
     try {
-      // Generate a unique filename for this save.
-      // See `src/lib/wiki-filename.ts` — the slug is Unicode-aware
-      // (so CJK titles don't collapse to empty) and the HHMMSS
-      // timestamp suffix guarantees same-day saves stay distinct.
-      const firstLine = content.split("\n")[0].replace(/^#+\s*/, "").trim()
-      const title = firstLine.slice(0, 60) || "Saved Query"
-      const { date, fileName } = makeQueryFileName(title)
-      const filePath = `${pp}/wiki/queries/${fileName}`
-
       // Strip hidden sources comment and thinking blocks from content
+      // BEFORE extracting the title — reasoning models (e.g. deepseek-r1)
+      // may start their reply with <think>…</think>, which would pollute
+      // the saved title if we extracted first and cleaned second.
       const cleanContent = content
         .replace(/<!--\s*sources:.*?-->/g, "")
         .replace(/<think(?:ing)?>\s*[\s\S]*?<\/think(?:ing)?>\s*/gi, "")
         .replace(/<think(?:ing)?>\s*[\s\S]*$/gi, "")
         .trimEnd()
+
+      // Generate a unique filename for this save.
+      // See `src/lib/wiki-filename.ts` — the slug is Unicode-aware
+      // (so CJK titles don't collapse to empty) and the HHMMSS
+      // timestamp suffix guarantees same-day saves stay distinct.
+      const firstLine = cleanContent.split("\n")[0].replace(/^#+\s*/, "").trim()
+      const title = firstLine.slice(0, 60) || "Saved Query"
+      const { date, fileName } = makeQueryFileName(title)
+      const filePath = `${pp}/wiki/queries/${fileName}`
 
       const frontmatter = [
         "---",

--- a/src/components/chat/chat-message.tsx
+++ b/src/components/chat/chat-message.tsx
@@ -11,6 +11,7 @@ import {
 } from "lucide-react"
 import { openUrl } from "@tauri-apps/plugin-opener"
 import { useWikiStore } from "@/stores/wiki-store"
+import { useChatStore } from "@/stores/chat-store"
 import { readFile, writeFile, listDirectory } from "@/commands/fs"
 import { lastQueryPages } from "@/components/chat/chat-panel"
 import type { DisplayMessage, MessageReference } from "@/stores/chat-store"
@@ -18,7 +19,7 @@ import type { FileNode } from "@/types/wiki"
 
 import { convertLatexToUnicode } from "@/lib/latex-to-unicode"
 import { normalizePath, getFileName } from "@/lib/path-utils"
-import { makeQueryFileName } from "@/lib/wiki-filename"
+import { makeQueryFileName, deriveTitleFromQuestion } from "@/lib/wiki-filename"
 import { hasUsableLlm } from "@/lib/has-usable-llm"
 import { messageImageToDataUrl } from "@/lib/chat-image-utils"
 import { resolveMarkdownImageSrc } from "@/lib/markdown-image-resolver"
@@ -74,6 +75,21 @@ function ChatMessageImpl({ message, isLastAssistant, onRegenerate }: ChatMessage
   const isAssistant = message.role === "assistant"
   const [hovered, setHovered] = useState(false)
 
+  // Find the preceding user question for this assistant message (for wiki title)
+  const userQuestion = useChatStore((s) => {
+    if (!isAssistant) return undefined
+    const messages = s.messages
+    const msgIdx = messages.findIndex((m) => m.id === message.id)
+    if (msgIdx < 0) return undefined
+    // Search backwards for the nearest user message in the same conversation
+    for (let i = msgIdx - 1; i >= 0; i--) {
+      if (messages[i].conversationId === message.conversationId && messages[i].role === "user") {
+        return messages[i].content
+      }
+    }
+    return undefined
+  })
+
   return (
     <div
       className={`flex gap-2 ${isUser ? "flex-row-reverse" : "flex-row"}`}
@@ -124,7 +140,7 @@ function ChatMessageImpl({ message, isLastAssistant, onRegenerate }: ChatMessage
         {isAssistant && hovered && (
           <div className="flex items-center gap-1">
             <CopyButton content={message.content} />
-            <SaveToWikiButton content={message.content} visible={true} />
+            <SaveToWikiButton content={message.content} question={userQuestion} visible={true} />
             {isLastAssistant && onRegenerate && (
               <button
                 type="button"
@@ -177,7 +193,7 @@ function CopyButton({ content }: { content: string }) {
   )
 }
 
-function SaveToWikiButton({ content, visible }: { content: string; visible: boolean }) {
+function SaveToWikiButton({ content, question, visible }: { content: string; question?: string; visible: boolean }) {
   const project = useWikiStore((s) => s.project)
   const setFileTree = useWikiStore((s) => s.setFileTree)
   const [saved, setSaved] = useState(false)
@@ -202,8 +218,13 @@ function SaveToWikiButton({ content, visible }: { content: string; visible: bool
       // See `src/lib/wiki-filename.ts` — the slug is Unicode-aware
       // (so CJK titles don't collapse to empty) and the HHMMSS
       // timestamp suffix guarantees same-day saves stay distinct.
+      // Prefer the user's question as title — summarized if long and with
+      // image markdown stripped (see deriveTitleFromQuestion). Fall back to
+      // the first line of the answer when no usable question text exists
+      // (e.g. an image-only question).
+      const titleFromQuestion = deriveTitleFromQuestion(question)
       const firstLine = cleanContent.split("\n")[0].replace(/^#+\s*/, "").trim()
-      const title = firstLine.slice(0, 60) || "Saved Query"
+      const title = titleFromQuestion || firstLine.slice(0, 60) || "Saved Query"
       const { date, fileName } = makeQueryFileName(title)
       const filePath = `${pp}/wiki/queries/${fileName}`
 

--- a/src/lib/wiki-filename.test.ts
+++ b/src/lib/wiki-filename.test.ts
@@ -5,7 +5,49 @@
  * into a single `-YYYY-MM-DD.md`. These tests pin the new policy.
  */
 import { describe, it, expect } from "vitest"
-import { makeQuerySlug, makeQueryFileName } from "./wiki-filename"
+import { makeQuerySlug, makeQueryFileName, deriveTitleFromQuestion } from "./wiki-filename"
+
+describe("deriveTitleFromQuestion", () => {
+  it("returns short questions unchanged (minus heading markers)", () => {
+    expect(deriveTitleFromQuestion("## InitSyncRange 是做什么的？")).toBe("InitSyncRange 是做什么的？")
+  })
+
+  it("collapses newlines and whitespace", () => {
+    expect(deriveTitleFromQuestion("第一行\n\n第二行")).toBe("第一行 第二行")
+  })
+
+  it("returns empty string for null/undefined/blank", () => {
+    expect(deriveTitleFromQuestion(undefined)).toBe("")
+    expect(deriveTitleFromQuestion(null)).toBe("")
+    expect(deriveTitleFromQuestion("   ")).toBe("")
+  })
+
+  it("strips image markdown so an image-only question yields no title", () => {
+    expect(deriveTitleFromQuestion("![screenshot](data:image/png;base64,AAAABBBBCCCC)")).toBe("")
+  })
+
+  it("keeps the text but drops the image when a question mixes both", () => {
+    const q = "这张图里的报错是什么意思？ ![err](data:image/png;base64,ZZZZ)"
+    expect(deriveTitleFromQuestion(q)).toBe("这张图里的报错是什么意思？")
+  })
+
+  it("summarizes an over-long question at a clause boundary with an ellipsis", () => {
+    const long =
+      "请帮我详细分析一下这个分布式同步系统的整体架构设计，包括它的数据一致性保证机制、节点之间的容错策略以及高并发场景下的整体性能优化方案。"
+    const title = deriveTitleFromQuestion(long)
+    expect(title.endsWith("…")).toBe(true)
+    // Must be a clean cut, not a mid-word hard slice with trailing punctuation.
+    expect(title).not.toMatch(/[，。、；]…$/)
+    expect(Array.from(title).length).toBeLessThanOrEqual(61) // 60 budget + ellipsis
+  })
+
+  it("falls back to a hard cut when there is no boundary in the budget", () => {
+    const long = "a".repeat(120)
+    const title = deriveTitleFromQuestion(long)
+    expect(title.endsWith("…")).toBe(true)
+    expect(Array.from(title).length).toBe(61)
+  })
+})
 
 describe("makeQuerySlug", () => {
   it("ASCII title is lowercased and hyphenated", () => {

--- a/src/lib/wiki-filename.ts
+++ b/src/lib/wiki-filename.ts
@@ -27,6 +27,61 @@
  * conversations with the same topic, or repeated "Untitled" saves).
  */
 
+/**
+ * Maximum display length for a saved-query title (the human-readable
+ * `title:` frontmatter / index label — distinct from the 50-char slug).
+ */
+const TITLE_MAX_LEN = 60
+
+/**
+ * Derive a clean, human-readable title from a user's question.
+ *
+ * The question is the best title source (the answer's first line is often
+ * boilerplate or — with reasoning models — polluted by <think> output). But
+ * raw question text needs cleaning:
+ *   - strip leading markdown heading markers
+ *   - drop image markdown (`![alt](data:image/png;base64,…)` and bare
+ *     `data:` URIs) so an image-only or image-heavy question doesn't leak a
+ *     giant base64 blob into the title
+ *   - collapse whitespace/newlines
+ *
+ * When the cleaned text is longer than `TITLE_MAX_LEN`, we *summarize* by
+ * cutting at the nearest sentence/clause boundary before the limit (falling
+ * back to a word boundary) and appending an ellipsis — rather than a hard
+ * mid-word slice, which reads as garbled.
+ *
+ * Returns "" when nothing usable remains (e.g. an image-only question), so
+ * callers can fall back to the answer content.
+ */
+export function deriveTitleFromQuestion(question: string | null | undefined): string {
+  if (!question) return ""
+
+  const cleaned = question
+    .replace(/^#+\s*/, "")
+    // Image markdown: ![alt](url) — including long base64 data URIs.
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, "")
+    // Bare data: URIs that slipped in without markdown wrapping.
+    .replace(/data:image\/[a-zA-Z0-9.+-]+;base64,[A-Za-z0-9+/=]+/g, "")
+    .replace(/\s+/g, " ")
+    .trim()
+
+  if (!cleaned) return ""
+  if (Array.from(cleaned).length <= TITLE_MAX_LEN) return cleaned
+
+  // Too long — summarize at a natural boundary within the limit.
+  const head = Array.from(cleaned).slice(0, TITLE_MAX_LEN).join("")
+  // Prefer the last sentence/clause terminator, then the last space.
+  const boundary = Math.max(
+    head.lastIndexOf("。"), head.lastIndexOf("！"), head.lastIndexOf("？"),
+    head.lastIndexOf("，"), head.lastIndexOf("、"), head.lastIndexOf("；"),
+    head.lastIndexOf("."), head.lastIndexOf("!"), head.lastIndexOf("?"),
+    head.lastIndexOf(","), head.lastIndexOf(";"), head.lastIndexOf(" "),
+  )
+  // Only honor a boundary that isn't uselessly early (keep ≥ half the budget).
+  const cut = boundary >= TITLE_MAX_LEN / 2 ? head.slice(0, boundary) : head
+  return cut.replace(/[\s、，；,;.。!！?？]+$/, "").trim() + "…"
+}
+
 /** Produce just the slug — exported for tests / callers that want
  *  to reuse it in places like the index.md wikilink target. */
 export function makeQuerySlug(title: string): string {


### PR DESCRIPTION
Fixes #404

## 问题

使用推理模型（如 deepseek-r1）时，LLM 回复可能以 `<think>…</think>` 开头。之前的代码先从原始内容提取标题、再清理 think 标签，导致保存的 query 页面标题被推理过程污染。此外，即使取到正确内容，把回答首行当标题本身也不理想——回答首行常是套话，且过长时会被硬截、含截图时会泄漏 base64。

## 修复

1. **清理提前**：先剥离 `<think>` 标签和 sources 注释，再提取标题。
2. **优先用提问做标题**：标题改为优先取用户的提问（回答首行仅作回退）。
3. **长问题摘要**：新增 `deriveTitleFromQuestion()`，过长时在 60 字符预算内按最近的句读/分句边界截断并加 `…`，避免断在词中间；找不到边界才硬截。
4. **截图处理**：剥离 `![...](...)` 图片 markdown 和裸 `data:image;base64,...`；纯图片提问得到空标题 → 回退到回答首行，图文混合则只保留文字。

## 测试

- `deriveTitleFromQuestion` 单元测试：短问题、换行折叠、空/纯图片、图文混合、超长摘要、无边界硬截，全部通过。
- TypeScript 类型检查通过。
