### PR TITLE
feat: support configurable bind host via LLM_WIKI_BIND_HOST env var

### DIFF
--- a/src-tauri/src/api_server.rs
+++ b/src-tauri/src/api_server.rs
@@ -73,7 +73,7 @@ pub fn start_api_server(app: AppHandle) {
         };
 
         API_STATUS.store(1, Ordering::Relaxed);
-        eprintln!("[API Server] Listening on http://127.0.0.1:{PORT}{API_PREFIX}");
+        eprintln!("[API Server] Listening on http://{}:{PORT}{API_PREFIX}", bind_host());
 
         for request in server.incoming_requests() {
             let method = request.method().clone();
@@ -104,13 +104,24 @@ pub fn start_api_server(app: AppHandle) {
     });
 }
 
+/// Returns the bind host for the API server.
+///
+/// Reads `LLM_WIKI_BIND_HOST` from the environment, falling back to
+/// `127.0.0.1` so existing installs keep their loopback-only behavior.
+/// Set to `0.0.0.0` to accept connections from other machines on the LAN.
+fn bind_host() -> String {
+    std::env::var("LLM_WIKI_BIND_HOST").unwrap_or_else(|_| "127.0.0.1".to_string())
+}
+
 fn bind_server_with_retry() -> Option<Server> {
+    let host = bind_host();
+    let addr = format!("{host}:{PORT}");
     for attempt in 1..=MAX_BIND_RETRIES {
-        match Server::http(format!("127.0.0.1:{PORT}")) {
+        match Server::http(&addr) {
             Ok(server) => return Some(server),
             Err(err) => {
                 eprintln!(
-                    "[API Server] Failed to bind 127.0.0.1:{PORT} (attempt {attempt}/{MAX_BIND_RETRIES}): {err}"
+                    "[API Server] Failed to bind {addr} (attempt {attempt}/{MAX_BIND_RETRIES}): {err}"
                 );
                 if attempt < MAX_BIND_RETRIES {
                     thread::sleep(Duration::from_secs(BIND_RETRY_DELAY_SECS));

--- a/src-tauri/src/clip_server.rs
+++ b/src-tauri/src/clip_server.rs
@@ -40,6 +40,15 @@ pub fn all_projects() -> Vec<(String, String)> {
         .unwrap_or_default()
 }
 
+/// Returns the bind host for the Clip server.
+///
+/// Reads `LLM_WIKI_BIND_HOST` from the environment, falling back to
+/// `127.0.0.1` so existing installs keep their loopback-only behavior.
+/// Set to `0.0.0.0` to accept connections from other machines on the LAN.
+fn bind_host() -> String {
+    std::env::var("LLM_WIKI_BIND_HOST").unwrap_or_else(|_| "127.0.0.1".to_string())
+}
+
 pub fn start_clip_server() {
     thread::spawn(|| {
         let mut restart_count: u32 = 0;
@@ -50,7 +59,7 @@ pub fn start_clip_server() {
                 let mut last_err = String::new();
                 let mut bound = None;
                 for attempt in 1..=MAX_BIND_RETRIES {
-                    match Server::http(format!("127.0.0.1:{}", PORT)) {
+                    match Server::http(format!("{}:{}", bind_host(), PORT)) {
                         Ok(s) => {
                             bound = Some(s);
                             break;
@@ -84,7 +93,7 @@ pub fn start_clip_server() {
 
             DAEMON_STATUS.store(1, Ordering::Relaxed); // running
             restart_count = 0; // Reset on successful bind
-            println!("[Clip Server] Listening on http://127.0.0.1:{}", PORT);
+            println!("[Clip Server] Listening on http://{}:{}", bind_host(), PORT);
 
             for mut request in server.incoming_requests() {
                 let cors_headers = vec![


### PR DESCRIPTION
## Summary

Both the API server (port 19828) and Clip server (port 19827) are hardcoded to bind `127.0.0.1`, which prevents LAN access from other machines. This PR adds an `LLM_WIKI_BIND_HOST` environment variable so users can set `0.0.0.0` to listen on all interfaces.

Closes #474

## Changes

- **`src-tauri/src/api_server.rs`**: Added `bind_host()` helper that reads `LLM_WIKI_BIND_HOST` (default `127.0.0.1`). Used in `bind_server_with_retry()` and the listening log line.
- **`src-tauri/src/clip_server.rs`**: Same `bind_host()` helper. Used in the bind loop and the listening log line.

## Behavior

| `LLM_WIKI_BIND_HOST` | Behavior |
|---|---|
| *(unset)* | Binds `127.0.0.1` — identical to current behavior |
| `0.0.0.0` | Listens on all interfaces — enables LAN access |
| `192.168.1.100` | Binds to a specific interface |

## Backward Compatibility

Fully backward compatible. No environment variable = no behavior change. Existing users, CI, and the default desktop experience are unaffected.

## Testing

- `cargo build` passes on Linux (the same check run in CI).
- Verified `bind_host()` returns `"127.0.0.1"` when the env var is unset.
- Verified `bind_host()` returns the env var value when set.

## Diff Summary

```
 2 files changed, 25 insertions(+), 5 deletions(-)
```
