### PR TITLE
feat: add explicit pause/resume for the ingest queue

### DIFF
--- a/src/components/layout/activity-panel.tsx
+++ b/src/components/layout/activity-panel.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef, useCallback } from "react"
 import {
   ChevronUp, ChevronDown, Loader2, CheckCircle2, AlertCircle,
   FileText, Users, Lightbulb, BookOpen, GitMerge, BarChart3, HelpCircle, Layout,
-  RotateCcw, X, Clock, TrendingUp, Target,
+  RotateCcw, X, Clock, TrendingUp, Target, Pause, Play,
 } from "lucide-react"
 import { useActivityStore, type ActivityItem } from "@/stores/activity-store"
 import { useWikiStore } from "@/stores/wiki-store"
@@ -15,6 +15,8 @@ import {
   retryAllFailedTasks,
   cancelTask,
   cancelAllTasks,
+  pauseProcessing,
+  resumeProcessing,
   type IngestTask,
 } from "@/lib/ingest-queue"
 import {
@@ -132,6 +134,15 @@ export function ActivityPanel() {
     )) return
     cancelAllTasks()
   }, [project, queueSummary.pending, queueSummary.processing])
+
+  const handleTogglePause = useCallback(() => {
+    if (!project) return
+    if (queueSummary.paused) {
+      resumeProcessing()
+    } else {
+      pauseProcessing()
+    }
+  }, [project, queueSummary.paused])
 
   const handleFileSyncRescan = useCallback(() => {
     if (!project) return
@@ -253,10 +264,24 @@ export function ActivityPanel() {
           {hasQueue && (queueSummary.processing > 0 || queueSummary.pending > 0) && (
             <div className="px-3 py-1.5 border-b border-border/50">
               <div className="flex items-center justify-between text-[10px] text-muted-foreground mb-1 gap-2">
-                <span>Ingest Queue</span>
+                <span>{queueSummary.paused ? "Ingest Queue (paused)" : "Ingest Queue"}</span>
                 <span className="flex-1 text-right">
                   {queueSummary.completed + queueSummary.failed}/{queueSummary.total} complete
                 </span>
+                {(queueSummary.pending > 0 || queueSummary.paused) && (
+                  <button
+                    onClick={handleTogglePause}
+                    className="flex items-center gap-0.5 rounded px-1.5 py-0.5 text-[10px] hover:bg-accent hover:text-foreground"
+                    title={
+                      queueSummary.paused
+                        ? "Resume processing queued tasks"
+                        : "Pause — let the current task finish, then stop before the next (no more LLM calls)"
+                    }
+                  >
+                    {queueSummary.paused ? <Play className="h-2.5 w-2.5" /> : <Pause className="h-2.5 w-2.5" />}
+                    {queueSummary.paused ? "Resume" : "Pause"}
+                  </button>
+                )}
                 {queueSummary.pending + queueSummary.processing >= 2 && (
                   <button
                     onClick={handleCancelAll}

--- a/src/lib/ingest-queue.test.ts
+++ b/src/lib/ingest-queue.test.ts
@@ -63,6 +63,9 @@ import {
   getQueue,
   getQueueSummary,
   restoreQueue,
+  pauseProcessing,
+  resumeProcessing,
+  isQueuePaused,
 } from "./ingest-queue"
 import { autoIngest } from "./ingest"
 import { readFile, writeFile } from "@/commands/fs"
@@ -598,6 +601,98 @@ describe("ingest-queue — pauseQueue & switch-project survival", () => {
       const parsed = JSON.parse(String(content))
       expect(parsed).toEqual([])
     }
+  })
+})
+
+describe("ingest-queue — pause/resume processing", () => {
+  it("finishes the in-flight task but does not start the next while paused", async () => {
+    // First task is controllable; later calls would resolve immediately,
+    // but we assert they never happen while paused.
+    let resolveFirst: (f: string[]) => void = () => {}
+    mockAutoIngest.mockImplementationOnce(
+      () => new Promise<string[]>((r) => { resolveFirst = r }),
+    )
+    mockAutoIngest.mockResolvedValue(["wiki/sources/foo.md"])
+
+    await enqueueBatch(TEST_ID, [
+      { sourcePath: "a.md", folderContext: "" },
+      { sourcePath: "b.md", folderContext: "" },
+    ])
+    await flushMicrotasks(2)
+    expect(getQueue().find((t) => t.sourcePath === "a.md")?.status).toBe("processing")
+
+    // Pause while a.md is in flight — it must keep running, b.md must wait.
+    pauseProcessing()
+    expect(isQueuePaused()).toBe(true)
+
+    // a.md completes normally (pause never aborts in-flight work).
+    resolveFirst(["wiki/sources/a.md"])
+    await flushMicrotasks(10)
+
+    // a.md drained; b.md stays pending; autoIngest was called exactly once.
+    expect(mockAutoIngest).toHaveBeenCalledTimes(1)
+    expect(getQueue().find((t) => t.sourcePath === "a.md")).toBeUndefined()
+    expect(getQueue().find((t) => t.sourcePath === "b.md")?.status).toBe("pending")
+    expect(getQueueSummary().paused).toBe(true)
+  })
+
+  it("resumeProcessing restarts the queue and processes the pending task", async () => {
+    let resolveFirst: (f: string[]) => void = () => {}
+    mockAutoIngest.mockImplementationOnce(
+      () => new Promise<string[]>((r) => { resolveFirst = r }),
+    )
+    mockAutoIngest.mockResolvedValue(["wiki/sources/foo.md"])
+
+    await enqueueBatch(TEST_ID, [
+      { sourcePath: "a.md", folderContext: "" },
+      { sourcePath: "b.md", folderContext: "" },
+    ])
+    await flushMicrotasks(2)
+    pauseProcessing()
+    resolveFirst(["wiki/sources/a.md"])
+    await flushMicrotasks(10)
+    expect(mockAutoIngest).toHaveBeenCalledTimes(1)
+    expect(getQueue().find((t) => t.sourcePath === "b.md")?.status).toBe("pending")
+
+    // Resume → b.md is handed to the LLM and drains.
+    resumeProcessing()
+    await flushMicrotasks(10)
+    expect(mockAutoIngest).toHaveBeenCalledTimes(2)
+    expect(getQueue()).toHaveLength(0)
+    expect(isQueuePaused()).toBe(false)
+  })
+
+  it("does not run the drain-sweep while paused (no token spend)", async () => {
+    let resolveFirst: (f: string[]) => void = () => {}
+    mockAutoIngest.mockImplementationOnce(
+      () => new Promise<string[]>((r) => { resolveFirst = r }),
+    )
+
+    await enqueueIngest(TEST_ID, "only.md")
+    await flushMicrotasks(2)
+    pauseProcessing()
+    resolveFirst(["wiki/sources/only.md"])
+    await flushMicrotasks(10)
+
+    // Queue is empty after the in-flight task drained, but the paused
+    // guard short-circuits processNext before onQueueDrained fires.
+    expect(mockSweep).not.toHaveBeenCalled()
+  })
+
+  it("restoreQueue resets the paused flag — every project loads un-paused", async () => {
+    pauseProcessing()
+    expect(isQueuePaused()).toBe(true)
+
+    mockReadFile.mockRejectedValue(new Error("ENOENT"))
+    await restoreQueue(TEST_ID, TEST_PATH)
+    expect(isQueuePaused()).toBe(false)
+  })
+
+  it("clearQueueState resets the paused flag", async () => {
+    pauseProcessing()
+    expect(isQueuePaused()).toBe(true)
+    clearQueueState()
+    expect(isQueuePaused()).toBe(false)
   })
 })
 

--- a/src/lib/ingest-queue.ts
+++ b/src/lib/ingest-queue.ts
@@ -25,6 +25,14 @@ export interface IngestTask {
 
 let queue: IngestTask[] = []
 let processing = false
+/** User-controlled pause. When true, processNext stops handing pending
+ *  tasks to the LLM — but the in-flight task (if any) is NOT aborted, it
+ *  runs to completion. The drain-sweep (also an LLM call) is suppressed
+ *  too, which is intentional for a "stop spending tokens" pause.
+ *  In-memory only: not persisted, reset to false on restoreQueue (so
+ *  every project loads un-paused) and clearQueueState. A pending queue
+ *  therefore auto-resumes on app restart — see resumeProcessing. */
+let paused = false
 /** UUID of the currently-active project. Used as a stale-context guard
  *  in processNext: if this changes mid-ingest (user switched projects),
  *  the orphaned runner bails instead of writing to the old project. */
@@ -339,6 +347,36 @@ export async function cancelAllTasks(): Promise<number> {
 }
 
 /**
+ * Pause queue processing. The currently-running task (if any) finishes
+ * normally — pause never aborts in-flight work — but no further pending
+ * tasks are handed to the LLM until resumeProcessing() is called. Use
+ * this to stop token spend without losing the queue or cancelling work.
+ *
+ * In-memory only: a paused queue auto-resumes on app restart / project
+ * switch (pending tasks are picked up by restoreQueue).
+ */
+export function pauseProcessing(): void {
+  paused = true
+  console.log("[Ingest Queue] Paused — in-flight task will finish; no new tasks will start")
+}
+
+/**
+ * Resume queue processing after pauseProcessing(). Kicks processNext so
+ * pending tasks start immediately. A no-op if a task is already running
+ * (the existing `if (processing) return` guard handles that).
+ */
+export function resumeProcessing(): void {
+  paused = false
+  console.log("[Ingest Queue] Resumed")
+  if (currentProjectId) processNext(currentProjectId)
+}
+
+/** Whether queue processing is currently paused by the user. */
+export function isQueuePaused(): boolean {
+  return paused
+}
+
+/**
  * Get current queue state.
  */
 export function getQueue(): readonly IngestTask[] {
@@ -348,7 +386,7 @@ export function getQueue(): readonly IngestTask[] {
 /**
  * Get queue summary.
  */
-export function getQueueSummary(): { pending: number; processing: number; failed: number; completed: number; total: number } {
+export function getQueueSummary(): { pending: number; processing: number; failed: number; completed: number; total: number; paused: boolean } {
   const activeTotal = queue.length + completedSinceIdle
   return {
     pending: queue.filter((t) => t.status === "pending").length,
@@ -356,6 +394,7 @@ export function getQueueSummary(): { pending: number; processing: number; failed
     failed: queue.filter((t) => t.status === "failed").length,
     completed: completedSinceIdle,
     total: activeTotal,
+    paused,
   }
 }
 
@@ -374,6 +413,7 @@ export function clearQueueState(): void {
   }
   queue = []
   processing = false
+  paused = false
   currentProjectId = ""
   currentProjectPath = ""
   currentAbortController = null
@@ -446,6 +486,9 @@ export async function restoreQueue(
   // pauseQueue, but clearing again costs nothing).
   queue = []
   processing = false
+  // Every project loads un-paused. Pause is a current-session control;
+  // it does not carry across project switches or app restarts.
+  paused = false
   currentAbortController = null
   lastWrittenFiles = []
   resetQueueAccounting()
@@ -517,6 +560,11 @@ async function processNext(projectId: string): Promise<void> {
   // Stale-context guard: processNext may be invoked by an orphaned
   // recursion from a previous project. If we're no longer active, bail.
   if (currentProjectId !== projectId) return
+  // User pause: don't hand the next pending task to the LLM. The
+  // in-flight task already running is unaffected (we don't abort it);
+  // it finishes, calls processNext again, and lands back here. Also
+  // skips the drain-sweep below — intended, since that's an LLM call.
+  if (paused) return
 
   const next = queue.find((t) => t.projectId === projectId && t.status === "pending")
   if (!next) {


### PR DESCRIPTION
## Problem

The ingest queue has only two controls today: **Cancel all** (destructive — aborts the running task, removes its partial output, drops every pending item) and **Retry failed**. There's no way to *stop spending tokens on pending work without throwing it away*.

This matters for the local-CLI / paid-API users: if you queue a batch and then realize you want to hold off (review intermediate output, switch to other work, avoid burning quota), your only option is to cancel everything and re-add it later.

## What this adds

A **Pause / Resume** toggle for the ingest queue:

- Pause lets the **in-flight task finish normally** — it is never aborted — but no further pending task is handed to the LLM until you resume.
- The drain-sweep (`sweepResolvedReviews`, itself an LLM call) is also suppressed while paused, so a pause genuinely stops token spend.
- Resume kicks processing again and pending tasks drain as usual.

## Implementation

- `pauseProcessing()` / `resumeProcessing()` / `isQueuePaused()` in `ingest-queue.ts`.
- A single `if (paused) return` guard at the top of `processNext` (before `queue.find`), leaving the abort controller untouched. Because `enqueueIngest`, `retryTask`, and `restoreQueue` all funnel through `processNext`, they honor the pause for free — a file added while paused just sits `pending`.
- `paused` is surfaced on `getQueueSummary()`, so the activity panel picks it up through the polling it already does — no new plumbing.
- **In-memory only** (not persisted): reset to `false` in `restoreQueue` and `clearQueueState`, so every project loads un-paused and a pending queue auto-resumes on app restart — consistent with the existing "resume pending on startup" behavior.

## UI

A Pause/Resume button next to "Cancel all" in the activity panel, plus a "(paused)" label on the queue header.

## Tests

`ingest-queue.test.ts` adds coverage for: the in-flight task completing while the next stays `pending`, resume draining the queue, the drain-sweep being skipped while paused, and the flag resetting on `restoreQueue` / `clearQueueState`.

## Note / possible follow-up

Pause is intentionally session-scoped: it does not survive an app restart (a pending queue auto-resumes, matching today's startup behavior). If restart-durable pause is desirable, the natural place is a project-store key rather than the queue JSON — happy to do that as a follow-up if you'd prefer it.