### PR TITLE
ci: add Intel macOS (x86_64) build target

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,13 @@ jobs:
           - platform: macos-latest
             args: '--target aarch64-apple-darwin'
             rust_target: aarch64-apple-darwin
+          # Intel macOS build. macos-13 is GitHub's last x86_64 runner
+          # (macos-14+ are Apple Silicon), so this is a NATIVE build —
+          # no cross-compile. Restores the Intel .dmg dropped after
+          # v0.2.0, when the macOS matrix narrowed to aarch64 only.
+          - platform: macos-13
+            args: '--target x86_64-apple-darwin'
+            rust_target: x86_64-apple-darwin
           - platform: ubuntu-22.04
             args: ''
             rust_target: ''
@@ -42,7 +49,7 @@ jobs:
           targets: ${{ matrix.rust_target }}
 
       - name: Install protoc (macOS)
-        if: matrix.platform == 'macos-latest'
+        if: startsWith(matrix.platform, 'macos-')
         run: brew install protobuf
 
       - name: Install dependencies (Ubuntu)


### PR DESCRIPTION
Since v0.2.0 no Intel macOS artifact has been published, because the macOS matrix only builds \`aarch64-apple-darwin\`. Intel Mac users have had no prebuilt binary.

This restores Intel support by adding a **native** x86_64 build:

- New matrix entry on \`macos-13\` (GitHub's last x86_64 runner — \`macos-14+\` are Apple Silicon), with \`--target x86_64-apple-darwin\`. Native build, no cross-compile.
- Widened the \`Install protoc (macOS)\` step from \`== 'macos-latest'\` to \`startsWith('macos-')\` so it also runs on \`macos-13\`.

No other changes needed: the artifact-upload glob (\`target/**/release/bundle/...\`) already covers the \`x86_64-apple-darwin\` path.

Verified locally on an Intel iMac (macOS 15.7.7): the v0.4.24 source builds natively to an x86_64 \`.app\` + \`.dmg\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)