### PR TITLE
fix: pass valid empty MCP config to Claude CLI

### DIFF
--- a/src-tauri/src/commands/claude_cli.rs
+++ b/src-tauri/src/commands/claude_cli.rs
@@ -30,6 +30,8 @@ use tokio::sync::Mutex;
 
 use super::cli_resolver::find_cli_command;
 
+const EMPTY_MCP_CONFIG: &str = r#"{"mcpServers":{}}"#;
+
 /// Shared state holding running `claude` child processes keyed by the
 /// frontend-generated stream id. Registered via .manage() in lib.rs.
 #[derive(Default)]
@@ -404,7 +406,7 @@ fn build_claude_cli_args(model: &str, isolate_local_config: bool) -> Vec<String>
             "project".to_string(),
             "--strict-mcp-config".to_string(),
             "--mcp-config".to_string(),
-            "{}".to_string(),
+            EMPTY_MCP_CONFIG.to_string(),
             "--disable-slash-commands".to_string(),
             "--tools".to_string(),
             "".to_string(),
@@ -528,9 +530,16 @@ mod tests {
             .windows(2)
             .any(|pair| pair[0] == "--setting-sources" && pair[1] == "project"));
         assert!(args.contains(&"--strict-mcp-config".to_string()));
-        assert!(args
+        let mcp_config = args
             .windows(2)
-            .any(|pair| pair[0] == "--mcp-config" && pair[1] == "{}"));
+            .find_map(|pair| (pair[0] == "--mcp-config").then_some(pair[1].as_str()))
+            .expect("isolation mode should pass an explicit empty MCP config");
+        assert_eq!(mcp_config, EMPTY_MCP_CONFIG);
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(mcp_config)
+                .expect("empty MCP config should be valid JSON"),
+            serde_json::json!({ "mcpServers": {} })
+        );
         assert!(args.contains(&"--disable-slash-commands".to_string()));
         assert!(args
             .windows(2)


### PR DESCRIPTION
## Problem

Fixes #459.

The local Claude Code CLI provider passed `--mcp-config "{}"` when local CLI config isolation was enabled. Claude Code CLI rejects that shape because it expects an explicit top-level `mcpServers` record, even when there are no MCP servers.

## Root cause

`build_claude_cli_args` serialized an empty isolated MCP config as `{}`. Newer Claude Code CLI versions validate that config as missing `mcpServers`, so provider connection checks can fail before the prompt is sent.

## Fix

- Pass `{"mcpServers":{}}` for the isolated empty MCP config.
- Keep `--strict-mcp-config` and the existing isolation flags intact.
- Update the Rust unit test to assert both the exact argument value and valid JSON shape.

## Validation

- `npm run typecheck`
- `npm run test:mocks -- src/lib/connection-tests.test.ts src/lib/__tests__/claude-cli-transport.test.ts` (37 tests)
- `npm run build`
- Not run locally: `cargo test --manifest-path src-tauri/Cargo.toml claude_args_can_isolate_user_config_tools_and_mcp` (`cargo`/`rustup` are not installed in this shell)
