### PR TITLE
fix: show dotfolders (.claude, .codex) in raw/sources listings and ingest

### DIFF
--- a/src-tauri/src/commands/fs.rs
+++ b/src-tauri/src/commands/fs.rs
@@ -1060,8 +1060,24 @@ pub async fn write_file_atomic(path: String, contents: String) -> Result<(), Str
     .map_err(|e| format!("write_file_atomic blocking task join error: {e}"))?
 }
 
+/// Whether a directory entry should appear in a listing.
+///
+/// Hidden (dot-prefixed) entries are shown only when `include_hidden`
+/// is set. That flag is reserved for the `raw/sources` content area,
+/// where dotfolders like `.claude` / `.codex` are legitimate sources
+/// the user deliberately added. Every other caller keeps hiding dot
+/// entries so internal state (`.llm-wiki`, `.git`), caches, and secrets
+/// (`.env`) never leak into trees or the ingest candidate set.
+fn entry_is_visible(name: &str, include_hidden: bool) -> bool {
+    include_hidden || !name.starts_with('.')
+}
+
 #[tauri::command]
-pub async fn list_directory(path: String) -> Result<Vec<FileNode>, String> {
+pub async fn list_directory(
+    path: String,
+    include_hidden: Option<bool>,
+) -> Result<Vec<FileNode>, String> {
+    let include_hidden = include_hidden.unwrap_or(false);
     tauri::async_runtime::spawn_blocking(move || {
         run_guarded("list_directory", || {
             let p = Path::new(&path);
@@ -1071,7 +1087,7 @@ pub async fn list_directory(path: String) -> Result<Vec<FileNode>, String> {
             if !p.is_dir() {
                 return Err(format!("Path is not a directory: '{}'", path));
             }
-            let nodes = build_tree(p, 0, 30)?;
+            let nodes = build_tree(p, 0, 30, include_hidden)?;
             Ok(nodes)
         })
     })
@@ -1079,7 +1095,12 @@ pub async fn list_directory(path: String) -> Result<Vec<FileNode>, String> {
     .map_err(|e| format!("list_directory blocking task join error: {e}"))?
 }
 
-fn build_tree(dir: &Path, depth: usize, max_depth: usize) -> Result<Vec<FileNode>, String> {
+fn build_tree(
+    dir: &Path,
+    depth: usize,
+    max_depth: usize,
+    include_hidden: bool,
+) -> Result<Vec<FileNode>, String> {
     if depth >= max_depth {
         return Ok(vec![]);
     }
@@ -1088,11 +1109,10 @@ fn build_tree(dir: &Path, depth: usize, max_depth: usize) -> Result<Vec<FileNode
         .map_err(|e| format!("Failed to read directory '{}': {}", dir.display(), e))?
         .filter_map(|entry| entry.ok())
         .filter(|entry| {
-            // Skip dotfiles
             entry
                 .file_name()
                 .to_str()
-                .map(|n| !n.starts_with('.'))
+                .map(|n| entry_is_visible(n, include_hidden))
                 .unwrap_or(false)
         })
         .collect();
@@ -1121,7 +1141,7 @@ fn build_tree(dir: &Path, depth: usize, max_depth: usize) -> Result<Vec<FileNode
         let is_dir = entry_path.is_dir();
 
         let children = if is_dir {
-            let kids = build_tree(&entry_path, depth + 1, max_depth)?;
+            let kids = build_tree(&entry_path, depth + 1, max_depth, include_hidden)?;
             if kids.is_empty() {
                 None
             } else {
@@ -2018,6 +2038,39 @@ mod tests {
         ));
         std::fs::create_dir_all(&dir).unwrap();
         dir
+    }
+
+    #[test]
+    fn build_tree_hides_dot_entries_by_default_and_includes_them_when_asked() {
+        let root = make_temp_dir("build-tree-hidden");
+        fs::create_dir_all(root.join(".claude")).unwrap();
+        fs::write(root.join(".claude/CLAUDE.md"), "x").unwrap();
+        fs::create_dir_all(root.join("visible")).unwrap();
+        fs::write(root.join("visible/doc.md"), "y").unwrap();
+        fs::write(root.join(".env"), "secret").unwrap();
+
+        // Default: dot entries (incl. .env) hidden, normal entries shown.
+        let hidden = build_tree(&root, 0, 30, false).unwrap();
+        let hidden_names: Vec<&str> = hidden.iter().map(|n| n.name.as_str()).collect();
+        assert!(hidden_names.contains(&"visible"));
+        assert!(
+            !hidden_names.iter().any(|n| n.starts_with('.')),
+            "no dot entries should leak by default: {hidden_names:?}"
+        );
+
+        // include_hidden=true: dotfolders/dotfiles present.
+        let shown = build_tree(&root, 0, 30, true).unwrap();
+        let shown_names: Vec<&str> = shown.iter().map(|n| n.name.as_str()).collect();
+        assert!(shown_names.contains(&".claude"));
+        assert!(shown_names.contains(&".env"));
+        assert!(shown_names.contains(&"visible"));
+
+        // The dotfolder's children come through too.
+        let claude = shown.iter().find(|n| n.name == ".claude").unwrap();
+        let kids = claude.children.as_ref().expect(".claude should have children");
+        assert!(kids.iter().any(|n| n.name == "CLAUDE.md"));
+
+        let _ = fs::remove_dir_all(root);
     }
 
     #[test]

--- a/src/commands/fs.ts
+++ b/src/commands/fs.ts
@@ -34,8 +34,17 @@ export async function writeFileAtomic(path: string, contents: string): Promise<v
   return invoke<void>("write_file_atomic", { path, contents })
 }
 
-export async function listDirectory(path: string): Promise<FileNode[]> {
-  return invoke<FileNode[]>("list_directory", { path })
+/**
+ * List a directory tree. Dot-prefixed entries (`.claude`, `.env`,
+ * `.llm-wiki`, …) are hidden by default; pass `includeHidden: true`
+ * only for the `raw/sources` content area, where dotfolders are
+ * legitimate user-added sources. See `entry_is_visible` in fs.rs.
+ */
+export async function listDirectory(
+  path: string,
+  includeHidden = false,
+): Promise<FileNode[]> {
+  return invoke<FileNode[]>("list_directory", { path, includeHidden })
 }
 
 export async function copyFile(

--- a/src/components/chat/chat-message.tsx
+++ b/src/components/chat/chat-message.tsx
@@ -41,7 +41,7 @@ export function useSourceFiles() {
   useEffect(() => {
     if (!project) return
     const pp = normalizePath(project.path)
-    listDirectory(`${pp}/raw/sources`)
+    listDirectory(`${pp}/raw/sources`, true)
       .then((tree) => {
         cachedSourceFiles = flattenNames(tree)
       })

--- a/src/components/layout/knowledge-tree.tsx
+++ b/src/components/layout/knowledge-tree.tsx
@@ -252,7 +252,7 @@ function RawSourcesSection() {
   useEffect(() => {
     if (!project) return
     const pp = normalizePath(project.path)
-    listDirectory(`${pp}/raw/sources`)
+    listDirectory(`${pp}/raw/sources`, true)
       .then((tree) => setSources(flattenAllFiles(tree)))
       .catch(() => setSources([]))
   }, [project])

--- a/src/components/sources/sources-view.tsx
+++ b/src/components/sources/sources-view.tsx
@@ -64,8 +64,9 @@ export function SourcesView() {
     if (!project) return
     const pp = normalizePath(project.path)
     try {
-      const tree = await listDirectory(`${pp}/raw/sources`)
-      // Filter out hidden files/dirs and cache
+      const tree = await listDirectory(`${pp}/raw/sources`, true)
+      // Keep user-added dotfolders (.claude, .codex) but drop ingest
+      // noise (.cache, .DS_Store) — see filterTree.
       const filtered = filterTree(tree)
       setSources(filtered)
       setRefreshError(null)
@@ -363,9 +364,14 @@ interface SourceTreeRow {
   depth: number
 }
 
+// Ingest-generated noise hidden from the sources tree even though the
+// listing now includes dot entries. User-added dotfolders (.claude,
+// .codex) pass through; only these internal artifacts are dropped.
+const HIDDEN_SOURCE_ENTRIES = new Set([".cache", ".DS_Store"])
+
 function filterTree(nodes: FileNode[]): FileNode[] {
   return nodes
-    .filter((n) => !n.name.startsWith("."))
+    .filter((n) => !HIDDEN_SOURCE_ENTRIES.has(n.name))
     .map((n) => {
       if (n.is_dir && n.children) {
         return { ...n, children: filterTree(n.children) }

--- a/src/lib/source-lifecycle.ts
+++ b/src/lib/source-lifecycle.ts
@@ -205,7 +205,11 @@ export async function importSourceFolder(
   const cfg = normalizeSourceWatchConfig(sourceWatchConfig)
   const maxBytes = cfg.maxFileSizeMb * 1024 * 1024
   const allowedFiles: string[] = []
-  const sourceFiles = flattenFiles(await listDirectory(selectedFolder))
+  // include hidden: a user importing a folder into raw/sources may
+  // legitimately want its dotfolders (.claude, .codex). Non-source
+  // noise is still filtered downstream by the source-watch allowlist
+  // and max-size check below.
+  const sourceFiles = flattenFiles(await listDirectory(selectedFolder, true))
 
   for (const file of sourceFiles) {
     const relativeSourcePath = getRelativePath(file.path, sourceRoot)


### PR DESCRIPTION
## Problem

`list_directory` unconditionally skips every dot-prefixed entry. If a user puts a dotfolder under `raw/sources` — `.claude`, `.codex`, a `.github` export, etc. — it's invisible in the Sources tab, and the folder-import ingest walk (which routes through the same listing) can't pick its files up either. The files are on disk, but the app behaves as if they aren't there.

## Approach

Add an opt-in `include_hidden` flag rather than relaxing the filter globally. A blanket unhide would leak `.llm-wiki`, `.git`, and secrets like `.env` into every tree and into the ingest candidate set — `raw/sources` is the one place dotfolders are deliberate content, so only that area opts in.

## Changes

- **`fs.rs`**: shared `entry_is_visible(name, include_hidden)` predicate; `list_directory(path, include_hidden?)` — defaults to `false`, so every existing caller is unchanged — threaded through the `build_tree` recursion.
- **TS `listDirectory`** gains an optional `includeHidden` arg, passed `true` only on the `raw/sources` content paths: the Sources tab, the knowledge tree, the chat source cache, and the folder-import ingest walk.
- **`sources-view`'s `filterTree`** no longer drops all dot entries — it now hides only ingest noise (`.cache`, `.DS_Store`), keeping user dotfolders visible.
- **Test**: `build_tree` hides dot entries by default (including `.env`) and includes them, with children, when asked.

## Out of scope

The scheduled-import auto-watch walk still hides dots — an automatic importer shouldn't pull `.git` from a watched folder. Easy to revisit if there's demand.