### PR TITLE
ci: restore Intel macOS (x86_64) build that was dropped in cea0029

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,13 @@ jobs:
           - platform: macos-latest
             args: '--target aarch64-apple-darwin'
             rust_target: aarch64-apple-darwin
+          # Intel macOS build. macos-13 is GitHub's last x86_64 runner
+          # (macos-14+ are Apple Silicon), so this is a NATIVE build —
+          # no cross-compile. Restores the Intel .dmg dropped after
+          # v0.2.0, when the macOS matrix narrowed to aarch64 only.
+          - platform: macos-13
+            args: '--target x86_64-apple-darwin'
+            rust_target: x86_64-apple-darwin
           - platform: ubuntu-22.04
             args: ''
             rust_target: ''
@@ -59,7 +66,8 @@ jobs:
       # The repo ships pre-downloaded PDFium binaries under
       # src-tauri/pdfium/ for every supported architecture
       # (libpdfium.so = Linux x86_64, libpdfium-arm64.so = Linux aarch64,
-      # libpdfium.dylib = macOS arm64, pdfium.dll = Windows).
+      # libpdfium.dylib = macOS arm64, libpdfium-x86_64.dylib = macOS Intel,
+      # pdfium.dll = Windows).
       # For architectures whose bundled filename must
       # stay `libpdfium.*`, swap the matching binary into place before cargo
       # runs. We do NOT pull from bblanchon/pdfium-binaries during CI — that
@@ -76,6 +84,12 @@ jobs:
         run: |
           cp src-tauri/pdfium/libpdfium-arm64.so src-tauri/pdfium/libpdfium.so
           file src-tauri/pdfium/libpdfium.so
+
+      - name: Use x86_64 pdfium binary (macOS Intel only)
+        if: matrix.rust_target == 'x86_64-apple-darwin'
+        run: |
+          cp src-tauri/pdfium/libpdfium-x86_64.dylib src-tauri/pdfium/libpdfium.dylib
+          file src-tauri/pdfium/libpdfium.dylib
 
       - name: Install protoc (Windows)
         if: matrix.platform == 'windows-latest'


### PR DESCRIPTION
Follow-up to #416 (merged).

**What happened**

- #416 added the Intel macOS build (native `x86_64` on the `macos-13` runner).
- You then improved it in `4f117d6` ("ci: add intel macos pdfium binary") — committing `libpdfium-x86_64.dylib`, a checksum step, and a swap step so the Intel `.app` links the correct PDFium. 
- Commit `cea0029` ("feat: add chat agent routing") then **removed** both the `macos-13` matrix entry and the Intel PDFium swap step. The subject is about chat routing, unrelated to CI, so this looks unintentional — a stray hunk that rode along with the feature commit.

**Effect:** no Intel macOS artifact has shipped since v0.5.0 (v0.5.0 / v0.5.1 / v0.5.2 releases have only `aarch64.dmg`). Intel Mac users are back to having no prebuilt binary.

**This PR** simply restores those two pieces — identical to your own `4f117d6` config:
- the `macos-13` / `x86_64-apple-darwin` matrix row, and
- the `Use x86_64 pdfium binary (macOS Intel only)` step.

The committed `libpdfium-x86_64.dylib` is still in the tree, so no new binaries are needed. Native build, no cross-compile.

I verified v0.4.24–v0.5.2 all build to a working x86_64 `.app`/`.dmg` on a real Intel iMac. If the removal was in fact deliberate (e.g. runner cost or `macos-13` retirement timeline), feel free to close — just flagging it in case it was accidental.

🤖 Generated with [Claude Code](https://claude.com/claude-code)