### PR TITLE
fix: content-stable review ids so resolved state survives ingest regeneration

### DIFF
--- a/src/stores/review-store.property.test.ts
+++ b/src/stores/review-store.property.test.ts
@@ -90,7 +90,10 @@ describe("review-store addItems — dedupe invariants", () => {
     )
   })
 
-  it("resolveItem always makes resolved item eligible for a NEW pending item of same key", () => {
+  it("re-adding the same key after resolve preserves the resolved item (resolved wins)", () => {
+    // Content-stable ids: re-surfacing a review during ingest must fold
+    // into the resolved item (same id, stays resolved), not spawn a new
+    // pending duplicate — that revival was the bug being fixed.
     fc.assert(
       fc.property(
         fc.string({ minLength: 1, maxLength: 20 }).filter((s) => s.trim().length > 0),
@@ -109,9 +112,11 @@ describe("review-store addItems — dedupe invariants", () => {
           ])
 
           const all = useReviewStore.getState().items
-          expect(all.length).toBe(2)
-          expect(all.filter((i) => i.resolved)).toHaveLength(1)
-          expect(all.filter((i) => !i.resolved)).toHaveLength(1)
+          expect(all.length).toBe(1)
+          expect(all[0].id).toBe(firstId)
+          expect(all[0].resolved).toBe(true)
+          expect(all[0].resolvedAction).toBe("auto-resolved")
+          expect(all[0].affectedPages).toEqual(expect.arrayContaining(["second.md"]))
         },
       ),
     )

--- a/src/stores/review-store.test.ts
+++ b/src/stores/review-store.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest"
-import { useReviewStore, type ReviewItem } from "./review-store"
+import { useReviewStore, reviewIdFor, type ReviewItem } from "./review-store"
 
 // Minimal builder so each test only specifies what it cares about.
 function makeInput(overrides: Partial<Omit<ReviewItem, "id" | "resolved" | "createdAt">> = {}) {
@@ -12,189 +12,65 @@ function makeInput(overrides: Partial<Omit<ReviewItem, "id" | "resolved" | "crea
   }
 }
 
-function reviewIdNumber(id: string): number {
-  const match = /^review-(\d+)$/.exec(id)
-  if (!match) throw new Error(`Unexpected review id: ${id}`)
-  return Number(match[1])
-}
-
-function lastItem(items: ReviewItem[]): ReviewItem {
-  if (items.length === 0) throw new Error("Expected at least one review item")
-  return items[items.length - 1]
-}
-
 // Reset the store between tests — Zustand stores are module-level singletons.
 beforeEach(() => {
   useReviewStore.setState({ items: [] })
 })
 
+describe("reviewIdFor — content-stable id", () => {
+  it("is identical for the same type + normalized title (survives regeneration)", () => {
+    // "Missing page: Attention" and "缺失页面: Attention" normalize equal.
+    expect(reviewIdFor({ type: "missing-page", title: "Missing page: Attention" }))
+      .toBe(reviewIdFor({ type: "missing-page", title: "缺失页面: Attention" }))
+  })
+
+  it("differs across types", () => {
+    expect(reviewIdFor({ type: "missing-page", title: "Attention" }))
+      .not.toBe(reviewIdFor({ type: "duplicate", title: "Attention" }))
+  })
+
+  it("differs across distinct titles", () => {
+    expect(reviewIdFor({ type: "missing-page", title: "Attention" }))
+      .not.toBe(reviewIdFor({ type: "missing-page", title: "Transformer" }))
+  })
+
+  it("does not depend on sourcePath (file moves keep the id stable)", () => {
+    // reviewIdFor only takes type + title; sourcePath cannot affect it.
+    const a = reviewIdFor({ type: "missing-page", title: "Attention" })
+    const b = reviewIdFor({ type: "missing-page", title: "Attention" })
+    expect(a).toBe(b)
+  })
+})
+
 describe("review-store addItem", () => {
-  it("adds a single item with generated id and resolved=false", () => {
+  it("adds a single item with content-stable id and resolved=false", () => {
     useReviewStore.getState().addItem(makeInput())
     const items = useReviewStore.getState().items
     expect(items).toHaveLength(1)
-    expect(items[0].id).toMatch(/^review-\d+$/)
+    expect(items[0].id).toBe(reviewIdFor(makeInput()))
     expect(items[0].resolved).toBe(false)
     expect(items[0].createdAt).toBeTypeOf("number")
   })
 
-  it("does NOT dedupe in addItem (single-item path is append-only)", () => {
-    // By design — dedupe only applies to addItems (bulk path from ingest).
+  it("dedupes same-content items (stable id identity), keeps distinct ones", () => {
     const store = useReviewStore.getState()
     store.addItem(makeInput({ title: "Same" }))
     store.addItem(makeInput({ title: "Same" }))
+    expect(useReviewStore.getState().items).toHaveLength(1)
+    store.addItem(makeInput({ title: "Different" }))
     expect(useReviewStore.getState().items).toHaveLength(2)
   })
 
-  it("continues ids after persisted review items are restored", () => {
-    useReviewStore.getState().addItem(makeInput({ title: "Probe" }))
-    const current = reviewIdNumber(lastItem(useReviewStore.getState().items).id)
-    const oldA = current + 40
-    const oldB = current + 41
-
-    useReviewStore.getState().setItems([
-      {
-        ...makeInput({ title: "Old A" }),
-        id: `review-${oldA}`,
-        resolved: false,
-        createdAt: 1,
-      },
-      {
-        ...makeInput({ title: "Old B" }),
-        id: `review-${oldB}`,
-        resolved: false,
-        createdAt: 2,
-      },
-    ])
-
-    useReviewStore.getState().addItem(makeInput({ title: "New" }))
-
-    const ids = useReviewStore.getState().items.map((item) => item.id)
-    expect(ids).toEqual([`review-${oldA}`, `review-${oldB}`, `review-${oldB + 1}`])
-  })
-
-  it("does not move the counter backwards after restoring lower persisted ids", () => {
-    useReviewStore.getState().addItem(makeInput({ title: "Probe" }))
-    const current = reviewIdNumber(lastItem(useReviewStore.getState().items).id)
-    const high = current + 40
-    const low = current + 5
-
-    useReviewStore.getState().setItems([
-      {
-        ...makeInput({ title: "High" }),
-        id: `review-${high}`,
-        resolved: false,
-        createdAt: 1,
-      },
-    ])
-    useReviewStore.getState().addItem(makeInput({ title: "After high" }))
-    expect(lastItem(useReviewStore.getState().items).id).toBe(`review-${high + 1}`)
-
-    useReviewStore.getState().setItems([
-      {
-        ...makeInput({ title: "Low" }),
-        id: `review-${low}`,
-        resolved: false,
-        createdAt: 2,
-      },
-    ])
-    useReviewStore.getState().addItem(makeInput({ title: "After low" }))
-    expect(lastItem(useReviewStore.getState().items).id).toBe(`review-${high + 2}`)
-  })
-
-  it("continues restored ids for bulk addItems", () => {
-    useReviewStore.getState().addItem(makeInput({ title: "Probe" }))
-    const current = reviewIdNumber(lastItem(useReviewStore.getState().items).id)
-    const restored = current + 40
-
-    useReviewStore.getState().setItems([
-      {
-        ...makeInput({ title: "Old" }),
-        id: `review-${restored}`,
-        resolved: false,
-        createdAt: 1,
-      },
-    ])
-
-    useReviewStore.getState().addItems([makeInput({ title: "Bulk new" })])
-
-    expect(lastItem(useReviewStore.getState().items).id).toBe(`review-${restored + 1}`)
-  })
-
-  it("advances past restored resolved items", () => {
-    useReviewStore.getState().addItem(makeInput({ title: "Probe" }))
-    const current = reviewIdNumber(lastItem(useReviewStore.getState().items).id)
-    const restored = current + 40
-
-    useReviewStore.getState().setItems([
-      {
-        ...makeInput({ title: "Resolved old" }),
-        id: `review-${restored}`,
-        resolved: true,
-        resolvedAction: "done",
-        createdAt: 1,
-      },
-    ])
-
-    useReviewStore.getState().addItem(makeInput({ title: "After resolved" }))
-
-    expect(lastItem(useReviewStore.getState().items).id).toBe(`review-${restored + 1}`)
-  })
-
-  it("ignores non-generated ids while restoring the numeric maximum", () => {
-    useReviewStore.getState().addItem(makeInput({ title: "Probe" }))
-    const current = reviewIdNumber(lastItem(useReviewStore.getState().items).id)
-    const restored = current + 40
-
-    useReviewStore.getState().setItems([
-      {
-        ...makeInput({ title: "Legacy" }),
-        id: "legacy-review-id",
-        resolved: false,
-        createdAt: 1,
-      },
-      {
-        ...makeInput({ title: "Generated" }),
-        id: `review-${restored}`,
-        resolved: false,
-        createdAt: 2,
-      },
-    ])
-
-    useReviewStore.getState().addItem(makeInput({ title: "After legacy" }))
-
-    expect(lastItem(useReviewStore.getState().items).id).toBe(`review-${restored + 1}`)
-  })
-
-  it("continues ids even if items were restored through raw setState", () => {
-    useReviewStore.getState().addItem(makeInput({ title: "Probe" }))
-    const current = reviewIdNumber(lastItem(useReviewStore.getState().items).id)
-    const restored = current + 40
-
-    useReviewStore.setState({
-      items: [
-        {
-          ...makeInput({ title: "Raw restored" }),
-          id: `review-${restored}`,
-          resolved: false,
-          createdAt: 1,
-        },
-      ],
-    })
-
-    useReviewStore.getState().addItem(makeInput({ title: "After raw restore" }))
-
-    expect(lastItem(useReviewStore.getState().items).id).toBe(`review-${restored + 1}`)
-  })
-
-  it("does not reset the counter when setItems restores an empty list", () => {
-    useReviewStore.getState().addItem(makeInput({ title: "Probe" }))
-    const current = reviewIdNumber(lastItem(useReviewStore.getState().items).id)
-
-    useReviewStore.getState().setItems([])
-    useReviewStore.getState().addItem(makeInput({ title: "After empty restore" }))
-
-    expect(lastItem(useReviewStore.getState().items).id).toBe(`review-${current + 1}`)
+  it("does not revive a resolved item when the same content is added again", () => {
+    const store = useReviewStore.getState()
+    store.addItem(makeInput({ title: "Attention" }))
+    const id = useReviewStore.getState().items[0].id
+    store.resolveItem(id, "user-resolved")
+    store.addItem(makeInput({ title: "Attention" }))
+    const items = useReviewStore.getState().items
+    expect(items).toHaveLength(1)
+    expect(items[0].resolved).toBe(true)
+    expect(items[0].resolvedAction).toBe("user-resolved")
   })
 })
 
@@ -229,19 +105,24 @@ describe("review-store addItems dedupe", () => {
     expect(useReviewStore.getState().items).toHaveLength(2)
   })
 
-  it("does NOT merge into a resolved item (creates a new one)", () => {
+  it("MERGES into a resolved item and preserves its resolved state (resolved wins)", () => {
+    // This is the core fix: re-surfacing a review during ingest must NOT
+    // discard its resolution. The same-content item folds into the
+    // resolved one (same id), keeping resolved + merging new pages.
     const store = useReviewStore.getState()
     store.addItems([makeInput({ title: "Attention" })])
     const oldId = useReviewStore.getState().items[0].id
     store.resolveItem(oldId, "user-resolved")
     store.addItems([makeInput({ title: "Attention", affectedPages: ["new.md"] })])
     const items = useReviewStore.getState().items
-    expect(items).toHaveLength(2)
-    expect(items.find((i) => i.resolved)?.id).toBe(oldId)
-    expect(items.find((i) => !i.resolved)?.affectedPages).toEqual(["new.md"])
+    expect(items).toHaveLength(1)
+    expect(items[0].id).toBe(oldId)
+    expect(items[0].resolved).toBe(true)
+    expect(items[0].resolvedAction).toBe("user-resolved")
+    expect(items[0].affectedPages).toEqual(["new.md"])
   })
 
-  it("covers contradiction type (was previously skipped in dedupe)", () => {
+  it("covers contradiction type", () => {
     useReviewStore.getState().addItems([
       makeInput({ type: "contradiction", title: "Conflict A", affectedPages: ["a.md"] }),
       makeInput({ type: "contradiction", title: "Conflict A", affectedPages: ["b.md"] }),
@@ -260,51 +141,31 @@ describe("review-store addItems dedupe", () => {
   })
 
   it("prefers the newer non-empty description on merge", () => {
-    useReviewStore.getState().addItems([
-      makeInput({ title: "A", description: "old desc" }),
-    ])
-    useReviewStore.getState().addItems([
-      makeInput({ title: "A", description: "new desc" }),
-    ])
+    useReviewStore.getState().addItems([makeInput({ title: "A", description: "old desc" })])
+    useReviewStore.getState().addItems([makeInput({ title: "A", description: "new desc" })])
     expect(useReviewStore.getState().items[0].description).toBe("new desc")
   })
 
   it("keeps old description if incoming is empty", () => {
-    useReviewStore.getState().addItems([
-      makeInput({ title: "A", description: "keep me" }),
-    ])
-    useReviewStore.getState().addItems([
-      makeInput({ title: "A", description: "" }),
-    ])
+    useReviewStore.getState().addItems([makeInput({ title: "A", description: "keep me" })])
+    useReviewStore.getState().addItems([makeInput({ title: "A", description: "" })])
     expect(useReviewStore.getState().items[0].description).toBe("keep me")
   })
 
   it("deduplicates affectedPages within the merge", () => {
-    useReviewStore.getState().addItems([
-      makeInput({ title: "A", affectedPages: ["x.md", "y.md"] }),
-    ])
-    useReviewStore.getState().addItems([
-      makeInput({ title: "A", affectedPages: ["y.md", "z.md"] }),
-    ])
-    const merged = useReviewStore.getState().items[0]
-    expect(merged.affectedPages).toEqual(["x.md", "y.md", "z.md"])
+    useReviewStore.getState().addItems([makeInput({ title: "A", affectedPages: ["x.md", "y.md"] })])
+    useReviewStore.getState().addItems([makeInput({ title: "A", affectedPages: ["y.md", "z.md"] })])
+    expect(useReviewStore.getState().items[0].affectedPages).toEqual(["x.md", "y.md", "z.md"])
   })
 
   it("merges searchQueries without duplicates", () => {
-    useReviewStore.getState().addItems([
-      makeInput({ title: "A", searchQueries: ["q1"] }),
-    ])
-    useReviewStore.getState().addItems([
-      makeInput({ title: "A", searchQueries: ["q1", "q2"] }),
-    ])
+    useReviewStore.getState().addItems([makeInput({ title: "A", searchQueries: ["q1"] })])
+    useReviewStore.getState().addItems([makeInput({ title: "A", searchQueries: ["q1", "q2"] })])
     expect(useReviewStore.getState().items[0].searchQueries).toEqual(["q1", "q2"])
   })
 
   it("sets affectedPages to undefined when the merged result is empty", () => {
-    useReviewStore.getState().addItems([
-      makeInput({ title: "A" }),
-      makeInput({ title: "A" }),
-    ])
+    useReviewStore.getState().addItems([makeInput({ title: "A" }), makeInput({ title: "A" })])
     expect(useReviewStore.getState().items[0].affectedPages).toBeUndefined()
   })
 
@@ -323,7 +184,7 @@ describe("review-store addItems dedupe", () => {
     expect(b?.affectedPages).toEqual(["3.md"])
   })
 
-  it("invariant: after addItems, no two pending items share (type, normalized title)", () => {
+  it("invariant: after addItems, every item has a unique stable id", () => {
     useReviewStore.getState().addItems([
       makeInput({ type: "missing-page", title: "Missing page: Foo" }),
       makeInput({ type: "missing-page", title: "缺失页面: Foo" }),
@@ -331,9 +192,71 @@ describe("review-store addItems dedupe", () => {
       makeInput({ type: "duplicate", title: "Foo" }),
       makeInput({ type: "duplicate", title: "Duplicate page: Foo" }),
     ])
-    const pending = useReviewStore.getState().items.filter((i) => !i.resolved)
-    const keys = pending.map((i) => `${i.type}::${i.title.toLowerCase().replace(/^(missing|duplicate).*?:\s*/i, "").trim()}`)
-    expect(new Set(keys).size).toBe(pending.length)
+    const ids = useReviewStore.getState().items.map((i) => i.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+})
+
+describe("review-store setItems — migrate-on-load", () => {
+  it("remaps old counter ids to content-stable ids", () => {
+    useReviewStore.getState().setItems([
+      { ...makeInput({ title: "Attention" }), id: "review-6", resolved: false, createdAt: 1 },
+    ])
+    const item = useReviewStore.getState().items[0]
+    expect(item.id).toBe(reviewIdFor({ type: "missing-page", title: "Attention" }))
+  })
+
+  it("collapses two old items with identical content into one — resolved wins", () => {
+    // Acceptance: two counter-id rows for the same review (one resolved)
+    // must fold into a single resolved item on load.
+    useReviewStore.getState().setItems([
+      {
+        ...makeInput({ title: "Attention", affectedPages: ["a.md"] }),
+        id: "review-6",
+        resolved: false,
+        createdAt: 5,
+      },
+      {
+        ...makeInput({ title: "Missing page: Attention", affectedPages: ["b.md"] }),
+        id: "review-99",
+        resolved: true,
+        resolvedAction: "user-resolved",
+        createdAt: 2,
+      },
+    ])
+    const items = useReviewStore.getState().items
+    expect(items).toHaveLength(1)
+    expect(items[0].resolved).toBe(true)
+    expect(items[0].resolvedAction).toBe("user-resolved")
+    expect(items[0].affectedPages).toEqual(expect.arrayContaining(["a.md", "b.md"]))
+    expect(items[0].createdAt).toBe(2) // earliest
+  })
+
+  it("is idempotent — loading already-stable ids changes nothing", () => {
+    const stable = reviewIdFor({ type: "missing-page", title: "Attention" })
+    useReviewStore.getState().setItems([
+      { ...makeInput({ title: "Attention" }), id: stable, resolved: true, resolvedAction: "x", createdAt: 1 },
+    ])
+    const first = useReviewStore.getState().items
+    useReviewStore.getState().setItems(first)
+    const second = useReviewStore.getState().items
+    expect(second).toHaveLength(1)
+    expect(second[0].id).toBe(stable)
+    expect(second[0].resolved).toBe(true)
+  })
+
+  it("resolve survives a re-ingest of the same source (same id, stays resolved)", () => {
+    // End-to-end of the user's scenario: resolve, then ingest re-surfaces
+    // the same review via addItems → it keeps its id and resolution.
+    useReviewStore.getState().addItems([makeInput({ title: "Attention" })])
+    const id = useReviewStore.getState().items[0].id
+    useReviewStore.getState().resolveItem(id, "user-resolved")
+    // simulate queue-shrink rebuild re-emitting the same review
+    useReviewStore.getState().addItems([makeInput({ title: "Attention", affectedPages: ["regen.md"] })])
+    const item = useReviewStore.getState().items[0]
+    expect(useReviewStore.getState().items).toHaveLength(1)
+    expect(item.id).toBe(id)
+    expect(item.resolved).toBe(true)
   })
 })
 

--- a/src/stores/review-store.ts
+++ b/src/stores/review-store.ts
@@ -30,87 +30,102 @@ interface ReviewState {
   clearResolved: () => void
 }
 
-let counter = 0
-
-function reviewCounterFromId(id: string): number | null {
-  const match = /^review-(\d+)$/.exec(id)
-  if (!match) return null
-  const n = Number(match[1])
-  return Number.isSafeInteger(n) && n > 0 ? n : null
-}
-
-function advanceCounterForItems(items: ReviewItem[]): void {
-  let max = counter
-  for (const item of items) {
-    const n = reviewCounterFromId(item.id)
-    if (n !== null && n > max) max = n
+/**
+ * Content-derived stable id. The SAME logical review (same type + same
+ * normalized title) always gets the SAME id, so it survives ingest
+ * regeneration, file moves, and reloads — and an external caller (the
+ * resolve API) can target it reliably.
+ *
+ * Deliberately NOT counter-based (the old `review-N` scheme re-numbered
+ * every review whenever the queue rebuilt, discarding resolved state)
+ * and deliberately NOT keyed on sourcePath (mutable — a file rename
+ * would re-id the review, the exact instability we're removing).
+ *
+ * "Collision" — two inputs sharing an id — is the intended behaviour:
+ * identical content is the same review. Stability is bounded by
+ * `normalizeReviewTitle` across LLM regenerations, the same ceiling the
+ * previous dedup already accepted.
+ */
+export function reviewIdFor(item: Pick<ReviewItem, "type" | "title">): string {
+  const key = `${item.type}::${normalizeReviewTitle(item.title)}`
+  // FNV-1a (32-bit) — small, deterministic, dependency-free.
+  let h = 0x811c9dc5
+  for (let i = 0; i < key.length; i++) {
+    h ^= key.charCodeAt(i)
+    h = Math.imul(h, 0x01000193)
   }
-  counter = max
+  return `review-${(h >>> 0).toString(16).padStart(8, "0")}`
 }
 
-function nextReviewId(existingItems: ReviewItem[]): string {
-  advanceCounterForItems(existingItems)
-  return `review-${++counter}`
+/** Union two optional string arrays, dropping the field when empty. */
+function unionField(a?: string[], b?: string[]): string[] | undefined {
+  const merged = Array.from(new Set([...(a ?? []), ...(b ?? [])]))
+  return merged.length > 0 ? merged : undefined
+}
+
+/**
+ * Collapse two items that resolved to the same stable id. resolved
+ * wins (if either was resolved, the survivor is), union the array
+ * fields, keep the earliest createdAt, prefer a non-empty description.
+ */
+function mergeReviewItems(a: ReviewItem, b: ReviewItem): ReviewItem {
+  return {
+    ...a, // a.id is kept; both share it by construction
+    resolved: a.resolved || b.resolved,
+    resolvedAction: a.resolved ? a.resolvedAction : b.resolved ? b.resolvedAction : a.resolvedAction,
+    description: a.description || b.description,
+    sourcePath: a.sourcePath ?? b.sourcePath,
+    affectedPages: unionField(a.affectedPages, b.affectedPages),
+    searchQueries: unionField(a.searchQueries, b.searchQueries),
+    createdAt: Math.min(a.createdAt, b.createdAt),
+  }
 }
 
 export const useReviewStore = create<ReviewState>((set) => ({
   items: [],
 
   addItem: (item) =>
-    set((state) => ({
-      items: [
-        ...state.items,
-        {
-          ...item,
-          id: nextReviewId(state.items),
-          resolved: false,
-          createdAt: Date.now(),
-        },
-      ],
-    })),
+    set((state) => {
+      const id = reviewIdFor(item)
+      // Same-content item already present (possibly resolved) → keep it
+      // as-is so resolved state survives. The stable id makes this a
+      // simple identity check, no separate dedup key.
+      if (state.items.some((it) => it.id === id)) {
+        return { items: state.items }
+      }
+      return {
+        items: [...state.items, { ...item, id, resolved: false, createdAt: Date.now() }],
+      }
+    }),
 
   addItems: (items) =>
     set((state) => {
-      // De-dupe against pending items with same type + normalized title (all
-      // 5 types — bulk ingest can re-surface the same contradiction/confirm
-      // from multiple files).
-      // Merge affectedPages / searchQueries / sourcePath instead of duplicating.
+      // Dedup on the content-stable id against ALL existing items —
+      // including resolved ones. The previous scheme only deduped
+      // against *pending* items, which is exactly why re-surfacing a
+      // review during ingest discarded its resolved state. Now a
+      // resolved review with the same content is preserved (resolved
+      // wins), with array fields merged.
       const result = [...state.items]
-      const keyFor = (t: string, title: string) => `${t}::${normalizeReviewTitle(title)}`
-
-      // Build index of existing pending items for fast lookup
-      const pendingIndex = new Map<string, number>()
-      result.forEach((it, idx) => {
-        if (!it.resolved) {
-          pendingIndex.set(keyFor(it.type, it.title), idx)
-        }
-      })
+      const indexById = new Map<string, number>()
+      result.forEach((it, idx) => indexById.set(it.id, idx))
 
       for (const incoming of items) {
-        const k = keyFor(incoming.type, incoming.title)
-        const existingIdx = pendingIndex.get(k)
+        const id = reviewIdFor(incoming)
+        const existingIdx = indexById.get(id)
 
         if (existingIdx !== undefined) {
-          // Merge into existing
           const old = result[existingIdx]
-          const mergedPages = Array.from(new Set([...(old.affectedPages ?? []), ...(incoming.affectedPages ?? [])]))
-          const mergedQueries = Array.from(new Set([...(old.searchQueries ?? []), ...(incoming.searchQueries ?? [])]))
           result[existingIdx] = {
-            ...old,
-            description: incoming.description || old.description, // prefer newer description
+            ...old, // preserves resolved / resolvedAction / createdAt / id
+            description: incoming.description || old.description,
             sourcePath: incoming.sourcePath ?? old.sourcePath,
-            affectedPages: mergedPages.length > 0 ? mergedPages : undefined,
-            searchQueries: mergedQueries.length > 0 ? mergedQueries : undefined,
+            affectedPages: unionField(old.affectedPages, incoming.affectedPages),
+            searchQueries: unionField(old.searchQueries, incoming.searchQueries),
           }
         } else {
-          const newItem = {
-            ...incoming,
-            id: nextReviewId(result),
-            resolved: false,
-            createdAt: Date.now(),
-          }
-          result.push(newItem)
-          pendingIndex.set(k, result.length - 1)
+          result.push({ ...incoming, id, resolved: false, createdAt: Date.now() })
+          indexById.set(id, result.length - 1)
         }
       }
 
@@ -118,8 +133,19 @@ export const useReviewStore = create<ReviewState>((set) => ({
     }),
 
   setItems: (items) => {
-    advanceCounterForItems(items)
-    set({ items })
+    // Migrate-on-load: remap every item to its content-stable id,
+    // collapsing any that share one. Old counter ids (review-N) and
+    // their resolved state are folded in here (resolved wins), so a
+    // resolved review keeps its resolution across the id-scheme change.
+    // Computing the id from content (not the old id) makes this
+    // idempotent — no migration-version flag needed.
+    const byId = new Map<string, ReviewItem>()
+    for (const raw of items) {
+      const remapped: ReviewItem = { ...raw, id: reviewIdFor(raw) }
+      const existing = byId.get(remapped.id)
+      byId.set(remapped.id, existing ? mergeReviewItems(existing, remapped) : remapped)
+    }
+    set({ items: [...byId.values()] })
   },
 
   resolveItem: (id, action) =>


### PR DESCRIPTION
## Problem

Review ids are a module-level incrementing counter (`review-N`). Any time review generation re-runs — e.g. the ingest queue rebuilds — every review is **re-numbered**, and because `addItems` only deduped against *pending* items, a previously **resolved** review comes back as a brand-new pending one. Its resolution is silently lost.

It also makes id-based targeting unreliable: a caller (the Review API, or anything holding an id) points at a number that no longer means the same review after a rebuild.

## Fix

Make the id content-derived and stable.

- **`reviewIdFor(item)` = FNV-1a(`type` + `normalizeReviewTitle(title)`)** — the same logical review gets the same id across regeneration, file moves, and reloads. `sourcePath` is deliberately excluded (it's mutable; including it would re-id a review on a file rename — the same instability being removed).
- **`addItems`** dedups on the stable id against **all** items including resolved ones (resolved wins, array fields merged). This is the actual fix for resolved state being dropped when a review re-surfaces.
- **`setItems`** migrates on load: remaps old `review-N` ids to stable ids and collapses duplicates (resolved wins, union `affectedPages`/`searchQueries`, earliest `createdAt`). Idempotent — the id is computed from content, no migration-version flag — so an existing `review.json` heals on first load + auto-save.
- **`addItem`** dedups by identity (no revival of a resolved item).

`normalizeReviewTitle` was already the dedup key; it's now also load-bearing for id identity (noted at `reviewIdFor`).

## Tests

Unit + property tests rewritten for stable-id behaviour, including acceptance cases:
- resolve a review, then re-add the same content (simulating ingest re-surfacing it) → **same id, stays resolved**;
- two counter-id rows with identical content **collapse to one resolved item** on load.

## Context

This is the store-layer counterpart that makes id-based review resolution (e.g. a resolve endpoint) actually reliable — without stable ids, resolving "review-12" is meaningless after the next rebuild.