### PR TITLE
fix: extract frontmatter title when cleaning up deleted wiki pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ pnpm-debug.log*
 # Brainstorm assets (not tracked in source control)
 .superpowers/
 .claude/
+
+# Worktrees
+.worktrees/

--- a/src/lib/source-lifecycle.ts
+++ b/src/lib/source-lifecycle.ts
@@ -29,6 +29,7 @@ import { removePageEmbedding } from "@/lib/embedding"
 import {
   buildDeletedKeys,
   cleanIndexListing,
+  extractFrontmatterTitle,
   normalizeWikiRefKey,
   stripDeletedWikilinks,
 } from "@/lib/wiki-cleanup"
@@ -413,9 +414,19 @@ export async function cleanupDeletedWikiPages(
   relativePaths: string[],
 ): Promise<void> {
   const pp = normalizePath(projectPath)
-  const deletedInfos = relativePaths
-    .map((path) => ({ slug: getFileStem(path), title: "" }))
-    .filter((info) => info.slug.length > 0 && !info.slug.startsWith("."))
+    const deletedInfos = (await Promise.all(
+    relativePaths.map(async (path) => {
+      const slug = getFileStem(path)
+      let title = ""
+      try {
+        const content = await readFile(`${pp}/${path}`)
+        title = extractFrontmatterTitle(content)
+      } catch {
+        // page already deleted or unreadable — slug-only match is best-effort
+      }
+      return { slug, title }
+    }),
+  )).filter((info) => info.slug.length > 0 && !info.slug.startsWith("."))
 
   if (deletedInfos.length === 0) return
 


### PR DESCRIPTION
Previously cleanupDeletedWikiPages always set title to empty string, which meant only file-stem slugs were used to match wikilinks in index.md and overview.md. Pages whose wikilinks used display titles (e.g. [[KV Cache]] for file kv-cache.md) were silently left behind. Now reads the frontmatter title from each wiki page before deletion, so both slug-form and title-form wikilinks are matched.