### PR TITLE
fix: use {"mcpServers":{}} instead of {} for empty MCP config

### DIFF
--- a/src-tauri/src/commands/claude_cli.rs
+++ b/src-tauri/src/commands/claude_cli.rs
@@ -404,7 +404,7 @@ fn build_claude_cli_args(model: &str, isolate_local_config: bool) -> Vec<String>
             "project".to_string(),
             "--strict-mcp-config".to_string(),
             "--mcp-config".to_string(),
-            "{}".to_string(),
+            r#"{"mcpServers":{}}"#.to_string(),
             "--disable-slash-commands".to_string(),
             "--tools".to_string(),
             "".to_string(),
@@ -530,7 +530,7 @@ mod tests {
         assert!(args.contains(&"--strict-mcp-config".to_string()));
         assert!(args
             .windows(2)
-            .any(|pair| pair[0] == "--mcp-config" && pair[1] == "{}"));
+            .any(|pair| pair[0] == "--mcp-config" && pair[1] == r#"{"mcpServers":{}}"#));
         assert!(args.contains(&"--disable-slash-commands".to_string()));
         assert!(args
             .windows(2)


### PR DESCRIPTION
Fixes #437

## Note
  I am not a Rust developer. I used Claude Code to fix this.

## What I experienced

Clicking **Test connection** under Settings > LLM Models > Claude Code CLI (local) failed with:

```
claude CLI exited with code 1: Error: Invalid MCP configuration: mcpServers: Invalid input: expected record, received undefined
```

This happened regardless of the "Isolate local CLI configuration" toggle.

## Root cause

When the connection test runs with isolation enabled, LLM Wiki passes `--mcp-config {}` to the Claude CLI. 

  Newer versions of Claude CLI validate that the JSON contains a `mcpServers` key. `{}` leaves it as `undefined`, which fails schema validation.

## Fix

Pass `{"mcpServers":{}}` instead of `{}`. The config is still empty (no MCP servers), but the required key is now explicitly present. Updated the unit test to match.

## Verified

After the fix, Test connection succeeds: **Connected in 2450 ms. Response: Ready**