### PR TITLE
fix: clear llmConfig when all LLM presets are deactivated

### DIFF
--- a/src/components/settings/sections/llm-provider-section.tsx
+++ b/src/components/settings/sections/llm-provider-section.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from "react-i18next"
 import { invoke } from "@tauri-apps/api/core"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
-import { useWikiStore, type ProviderOverride, type ReasoningConfig, type ReasoningMode } from "@/stores/wiki-store"
+import { useWikiStore, type LlmConfig, type ProviderOverride, type ReasoningConfig, type ReasoningMode } from "@/stores/wiki-store"
 import { LLM_PRESETS, type LlmPreset } from "../llm-presets"
 import { ContextSizeSelector } from "../context-size-selector"
 import { resolveConfig } from "../preset-resolver"
@@ -41,6 +41,16 @@ export function LlmProviderSection() {
         setLlmConfig(resolved)
         await saveLlmConfig(resolved)
       }
+    } else {
+      // All presets disabled: write llmConfig into a state where hasUsableLlm()
+      // returns false so ingest, dedup, and sweep queues pause immediately.
+      // Clearing provider to "openai" (a keyed provider) + empty apiKey covers
+      // the case where the previous provider was a keyless local CLI.
+      // resolveConfig() on re-enable reads from providerConfigs[], not llmConfig,
+      // so the cleared values here do not affect the user's saved settings.
+      const cleared: LlmConfig = { ...llmConfig, provider: "openai", apiKey: "" }
+      setLlmConfig(cleared)
+      await saveLlmConfig(cleared)
     }
   }
 


### PR DESCRIPTION
## Problem

When the user toggles off the last active LLM preset, `toggleActive()` sets `activePresetId` to `null` and calls `persist(providerConfigs, null)`. Inside `persist()`, the `if (newActive)` block is skipped, so `setLlmConfig()` and `saveLlmConfig()` are never called.

The result: `llmConfig` in the store still holds the previous provider's config. Background queues (`ingest-queue`, `dedup-queue`, `sweep-reviews`, `clip-watcher`) all guard themselves with `hasUsableLlm(llmConfig)`, which reads from the un-updated `llmConfig` and continues to return `true` — so processing carries on even though the user explicitly disabled all providers.

This is most visible with keyless providers (Claude Code CLI, Codex CLI, Ollama): turning them off has no observable effect on ingest.

## Fix

Add an `else` branch to `persist()` that, when `newActive === null`, writes `llmConfig` to a state where `hasUsableLlm()` returns `false`:

```ts
} else {
  const cleared: LlmConfig = { ...llmConfig, provider: "openai", apiKey: "" }
  setLlmConfig(cleared)
  await saveLlmConfig(cleared)
}
```

Setting `provider` to `"openai"` (a keyed provider) and clearing `apiKey` makes `hasUsableLlm()` return `false` regardless of what the previous provider was — including keyless local CLI providers that `hasUsableLlm` would otherwise always pass.

`resolveConfig()` is safe: on re-enable it reads `provider` and `apiKey` from `providerConfigs[newActive]` (the user's saved per-preset settings), not from `llmConfig`, so the cleared values here do not affect the user's stored configuration.

## Testing

1. Configure any LLM preset (including a keyless one like Claude Code CLI).
2. Start an ingest run.
3. Toggle the active preset off — the toggle turns grey and `activePresetId` becomes `null`.
4. Observe that in-progress tasks complete but no new tasks are picked up from the queue.
5. Toggle the same preset back on — processing resumes with the correct config.