### PR TITLE
feat: add max-tokens field selector for custom OpenAI-compatible LLMs

### DIFF
--- a/src/components/settings/llm-presets.ts
+++ b/src/components/settings/llm-presets.ts
@@ -1,4 +1,4 @@
-import type { AzureModelFamily } from "@/stores/wiki-store"
+import type { AzureModelFamily, MaxTokensParam } from "@/stores/wiki-store"
 
 /**
  * Curated LLM provider presets.
@@ -55,6 +55,11 @@ export interface LlmPreset {
   suggestedModels?: string[]
   /** Custom providers only: which wire protocol to speak. */
   apiMode?: CustomApiMode
+  /**
+   * Custom OpenAI-compatible providers only: force the token-budget wire
+   * field name (`max_tokens` / `max_completion_tokens`). Omitted = `auto`.
+   */
+  maxTokensParam?: MaxTokensParam
   /** Suggested context window; user can override. */
   suggestedContextSize?: number
 }

--- a/src/components/settings/preset-resolver.ts
+++ b/src/components/settings/preset-resolver.ts
@@ -50,6 +50,7 @@ export function resolveConfig(
       customEndpoint: ov.baseUrl ?? preset.baseUrl ?? "",
       maxContextSize,
       apiMode: ov.apiMode ?? preset.apiMode ?? "chat_completions",
+      maxTokensParam: ov.maxTokensParam ?? preset.maxTokensParam ?? "auto",
       reasoning,
       localCliIsolation: false,
     }

--- a/src/components/settings/sections/llm-provider-section.tsx
+++ b/src/components/settings/sections/llm-provider-section.tsx
@@ -133,6 +133,7 @@ function PresetRow({
   const model = ov.model ?? preset.defaultModel ?? ""
   const apiKey = ov.apiKey ?? ""
   const apiMode = ov.apiMode ?? preset.apiMode ?? "chat_completions"
+  const maxTokensParam = ov.maxTokensParam ?? preset.maxTokensParam ?? "auto"
   const baseUrl = ov.baseUrl ?? preset.baseUrl ?? ""
   const azureApiVersion = ov.azureApiVersion ?? preset.azureApiVersion ?? AZURE_OPENAI_API_VERSION
   const azureModelFamily = ov.azureModelFamily ?? preset.azureModelFamily ?? "auto"
@@ -153,7 +154,7 @@ function PresetRow({
 
   const resolvedConfig = useMemo(
     () => resolveConfig(preset, ov, useWikiStore.getState().llmConfig),
-    [apiKey, apiMode, azureApiVersion, azureModelFamily, baseUrl, context, model, preset, reasoning, ov],
+    [apiKey, apiMode, maxTokensParam, azureApiVersion, azureModelFamily, baseUrl, context, model, preset, reasoning, ov],
   )
 
   async function runProviderTest(kind: "connection" | "function") {
@@ -288,6 +289,26 @@ function PresetRow({
               placeholder={preset.baseUrl ?? "https://your-api.example.com/v1"}
               onChange={(v) => onChange({ baseUrl: v })}
             />
+          )}
+
+          {preset.provider === "custom" && apiMode === "chat_completions" && (
+            <div className="space-y-2">
+              <Label>{t("settings.sections.llm.maxTokensParam")}</Label>
+              <select
+                className="w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                value={maxTokensParam}
+                onChange={(e) => onChange({ maxTokensParam: e.target.value as typeof maxTokensParam })}
+              >
+                <option value="auto">{t("settings.sections.llm.maxTokensParamAuto")}</option>
+                <option value="max_tokens">{t("settings.sections.llm.maxTokensParamMaxTokens")}</option>
+                <option value="max_completion_tokens">
+                  {t("settings.sections.llm.maxTokensParamMaxCompletionTokens")}
+                </option>
+              </select>
+              <p className="text-xs text-muted-foreground">
+                {t("settings.sections.llm.maxTokensParamHint")}
+              </p>
+            </div>
           )}
 
           {preset.provider === "azure" && (

--- a/src/components/settings/settings-types.ts
+++ b/src/components/settings/settings-types.ts
@@ -1,5 +1,5 @@
 import type { CustomApiMode } from "./llm-presets"
-import type { AzureModelFamily, CloseBehavior, MineruModelVersion, ReasoningConfig, SourceWatchConfig } from "@/stores/wiki-store"
+import type { AzureModelFamily, CloseBehavior, MaxTokensParam, MineruModelVersion, ReasoningConfig, SourceWatchConfig } from "@/stores/wiki-store"
 
 /**
  * Shape of the draft state each section reads from and writes into.
@@ -18,6 +18,7 @@ export interface SettingsDraft {
   azureModelFamily: AzureModelFamily
   maxContextSize: number
   apiMode: CustomApiMode | undefined
+  maxTokensParam: MaxTokensParam
   reasoning: ReasoningConfig | undefined
   localCliIsolation: boolean
 

--- a/src/components/settings/settings-view.tsx
+++ b/src/components/settings/settings-view.tsx
@@ -127,6 +127,7 @@ function initialDraft(
     azureModelFamily: llm.azureModelFamily ?? "auto",
     maxContextSize: llm.maxContextSize ?? 204800,
     apiMode: llm.apiMode,
+    maxTokensParam: llm.maxTokensParam ?? "auto",
     reasoning: llm.reasoning,
     localCliIsolation: llm.localCliIsolation === true,
     embeddingEnabled: embed.enabled,
@@ -347,6 +348,7 @@ export function SettingsView() {
       azureModelFamily: draft.provider === "azure" ? draft.azureModelFamily : undefined,
       maxContextSize: draft.maxContextSize,
       apiMode: draft.provider === "custom" ? draft.apiMode : undefined,
+      maxTokensParam: draft.provider === "custom" ? draft.maxTokensParam : undefined,
       reasoning: draft.reasoning,
       localCliIsolation: draft.localCliIsolation,
     }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -321,6 +321,11 @@
         "azureModelFamilyAuto": "Auto-detect from deployment name",
         "azureModelFamilyGpt5": "GPT-5 / o-series strict parameters",
         "azureModelFamilyHint": "Azure deployment names are arbitrary. Choose GPT-5 / o-series if this deployment rejects max_tokens or non-default temperature.",
+        "maxTokensParam": "Max-tokens field",
+        "maxTokensParamAuto": "Auto (recommended)",
+        "maxTokensParamMaxTokens": "Force max_tokens",
+        "maxTokensParamMaxCompletionTokens": "Force max_completion_tokens",
+        "maxTokensParamHint": "Which wire field carries the token budget on the OpenAI-compatible path. Auto lets LLM Wiki pick per endpoint; a forced choice can be rejected by strict endpoints (e.g. a custom Azure GPT-5 deployment rejects max_tokens), so leave on Auto unless your endpoint requires a specific field.",
         "reasoning": {
           "title": "Reasoning / thinking",
           "auto": "Auto",

--- a/src/i18n/zh.json
+++ b/src/i18n/zh.json
@@ -321,6 +321,11 @@
         "azureModelFamilyAuto": "根据部署名称自动判断",
         "azureModelFamilyGpt5": "GPT-5 / o-series 严格参数",
         "azureModelFamilyHint": "Azure 的 deployment 名称可以任意命名。如果该部署拒绝 max_tokens 或非默认 temperature，请选择 GPT-5 / o-series。",
+        "maxTokensParam": "Max-tokens 字段名",
+        "maxTokensParamAuto": "自动（推荐）",
+        "maxTokensParamMaxTokens": "强制使用 max_tokens",
+        "maxTokensParamMaxCompletionTokens": "强制使用 max_completion_tokens",
+        "maxTokensParamHint": "决定在 OpenAI 兼容线路上用哪个字段携带 token 预算。自动模式会按 endpoint 自行选择；强制指定可能被严格的 endpoint 拒绝（例如自定义 Azure GPT-5 部署会拒绝 max_tokens），除非你的 endpoint 明确要求某个字段，否则请保持自动。",
         "reasoning": {
           "title": "Reasoning / thinking",
           "auto": "自动",

--- a/src/lib/llm-providers.test.ts
+++ b/src/lib/llm-providers.test.ts
@@ -840,3 +840,93 @@ describe("reasoning controls", () => {
     expect(body.reasoning_effort).toBeUndefined()
   })
 })
+
+describe("maxTokensParam override (custom OpenAI-compatible path)", () => {
+  it("forces max_completion_tokens on a plain custom endpoint", () => {
+    const cfg = mkConfig({
+      provider: "custom",
+      model: "some-router-model",
+      customEndpoint: "https://gateway.example.com/v1",
+      apiMode: "chat_completions",
+      maxTokensParam: "max_completion_tokens",
+    })
+    const body = getProviderConfig(cfg).buildBody(
+      [{ role: "user", content: "hi" }],
+      { max_tokens: 4096 },
+    ) as Record<string, unknown>
+
+    expect(body.max_completion_tokens).toBe(4096)
+    expect(body.max_tokens).toBeUndefined()
+  })
+
+  it("wins over an adapter rename (Xiaomi MiMo) and forces back to max_tokens", () => {
+    const cfg = mkConfig({
+      provider: "custom",
+      model: "mimo-v2.5-pro",
+      customEndpoint: "https://api.xiaomimimo.com/v1",
+      apiMode: "chat_completions",
+      maxTokensParam: "max_tokens",
+    })
+    const body = getProviderConfig(cfg).buildBody(
+      [{ role: "user", content: "hi" }],
+      { max_tokens: 2048 },
+    ) as Record<string, unknown>
+
+    expect(body.max_tokens).toBe(2048)
+    expect(body.max_completion_tokens).toBeUndefined()
+  })
+
+  it("is byte-identical to current behavior when omitted or auto", () => {
+    const base = {
+      provider: "custom" as const,
+      model: "some-router-model",
+      customEndpoint: "https://gateway.example.com/v1",
+      apiMode: "chat_completions" as const,
+    }
+    const omitted = getProviderConfig(mkConfig(base)).buildBody(
+      [{ role: "user", content: "hi" }],
+      { max_tokens: 1234 },
+    ) as Record<string, unknown>
+    const auto = getProviderConfig(mkConfig({ ...base, maxTokensParam: "auto" })).buildBody(
+      [{ role: "user", content: "hi" }],
+      { max_tokens: 1234 },
+    ) as Record<string, unknown>
+
+    expect(auto).toEqual(omitted)
+    expect(omitted.max_tokens).toBe(1234)
+    expect(omitted.max_completion_tokens).toBeUndefined()
+  })
+
+  it("is a no-op when the caller passes no token budget", () => {
+    const cfg = mkConfig({
+      provider: "custom",
+      model: "some-router-model",
+      customEndpoint: "https://gateway.example.com/v1",
+      apiMode: "chat_completions",
+      maxTokensParam: "max_completion_tokens",
+    })
+    const body = getProviderConfig(cfg).buildBody([
+      { role: "user", content: "hi" },
+    ]) as Record<string, unknown>
+
+    expect(body.max_tokens).toBeUndefined()
+    expect(body.max_completion_tokens).toBeUndefined()
+  })
+
+  it("still applies on the DeepSeek early-return path", () => {
+    const cfg = mkConfig({
+      provider: "custom",
+      model: "deepseek-v4-flash",
+      customEndpoint: "https://api.deepseek.com/v1",
+      apiMode: "chat_completions",
+      maxTokensParam: "max_completion_tokens",
+    })
+    const body = getProviderConfig(cfg).buildBody(
+      [{ role: "user", content: "hi" }],
+      { max_tokens: 1024 },
+    ) as Record<string, unknown>
+
+    expect(body.max_completion_tokens).toBe(1024)
+    expect(body.max_tokens).toBeUndefined()
+  })
+})

--- a/src/lib/llm-providers.ts
+++ b/src/lib/llm-providers.ts
@@ -383,6 +383,25 @@ function adaptXiaomiMimoBody(
   }
 }
 
+/**
+ * Force the token-budget wire field name when the user picked one
+ * explicitly (`maxTokensParam` !== "auto"). Runs as the final body
+ * transform so it wins over the strict-OpenAI/Azure/Kimi/MiMo adapters.
+ * No-op when the choice is "auto" or when no token budget is present.
+ */
+function applyMaxTokensParamOverride(config: LlmConfig, body: Record<string, unknown>): void {
+  const choice = config.maxTokensParam ?? "auto"
+  if (choice === "auto") return
+  const value =
+    typeof body.max_tokens === "number" ? body.max_tokens
+    : typeof body.max_completion_tokens === "number" ? body.max_completion_tokens
+    : undefined
+  if (value === undefined) return
+  delete body.max_tokens
+  delete body.max_completion_tokens
+  body[choice] = value
+}
+
 function buildOpenAiCompatibleBody(
   config: LlmConfig,
   messages: ChatMessage[],
@@ -410,10 +429,7 @@ function buildOpenAiCompatibleBody(
         }
       }
     }
-    return body
-  }
-
-  if (config.provider === "ollama") {
+  } else if (config.provider === "ollama") {
     // Ollama's OpenAI-compatible /v1/chat/completions maps reasoning
     // control onto `reasoning_effort` ("high"|"medium"|"low"|"none";
     // "none" disables thinking). This is the only lever that stops a
@@ -438,19 +454,23 @@ function buildOpenAiCompatibleBody(
     } else if (reasoning.mode === "max") {
       body.reasoning_effort = "high"
     }
-    return body
-  }
+  } else {
+    if (reasoning.mode === "off" && isQwenThinkingModel(config.model)) {
+      body.chat_template_kwargs = { enable_thinking: false }
+    }
 
-  if (reasoning.mode === "off" && isQwenThinkingModel(config.model)) {
-    body.chat_template_kwargs = { enable_thinking: false }
-  }
-
-  if (config.provider === "openai" && reasoning.mode !== "auto" && reasoning.mode !== "off") {
-    if (reasoning.mode === "low" || reasoning.mode === "medium" || reasoning.mode === "high") {
-      body.reasoning_effort = reasoning.mode
+    if (config.provider === "openai" && reasoning.mode !== "auto" && reasoning.mode !== "off") {
+      if (reasoning.mode === "low" || reasoning.mode === "medium" || reasoning.mode === "high") {
+        body.reasoning_effort = reasoning.mode
+      }
     }
   }
 
+  // Last transform so the user's explicit choice wins over the
+  // strict-OpenAI, Azure, Kimi and MiMo adapters above. Single exit
+  // point guarantees it also covers the DeepSeek path (itself a custom
+  // OpenAI-compatible endpoint), which previously returned early.
+  applyMaxTokensParamOverride(config, body)
   return body
 }
 

--- a/src/stores/wiki-store.ts
+++ b/src/stores/wiki-store.ts
@@ -10,6 +10,15 @@ import { DEFAULT_SOURCE_WATCH_CONFIG } from "@/lib/source-watch-config"
  */
 export type CustomApiMode = "chat_completions" | "anthropic_messages"
 export type AzureModelFamily = "auto" | "gpt5"
+/**
+ * Which wire field carries the token budget on the OpenAI-compatible
+ * custom path. `auto` keeps the existing per-endpoint heuristic
+ * (the adapters in src/lib/llm-providers.ts decide `max_tokens` vs
+ * `max_completion_tokens`). `max_tokens` / `max_completion_tokens`
+ * force that key regardless of the heuristic. `undefined` resolves to
+ * `auto` for backward compatibility with older saved configs.
+ */
+export type MaxTokensParam = "auto" | "max_tokens" | "max_completion_tokens"
 export type ReasoningMode = "auto" | "off" | "low" | "medium" | "high" | "max" | "custom"
 
 export interface ReasoningConfig {
@@ -27,6 +36,11 @@ interface LlmConfig {
   azureModelFamily?: AzureModelFamily
   maxContextSize: number // max context window in characters
   apiMode?: CustomApiMode
+  /**
+   * Custom OpenAI-compatible path only. Forces the token-budget wire
+   * field name. Defaults to `auto` (existing heuristic) when missing.
+   */
+  maxTokensParam?: MaxTokensParam
   reasoning?: ReasoningConfig
   /**
    * Local CLI providers only. When true, LLM Wiki asks Claude/Codex CLI
@@ -289,6 +303,7 @@ export interface ProviderOverride {
   azureApiVersion?: string
   azureModelFamily?: AzureModelFamily
   apiMode?: CustomApiMode
+  maxTokensParam?: MaxTokensParam
   maxContextSize?: number
   reasoning?: ReasoningConfig
   localCliIsolation?: boolean


### PR DESCRIPTION
## Summary

For custom OpenAI-compatible LLMs, a heuristic is in place to choose between `max_tokens` and `max_completion_tokens`.
However, it fails for certain models provided by [GitHub Marketplace](https://github.com/marketplace/models).
E.g. with GPT-5, we have

- Endpoint: `https://models.github.ai/inference`
- Model: `openai/gpt-5`

The heuristic chooses `max_tokens` that leads to the error below.

> HTTP 400: Bad Request — { "error": { "message": "Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.", "type": "invalid_request_error", "param": "max_tokens", "code": "unsupported_parameter" } }

Until now there is no way for a user to override the field name.
This PR adds a settings dropdown that lets the user force the field name for the main LLM on the custom OpenAI-compatible path.

## What changed

1. New optional config field `maxTokensParam` with three values: `auto` (default), `max_tokens`, and `max_completion_tokens`, declared once as the exported `MaxTokensParam` union in the store.
2. The field is threaded through the preset resolver, the `LlmPreset` template, the settings draft, and the global Save path so it persists and cannot be clobbered by a Save triggered from another tab.
3. A new dropdown in the LLM provider section, gated to `custom` presets in `chat_completions` mode, with label, option, and hint strings added to both the English and Chinese locales.
4. A final reconciliation step, `applyMaxTokensParamOverride`, that forces the chosen field name on the request body.

## Behavior and backward compatibility

`auto` is the default and reproduces today's output exactly, so existing configurations behave unchanged.
The field is optional and missing values resolve to `auto`, so no persistence migration is required and older saved configs keep working.
A manual choice can still be rejected by strict endpoints, so the in-app hint recommends leaving the setting on auto unless the endpoint requires a specific field.

## Implementation notes

The override runs as the final body transform, so it overrides the token-field renaming done by the strict-OpenAI/Azure and MiMo adapters.
`buildOpenAiCompatibleBody` was refactored from three separate `return body` points into a single exit point so the override also applies on the DeepSeek and Ollama paths, which previously returned early.
The override reads whichever of `max_tokens` or `max_completion_tokens` is present, deletes both, and writes the value under the chosen field; it is a no-op when neither is present or when the choice is `auto`, and it preserves a value of `0`.

## Testing

1. `npx vitest run llm-providers` passes with 111 tests, including 5 new cases.
2. `npm run typecheck` is clean.

The new test cases cover forcing `max_completion_tokens` on a plain custom endpoint, the override winning over an adapter rename on a Xiaomi MiMo endpoint, `auto` and omitted being identical to current behavior, a no-op when no token budget is passed, and the override still applying on the DeepSeek early-return path.
