### PR TITLE
feat: inject project schema into the analysis prompt so custom page types get recommended

### DIFF
--- a/src/lib/ingest.prompt.test.ts
+++ b/src/lib/ingest.prompt.test.ts
@@ -53,6 +53,25 @@ describe("buildAnalysisPrompt language directive", () => {
     expect(prompt).toContain("Which named subject is each claim about")
     expect(prompt).toContain("Do not transfer claims, limits, or evaluations")
   })
+
+  it("injects the project schema so analysis can recommend custom-typed pages", () => {
+    const schema = "## Page Types\n| goal | wiki/goals/ | Outcomes |\n| habit | wiki/habits/ | Behaviours |"
+    const prompt = buildAnalysisPrompt("", "", "", schema)
+    expect(prompt).toContain("## Project Schema")
+    expect(prompt).toContain("wiki/goals/")
+    // Recommendations guidance must mention schema-defined types
+    expect(prompt).toContain("goal, habit")
+  })
+
+  it("omits the schema section when no schema is provided", () => {
+    const prompt = buildAnalysisPrompt("", "", "")
+    expect(prompt).not.toContain("## Project Schema")
+  })
+
+  it("does not invent schema content not present in the source", () => {
+    const prompt = buildAnalysisPrompt("", "", "", "| goal | wiki/goals/ | x |")
+    expect(prompt).toContain("never invent")
+  })
 })
 
 describe("buildGenerationPrompt language directive", () => {

--- a/src/lib/ingest.ts
+++ b/src/lib/ingest.ts
@@ -809,7 +809,7 @@ async function autoIngestImpl(
     await streamChat(
       llmConfig,
       [
-        { role: "system", content: buildAnalysisPrompt(purpose, index, sourceContext) },
+        { role: "system", content: buildAnalysisPrompt(purpose, index, sourceContext, schema) },
         { role: "user", content: `Analyze this source document:\n\n**File:** ${sourceIdentity}${folderContext ? `\n**Folder context:** ${folderContext}` : ""}\n\n---\n\n${sourceContext}` },
       ],
       {
@@ -1744,7 +1744,12 @@ function shouldRunDedicatedReviewStage(generation: string): boolean {
  * Step 1 prompt: AI reads the source and produces a structured analysis.
  * This is the "discussion" step — the AI reasons about the source before writing wiki pages.
  */
-export function buildAnalysisPrompt(purpose: string, index: string, sourceContent: string = ""): string {
+export function buildAnalysisPrompt(
+  purpose: string,
+  index: string,
+  sourceContent: string = "",
+  schema: string = "",
+): string {
   return [
     "You are an expert research analyst. Read the source document and produce a structured analysis.",
     "Do not output chain-of-thought, hidden reasoning, or a thinking transcript. Reason internally and write only the concise final analysis.",
@@ -1781,6 +1786,7 @@ export function buildAnalysisPrompt(purpose: string, index: string, sourceConten
     "",
     "## Recommendations",
     "- What wiki pages should be created or updated?",
+    "- If the project schema (below) defines page types beyond entity/concept (e.g. goal, habit, reflection, finding, decision, meeting), and the source genuinely contains matching content, recommend pages of those types — name the type explicitly. Only when the source actually supports it; never invent goals/habits/journal entries that aren't in the source.",
     "- What should be emphasized vs. de-emphasized?",
     "- Any open questions worth flagging for the user?",
     "",
@@ -1788,6 +1794,9 @@ export function buildAnalysisPrompt(purpose: string, index: string, sourceConten
     "",
     "If a folder context is provided, use it as a hint for categorization — the folder structure often reflects the user's organizational intent (e.g., 'papers/energy' suggests the file is an energy-related paper).",
     "",
+    schema
+      ? `## Project Schema (page types available — map source content to schema-defined types when it fits)\n${schema}`
+      : "",
     purpose ? `## Wiki Purpose (for context)\n${purpose}` : "",
     index ? `## Current Wiki Index (for checking existing content)\n${index}` : "",
   ].filter(Boolean).join("\n")


### PR DESCRIPTION
## Problem

Stage 1 (analysis) only ever extracts **Key Entities / Key Concepts**. It never receives the project `schema`, so custom page types a template defines — `goal`, `habit`, `reflection`, `journal` (Personal Growth), `finding`, `decision`, `meeting`, etc. — are invisible to it.

Stage 2 (generation) *does* get the schema, but since analysis is blind to those types, source content that maps to them is rarely recommended and almost never routed to the right folder. In practice a non-default template's extra folders stay empty and the user has to fill them by hand even when a source document actually contains that material.

## Fix

Pass `schema` into `buildAnalysisPrompt` and use it two ways:

- Include the schema as analysis context ("map source content to schema-defined types when it fits").
- Extend the Recommendations section to call out schema types beyond entity/concept **when the source genuinely contains matching content** — with an explicit guard against inventing goals/habits/journal entries that aren't in the source.

The schema is already loaded in `autoIngestImpl` (generation uses it) and already counted in the stable-context budget, so this is just wiring it to the existing call site — no new I/O, no budget change.

## Notes

- Personal-growth/journal-style types are still primarily user-authored living documents; this only helps when a source *does* contain such content (e.g. a "2026 goals" note), so it stops those cases from being silently dropped into generic entity/concept pages.
- Routing already accepts schema-defined types (`validateWikiPageRouting`), so recommended custom-typed pages pass through cleanly.

## Tests

Added cases for schema injection, omission when no schema is provided, and the no-invention guard.