### PR TITLE
feat: use system font stack for better CJK rendering

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,13 +1,11 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";
-@import "@fontsource-variable/geist";
-
 @custom-variant dark (&:is(.dark *));
 
 @theme inline {
     --font-heading: var(--font-sans);
-    --font-sans: 'Geist Variable', sans-serif;
+    --font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Pingfang SC', 'Hiragino Sans GB', 'Microsoft YaHei', 'Helvetica Neue', Helvetica, Arial, sans-serif;
     --color-sidebar-ring: var(--sidebar-ring);
     --color-sidebar-border: var(--sidebar-border);
     --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);


### PR DESCRIPTION
## Summary

Replaces the hardcoded `Geist Variable` font with a system default font stack to improve text rendering for Chinese/Japanese/Korean (CJK) users.

## Changes

- Remove `@import "@fontsource-variable/geist"` (no longer needed)
- Replace `--font-sans: 'Geist Variable', sans-serif` with system font stack:

```css
--font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Pingfang SC', 'Hiragino Sans GB', 'Microsoft YaHei', 'Helvetica Neue', Helvetica, Arial, sans-serif;
```

## Why

`Geist` is designed primarily for Latin characters. For CJK users (Chinese/Japanese/Korean), system fonts like `Pingfang SC` (macOS) and `Microsoft YaHei` (Windows) provide much better readability and a more native feel.

The system font stack is also slightly faster (no extra font file to download) and respects the user's OS preferences.

## Testing

Tested locally on macOS (aarch64) with Chinese text — rendering is noticeably more natural.

---
Closes: #