### PR TITLE
feat: add Jina Search as a web search provider

### DIFF
--- a/src/components/settings/sections/web-search-section.tsx
+++ b/src/components/settings/sections/web-search-section.tsx
@@ -54,6 +54,13 @@ const SEARCH_PROVIDERS = [
     hint: "Anonymous Firecrawl Search API",
     configKind: "none",
   },
+  {
+    id: "jina",
+    label: "Jina",
+    hint: "Jina Search API (s.jina.ai)",
+    keyPlaceholder: "Enter your Jina API key (jina.ai)",
+    configKind: "key",
+  },
 ] as const
 
 export function WebSearchSection() {

--- a/src/lib/web-search.test.ts
+++ b/src/lib/web-search.test.ts
@@ -34,6 +34,44 @@ describe("webSearch", () => {
     ])
   })
 
+  it("calls Jina Search and normalizes results using descriptions as snippets", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      code: 200,
+      status: 200,
+      data: [
+        { title: "Wikipedia", url: "https://www.wikipedia.org/", description: "Free encyclopedia", content: "" },
+        { title: "No url", url: "", description: "skip me" },
+      ],
+    }))
+
+    const out = await webSearch("wikipedia", { provider: "jina", apiKey: "jina-key" }, 5)
+    const [url, init] = fetchMock.mock.calls[0]
+    const parsed = new URL(String(url))
+
+    expect(parsed.origin + parsed.pathname).toBe("https://s.jina.ai/")
+    expect(parsed.searchParams.get("q")).toBe("wikipedia")
+    expect(parsed.searchParams.get("count")).toBe("5")
+    expect(init).toEqual(expect.objectContaining({ method: "GET" }))
+    expect((init?.headers as Record<string, string>).Authorization).toBe("Bearer jina-key")
+    expect((init?.headers as Record<string, string>)["X-Respond-With"]).toBe("no-content")
+    expect(out).toEqual([
+      { title: "Wikipedia", url: "https://www.wikipedia.org/", snippet: "Free encyclopedia", source: "wikipedia.org" },
+    ])
+  })
+
+  it("throws a clear error when Jina is selected without an API key", async () => {
+    await expect(webSearch("x", { provider: "jina", apiKey: "" }, 3)).rejects.toThrow(/Jina/)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it("surfaces Jina authentication failures", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ name: "AuthenticationFailedError" }, { status: 401 }))
+
+    await expect(
+      webSearch("x", { provider: "jina", apiKey: "bad-key" }, 3),
+    ).rejects.toThrow(/authentication failed/i)
+  })
+
   it("calls SerpApi Google Search and normalizes organic results", async () => {
     fetchMock.mockResolvedValueOnce(jsonResponse({
       organic_results: [

--- a/src/lib/web-search.ts
+++ b/src/lib/web-search.ts
@@ -143,6 +143,9 @@ export async function webSearch(
   if ((resolved.provider === "tavily" || resolved.provider === "serpapi") && !resolved.apiKey) {
     throw new Error("Web search not configured. Add a Tavily or SerpApi API key in Settings, or select a key-free provider such as Firecrawl or SearXNG.")
   }
+  if (resolved.provider === "jina" && !resolved.apiKey?.trim()) {
+    throw new Error("Jina Search requires a Jina API key. Add one in Settings (jina.ai).")
+  }
   if (resolved.provider === "searxng" && !resolved.searXngUrl?.trim()) {
     throw new Error("Web search not configured. Add a SearXNG instance URL in Settings.")
   }
@@ -161,6 +164,8 @@ export async function webSearch(
       return ollamaSearch(query, resolved.apiKey ?? "", maxResults)
     case "firecrawl":
       return firecrawlSearch(query, maxResults)
+    case "jina":
+      return jinaSearch(query, resolved.apiKey ?? "", maxResults)
     default:
       throw new Error(`Unknown search provider: ${resolved.provider}`)
   }
@@ -556,4 +561,89 @@ async function ollamaSearch(
         source: hostnameFromUrl(url),
       }
     })
+}
+
+interface JinaSearchResponse {
+  code?: number
+  status?: number
+  data?: Array<{
+    title?: string
+    url?: string
+    description?: string
+    content?: string
+  }>
+  // Jina returns this name on failures (e.g. invalid token, quota).
+  name?: string
+  message?: string
+  readableMessage?: string
+}
+
+async function jinaSearch(
+  query: string,
+  apiKey: string,
+  maxResults: number,
+): Promise<WebSearchResult[]> {
+  const trimmedApiKey = apiKey.trim()
+  if (!trimmedApiKey) {
+    throw new Error("Jina Search requires a Jina API key. Add one in Settings (jina.ai).")
+  }
+
+  const endpoint = new URL("https://s.jina.ai/")
+  endpoint.searchParams.set("q", query)
+  // Jina caps `count` at 20; never request fewer than 1 result.
+  endpoint.searchParams.set("count", String(Math.max(1, Math.min(maxResults, 20))))
+
+  const httpFetch = await getHttpFetch()
+  let response: Response
+  try {
+    response = await httpFetch(endpoint.toString(), {
+      method: "GET",
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${trimmedApiKey}`,
+        // Return the SERP only; skip reading each result page so the search
+        // stays fast and cheap. Snippets come from each item's description.
+        "X-Respond-With": "no-content",
+      },
+    })
+  } catch (err) {
+    if (isFetchNetworkError(err)) {
+      throw new Error(
+        "Network error reaching s.jina.ai. Check your connectivity and whether the Jina API key is still valid.",
+      )
+    }
+    throw err
+  }
+
+  const text = await response.text().catch(() => "")
+  let data: JinaSearchResponse = {}
+  try {
+    data = text ? (JSON.parse(text) as JinaSearchResponse) : {}
+  } catch {
+    if (!response.ok) {
+      throw new Error(`Jina search failed (${response.status}): ${text || "Unknown error"}`)
+    }
+    throw new Error("Jina search returned an invalid JSON response.")
+  }
+
+  if (!response.ok) {
+    if (response.status === 401) {
+      throw new Error("Jina search authentication failed. Check your Jina API key.")
+    }
+    const detail = data.readableMessage ?? data.message ?? data.name ?? (text || "Unknown error")
+    throw new Error(`Jina search failed (${response.status}): ${detail}`)
+  }
+
+  return (data.data ?? [])
+    .slice(0, maxResults)
+    .map((r) => {
+      const url = r.url ?? ""
+      return {
+        title: r.title ?? "Untitled",
+        url,
+        snippet: r.description ?? r.content ?? "",
+        source: hostnameFromUrl(url),
+      }
+    })
+    .filter((item) => item.url.length > 0)
 }

--- a/src/stores/wiki-store.ts
+++ b/src/stores/wiki-store.ts
@@ -38,7 +38,7 @@ interface LlmConfig {
   codexCliTimeoutMinutes?: number
 }
 
-export type SearchProvider = "tavily" | "serpapi" | "searxng" | "ollama" | "firecrawl" | "none"
+export type SearchProvider = "tavily" | "serpapi" | "searxng" | "ollama" | "firecrawl" | "jina" | "none"
 export type DeepResearchSource = "web" | "anytxt" | "both"
 export type SerpApiEngine =
   | "google"


### PR DESCRIPTION
## Summary

  - Adds [Jina Search](https://jina.ai) (`s.jina.ai`) as a new web search provider alongside Tavily, SerpApi, SearXNG, Firecrawl, and Ollama
  - Uses `X-Respond-With: no-content` to return SERP results only (no per-page content fetching), keeping searches fast and token-efficient
  - Snippets are sourced from each result's `description` field

  ## Changes

  - `wiki-store.ts` — added `"jina"` to the `SearchProvider` union type
  - `web-search.ts` — added `jinaSearch()` with auth, error handling, and result normalization consistent with existing providers
  - `web-search-section.tsx` — added Jina entry to `SEARCH_PROVIDERS` (key-based config, works with the existing password input + Test button UI)
  - `web-search.test.ts` — 3 new tests: result normalization, missing API key error, 401 auth failure

  ## Test plan

  - [x] Add a Jina API key in Settings → Web Search → Jina
  - [x] Click "Test" — expect at least 1 result returned
  - [x] Activate Jina as the provider, run a Deep Research query
  - [x] Leave key empty, click "Test" — expect a clear error message
  - [x] All 28 unit tests pass (`npx vitest run src/lib/web-search.test.ts`)