### PR TITLE
feat: add fastCRW web search provider

### DIFF
--- a/src/components/settings/sections/web-search-section.tsx
+++ b/src/components/settings/sections/web-search-section.tsx
@@ -54,6 +54,14 @@ const SEARCH_PROVIDERS = [
     hint: "Anonymous Firecrawl Search API",
     configKind: "none",
   },
+  {
+    id: "fastcrw",
+    label: "fastCRW",
+    hint: "SearXNG-based search — self-hostable or managed cloud",
+    keyPlaceholder: "fastCRW API key (fastcrw.com) — for the managed cloud",
+    urlPlaceholder: "http://localhost:3000 — leave blank to use the cloud",
+    configKind: "key+url",
+  },
 ] as const
 
 export function WebSearchSection() {
@@ -282,7 +290,9 @@ export function WebSearchSection() {
             ? true
             : provider.id === "searxng"
               ? !!override?.searXngUrl
-              : !!override?.apiKey
+              : provider.id === "fastcrw"
+                ? !!override?.apiKey || !!override?.fastCrwUrl
+                : !!override?.apiKey
           const isExpanded = !!expanded[provider.id]
           return (
             <div
@@ -349,7 +359,30 @@ export function WebSearchSection() {
 
               {isExpanded && (
                 <div className="space-y-4 border-t bg-background/50 px-4 py-3">
-                  {provider.configKind === "url" ? (
+                  {provider.configKind === "key+url" ? (
+                    <>
+                      <div className="space-y-2">
+                        <Label>{t("settings.apiKey")}</Label>
+                        <Input
+                          type="password"
+                          value={override?.apiKey ?? ""}
+                          onChange={(e) => updateProvider(provider.id, { apiKey: e.target.value })}
+                          placeholder={provider.keyPlaceholder}
+                        />
+                      </div>
+                      <div className="space-y-2">
+                        <Label>{t("settings.sections.webSearch.instanceUrl")}</Label>
+                        <Input
+                          value={override?.fastCrwUrl ?? ""}
+                          onChange={(e) => updateProvider(provider.id, { fastCrwUrl: e.target.value })}
+                          placeholder={provider.urlPlaceholder}
+                        />
+                        <p className="text-xs text-muted-foreground">
+                          {t("settings.sections.webSearch.fastcrwHint")}
+                        </p>
+                      </div>
+                    </>
+                  ) : provider.configKind === "url" ? (
                     <div className="space-y-2">
                       <Label>{t("settings.sections.webSearch.instanceUrl")}</Label>
                       <Input
@@ -445,6 +478,12 @@ function localizeSearchTestError(err: unknown, t: ReturnType<typeof useTranslati
   }
   if (/Firecrawl search returned an invalid JSON response/i.test(message)) {
     return t("settings.sections.webSearch.firecrawlInvalidJson")
+  }
+  if (/Network error reaching fastCRW Search/i.test(message)) {
+    return t("settings.sections.webSearch.fastcrwNetworkError")
+  }
+  if (/fastCRW search returned an invalid JSON response/i.test(message)) {
+    return t("settings.sections.webSearch.fastcrwInvalidJson")
   }
   return t("settings.sections.webSearch.testFailed", { message })
 }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -424,6 +424,9 @@
         "firecrawlIpBlocked": "Firecrawl anonymous search is blocked for this IP. Choose another Web Search provider or try a different network.",
         "firecrawlNetworkError": "Could not reach Firecrawl Search. Check your network or choose another Web Search provider.",
         "firecrawlInvalidJson": "Firecrawl returned an invalid response. Try again later or choose another Web Search provider.",
+        "fastcrwHint": "SearXNG-based web search. Use the managed cloud with an API key from fastcrw.com, or set Base URL to your own self-hosted fastCRW instance (e.g. http://localhost:3000) for unlimited, private search.",
+        "fastcrwNetworkError": "Could not reach fastCRW Search. Check your network or choose another Web Search provider.",
+        "fastcrwInvalidJson": "fastCRW returned an invalid response. Try again later or choose another Web Search provider.",
         "configureBeforeTesting": "Configure first"
       },
       "network": {

--- a/src/i18n/zh.json
+++ b/src/i18n/zh.json
@@ -424,6 +424,9 @@
         "firecrawlIpBlocked": "Firecrawl 匿名搜索已被当前 IP 拦截。请切换其他网页搜索 Provider，或尝试更换网络。",
         "firecrawlNetworkError": "无法连接 Firecrawl Search。请检查网络，或切换其他网页搜索 Provider。",
         "firecrawlInvalidJson": "Firecrawl 返回了无效响应。请稍后重试，或切换其他网页搜索 Provider。",
+        "fastcrwHint": "基于 SearXNG 的网页搜索。可使用托管云服务（在 fastcrw.com 获取 API Key），或将 Base URL 指向自托管的 fastCRW 实例（例如 http://localhost:3000）以获得无限制、私有的搜索。",
+        "fastcrwNetworkError": "无法连接 fastCRW Search。请检查网络，或切换其他网页搜索 Provider。",
+        "fastcrwInvalidJson": "fastCRW 返回了无效响应。请稍后重试，或切换其他网页搜索 Provider。",
         "configureBeforeTesting": "请先配置"
       },
       "network": {

--- a/src/lib/web-search.test.ts
+++ b/src/lib/web-search.test.ts
@@ -311,6 +311,236 @@ describe("webSearch", () => {
       ])
   })
 
+  it("calls fastCRW cloud with Bearer auth and maps the flat data array", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      success: true,
+      data: [
+        { title: "Doc", url: "https://example.com/doc", description: "Desc", snippet: "Desc" },
+      ],
+    }))
+
+    const out = await webSearch(
+      "llm_wiki",
+      { provider: "fastcrw", apiKey: "", providerConfigs: { fastcrw: { apiKey: "k" } } },
+      2,
+    )
+    const [url, init] = fetchMock.mock.calls[0]
+
+    expect(url).toBe("https://api.fastcrw.com/v1/search")
+    expect(init).toEqual(expect.objectContaining({ method: "POST" }))
+    expect((init?.headers as Record<string, string>).Authorization).toBe("Bearer k")
+    expect(JSON.parse(String(init?.body))).toEqual({ query: "llm_wiki", limit: 2 })
+    expect(out).toEqual([
+      { title: "Doc", url: "https://example.com/doc", snippet: "Desc", source: "example.com" },
+    ])
+  })
+
+  it("maps the self-hosted engine's nested data.results shape", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      success: true,
+      data: { results: [{ title: "Self", url: "https://example.com/self", description: "Body" }] },
+    }))
+
+    await expect(webSearch(
+      "q",
+      { provider: "fastcrw", apiKey: "", providerConfigs: { fastcrw: { fastCrwUrl: "http://localhost:3000" } } },
+      5,
+    )).resolves.toEqual([
+      { title: "Self", url: "https://example.com/self", snippet: "Body", source: "example.com" },
+    ])
+  })
+
+  it("calls a self-hosted fastCRW base URL", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ success: true, data: { results: [] } }))
+
+    await webSearch(
+      "q",
+      { provider: "fastcrw", apiKey: "", providerConfigs: { fastcrw: { fastCrwUrl: "http://localhost:3000" } } },
+      5,
+    )
+
+    expect(fetchMock.mock.calls[0][0]).toBe("http://localhost:3000/v1/search")
+  })
+
+  it("strips a trailing slash from the fastCRW base URL", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ success: true, data: { results: [] } }))
+
+    await webSearch(
+      "q",
+      { provider: "fastcrw", apiKey: "", providerConfigs: { fastcrw: { fastCrwUrl: "http://localhost:3000/" } } },
+      5,
+    )
+
+    expect(fetchMock.mock.calls[0][0]).toBe("http://localhost:3000/v1/search")
+  })
+
+  it("omits the Authorization header for keyless self-hosted fastCRW", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ success: true, data: { results: [] } }))
+
+    await webSearch(
+      "q",
+      { provider: "fastcrw", apiKey: "", providerConfigs: { fastcrw: { fastCrwUrl: "http://localhost:3000" } } },
+      5,
+    )
+    const [, init] = fetchMock.mock.calls[0]
+
+    expect((init?.headers as Record<string, string>).Authorization).toBeUndefined()
+  })
+
+  it("does not leak a stale top-level apiKey to a keyless self-hosted fastCRW", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ success: true, data: [] }))
+
+    await webSearch(
+      "q",
+      {
+        provider: "fastcrw",
+        apiKey: "stale-other-provider-key",
+        providerConfigs: { fastcrw: { fastCrwUrl: "http://localhost:3000" } },
+      },
+      5,
+    )
+    const [url, init] = fetchMock.mock.calls[0]
+
+    expect(url).toBe("http://localhost:3000/v1/search")
+    expect((init?.headers as Record<string, string>).Authorization).toBeUndefined()
+  })
+
+  it("rejects whitespace-only fastCRW config as unconfigured", async () => {
+    await expect(webSearch(
+      "q",
+      { provider: "fastcrw", apiKey: "", providerConfigs: { fastcrw: { apiKey: "  ", fastCrwUrl: "  " } } },
+      5,
+    )).rejects.toThrow("fastCRW not configured")
+  })
+
+  it("allows empty fastCRW result sets", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ success: true, data: { results: [] } }))
+
+    await expect(webSearch(
+      "q",
+      { provider: "fastcrw", apiKey: "", providerConfigs: { fastcrw: { apiKey: "k" } } },
+      5,
+    )).resolves.toEqual([])
+  })
+
+  it("filters fastCRW results with missing URLs", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      success: true,
+      data: {
+        results: [
+          { title: "No URL", description: "skip" },
+          { title: "Has URL", url: "https://example.com/ok", description: "keep" },
+        ],
+      },
+    }))
+
+    await expect(webSearch(
+      "q",
+      { provider: "fastcrw", apiKey: "", providerConfigs: { fastcrw: { apiKey: "k" } } },
+      5,
+    )).resolves.toEqual([
+      { title: "Has URL", url: "https://example.com/ok", snippet: "keep", source: "example.com" },
+    ])
+  })
+
+  it("returns fastCRW results when success is true despite an advisory error field", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      success: true,
+      error: "partial results only",
+      data: { results: [{ title: "Advisory", url: "https://example.com/a", description: "Still usable" }] },
+    }))
+
+    await expect(webSearch(
+      "q",
+      { provider: "fastcrw", apiKey: "", providerConfigs: { fastcrw: { apiKey: "k" } } },
+      5,
+    )).resolves.toEqual([
+      { title: "Advisory", url: "https://example.com/a", snippet: "Still usable", source: "example.com" },
+    ])
+  })
+
+  it("surfaces fastCRW application errors", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ success: false, error: "bad query" }))
+
+    await expect(webSearch(
+      "q",
+      { provider: "fastcrw", apiKey: "", providerConfigs: { fastcrw: { apiKey: "k" } } },
+      5,
+    )).rejects.toThrow("fastCRW search failed: bad query")
+  })
+
+  it("surfaces fastCRW unknown error fallback", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ success: false }))
+
+    await expect(webSearch(
+      "q",
+      { provider: "fastcrw", apiKey: "", providerConfigs: { fastcrw: { apiKey: "k" } } },
+      5,
+    )).rejects.toThrow("fastCRW search failed: Unknown error")
+  })
+
+  it("surfaces fastCRW non-ok JSON errors", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ success: false, error: "Invalid or missing API key" }, { status: 401 }))
+
+    await expect(webSearch(
+      "q",
+      { provider: "fastcrw", apiKey: "", providerConfigs: { fastcrw: { apiKey: "bad" } } },
+      5,
+    )).rejects.toThrow("fastCRW search failed (401): Invalid or missing API key")
+  })
+
+  it("surfaces fastCRW non-json HTTP errors", async () => {
+    fetchMock.mockResolvedValueOnce(new Response("<html>Service unavailable</html>", {
+      status: 503,
+      headers: { "Content-Type": "text/html" },
+    }))
+
+    await expect(webSearch(
+      "q",
+      { provider: "fastcrw", apiKey: "", providerConfigs: { fastcrw: { apiKey: "k" } } },
+      5,
+    )).rejects.toThrow("fastCRW search failed (503): <html>Service unavailable</html>")
+  })
+
+  it("surfaces fastCRW network errors", async () => {
+    fetchMock.mockRejectedValueOnce(new TypeError("Failed to fetch"))
+
+    await expect(webSearch(
+      "q",
+      { provider: "fastcrw", apiKey: "", providerConfigs: { fastcrw: { apiKey: "k" } } },
+      5,
+    )).rejects.toThrow("Network error reaching fastCRW Search")
+  })
+
+  it("migrates a legacy top-level apiKey into fastCRW config", () => {
+    const resolved = resolveSearchConfig({ provider: "fastcrw", apiKey: "k" })
+
+    expect(resolved.providerConfigs?.fastcrw?.apiKey).toBe("k")
+  })
+
+  it("treats fastCRW as configured with either a key or a self-host URL", () => {
+    expect(hasConfiguredSearchProvider({
+      provider: "fastcrw",
+      apiKey: "",
+      providerConfigs: { fastcrw: { apiKey: "k" } },
+    })).toBe(true)
+    expect(hasConfiguredSearchProvider({
+      provider: "fastcrw",
+      apiKey: "",
+      providerConfigs: { fastcrw: { fastCrwUrl: "http://localhost:3000" } },
+    })).toBe(true)
+    expect(hasConfiguredSearchProvider({
+      provider: "fastcrw",
+      apiKey: "",
+      providerConfigs: { fastcrw: {} },
+    })).toBe(false)
+    expect(hasConfiguredSearchProvider({
+      provider: "fastcrw",
+      apiKey: "",
+      providerConfigs: { fastcrw: { apiKey: "  ", fastCrwUrl: "  " } },
+    })).toBe(false)
+  })
+
   it("requires a configured search provider and key", async () => {
     await expect(webSearch("x", { provider: "none", apiKey: "" }, 5))
       .rejects.toThrow("Select a search provider")

--- a/src/lib/web-search.ts
+++ b/src/lib/web-search.ts
@@ -117,6 +117,10 @@ export function hasConfiguredSearchProvider(config: SearchApiConfig): boolean {
   if (resolved.provider === "firecrawl") {
     return true
   }
+  if (resolved.provider === "fastcrw") {
+    const cfg = resolved.providerConfigs?.fastcrw
+    return Boolean(cfg?.apiKey?.trim() || cfg?.fastCrwUrl?.trim())
+  }
   return Boolean(resolved.apiKey?.trim())
 }
 
@@ -149,6 +153,12 @@ export async function webSearch(
   if (resolved.provider === "ollama" && !resolved.apiKey?.trim()) {
     throw new Error("Ollama Web Search API requires an Ollama API key. Add one in Settings.")
   }
+  if (resolved.provider === "fastcrw") {
+    const cfg = resolved.providerConfigs?.fastcrw
+    if (!cfg?.apiKey?.trim() && !cfg?.fastCrwUrl?.trim()) {
+      throw new Error("fastCRW not configured. Add a fastCRW API key (fastcrw.com), or set a self-hosted Base URL in Settings.")
+    }
+  }
 
   switch (resolved.provider) {
     case "tavily":
@@ -161,6 +171,12 @@ export async function webSearch(
       return ollamaSearch(query, resolved.apiKey ?? "", maxResults)
     case "firecrawl":
       return firecrawlSearch(query, maxResults)
+    case "fastcrw": {
+      // Read key + url only from fastcrw's own override — never fall back to the
+      // flattened top-level apiKey, which can hold another provider's key.
+      const cfg = resolved.providerConfigs?.fastcrw
+      return fastcrwSearch(query, cfg?.apiKey ?? "", cfg?.fastCrwUrl ?? "", maxResults)
+    }
     default:
       throw new Error(`Unknown search provider: ${resolved.provider}`)
   }
@@ -395,6 +411,95 @@ function normalizeFirecrawlResult(item: unknown): WebSearchResult {
     url,
     snippet: r.snippet ?? r.description ?? r.metadata?.description ?? r.content ?? r.markdown ?? "",
     source: hostnameFromUrl(url) || r.source || "",
+  }
+}
+
+const FASTCRW_DEFAULT_BASE_URL = "https://api.fastcrw.com"
+
+// The managed cloud (api.fastcrw.com) returns results as a flat `data` array;
+// the self-hosted engine nests them under `data.results`. Handle both.
+interface FastCrwSearchResponse {
+  success?: boolean
+  error?: string
+  data?: unknown[] | { results?: unknown[] }
+}
+
+async function fastcrwSearch(
+  query: string,
+  apiKey: string,
+  baseUrl: string,
+  maxResults: number,
+): Promise<WebSearchResult[]> {
+  const base = (baseUrl.trim() || FASTCRW_DEFAULT_BASE_URL).replace(/\/+$/, "")
+  const key = apiKey.trim()
+  const httpFetch = await getHttpFetch()
+  let response: Response
+  try {
+    response = await httpFetch(`${base}/v1/search`, {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+        ...(key ? { Authorization: `Bearer ${key}` } : {}),
+      },
+      body: JSON.stringify({
+        query,
+        limit: maxResults,
+      }),
+    })
+  } catch (err) {
+    if (isFetchNetworkError(err)) {
+      throw new Error(
+        "Network error reaching fastCRW Search. Check your connectivity or choose another Web Search provider.",
+      )
+    }
+    throw err
+  }
+
+  const text = await response.text().catch(() => "")
+  let data: FastCrwSearchResponse = {}
+  try {
+    data = text ? JSON.parse(text) as FastCrwSearchResponse : {}
+  } catch {
+    if (!response.ok) {
+      throw new Error(`fastCRW search failed (${response.status}): ${text || "Unknown error"}`)
+    }
+    throw new Error("fastCRW search returned an invalid JSON response.")
+  }
+
+  if (!response.ok) {
+    throw new Error(`fastCRW search failed (${response.status}): ${data.error ?? text ?? "Unknown error"}`)
+  }
+
+  if (data.success === false || (data.success !== true && typeof data.error === "string" && data.error.trim())) {
+    throw new Error(`fastCRW search failed: ${data.error ?? "Unknown error"}`)
+  }
+
+  return normalizeFastCrwResults(data, maxResults)
+}
+
+function normalizeFastCrwResults(data: FastCrwSearchResponse, maxResults: number): WebSearchResult[] {
+  const d = data.data
+  const rawResults: unknown[] = Array.isArray(d) ? d : (d?.results ?? [])
+  return rawResults
+    .slice(0, maxResults)
+    .map((item) => normalizeFastCrwResult(item))
+    .filter((item) => item.url.length > 0)
+}
+
+function normalizeFastCrwResult(item: unknown): WebSearchResult {
+  const r = item as {
+    title?: string
+    url?: string
+    description?: string
+    snippet?: string
+  }
+  const url = r.url ?? ""
+  return {
+    title: r.title ?? "Untitled",
+    url,
+    snippet: r.snippet || r.description || "",
+    source: hostnameFromUrl(url),
   }
 }
 

--- a/src/stores/wiki-store.ts
+++ b/src/stores/wiki-store.ts
@@ -38,7 +38,7 @@ interface LlmConfig {
   codexCliTimeoutMinutes?: number
 }
 
-export type SearchProvider = "tavily" | "serpapi" | "searxng" | "ollama" | "firecrawl" | "none"
+export type SearchProvider = "tavily" | "serpapi" | "searxng" | "ollama" | "firecrawl" | "fastcrw" | "none"
 export type DeepResearchSource = "web" | "anytxt" | "both"
 export type SerpApiEngine =
   | "google"
@@ -70,6 +70,7 @@ export interface SearchProviderOverride {
   searXngUrl?: string
   searXngCategories?: SearXngCategory[]
   ollamaUrl?: string
+  fastCrwUrl?: string
 }
 
 export type SearchProviderConfigs = Partial<Record<Exclude<SearchProvider, "none">, SearchProviderOverride>>


### PR DESCRIPTION
## What

Adds **fastCRW** as a web search provider, alongside the existing Tavily / SerpApi / SearXNG / Ollama / Firecrawl options. Because Deep Research consumes the active web-search provider generically, this also makes fastCRW available for Deep Research with no extra wiring.

fastCRW is a SearXNG-based, Firecrawl-compatible search API. It can be used two ways:
- **Managed cloud** (`https://api.fastcrw.com`) with an API key from fastcrw.com.
- **Self-hosted** — point the Base URL at your own instance (e.g. `http://localhost:3000`) for unlimited, private search (no key required unless your instance enables auth).

## Why a new provider instead of the existing Firecrawl entry

The Firecrawl entry is `configKind: "none"` (anonymous, no config). fastCRW needs a Bearer API key for the cloud **and** a configurable Base URL for self-hosting. Folding it into Firecrawl would change Firecrawl's behavior, so a sibling provider is cleaner and keeps existing providers untouched.

## Changes (purely additive)

- `stores/wiki-store.ts` — `"fastcrw"` added to the `SearchProvider` union; `fastCrwUrl?` added to `SearchProviderOverride`.
- `lib/web-search.ts` — `fastcrwSearch` + normalizer + dispatch case + `hasConfiguredSearchProvider`/guard branches.
- `components/settings/sections/web-search-section.tsx` — provider entry with a new `key+url` config kind (renders both an API-key and a Base-URL input).
- `i18n/en.json` + `i18n/zh.json` — hint + error strings (parity preserved).
- `lib/web-search.test.ts` — 17 tests mirroring the Firecrawl suite.

## Notes

- Endpoint is `POST {baseUrl}/v1/search`; results are read from either the cloud's flat `data` array or the self-hosted engine's `data.results` (both shapes handled).
- API key + Base URL are read only from the provider's own config (never a stale top-level key), so a keyless self-host never receives another provider's `Authorization` header.
- No README/docs edits (mirrors Firecrawl's footprint); intentionally no IP-block error string since fastCRW uses Bearer auth, not anonymous access.

## Verification (local)

`npm run typecheck` · `npx vitest run` (1541 passed, incl. i18n parity) · `npm run build` — all green.
