### PR TITLE
Make the MCP server project-aware to prevent cross-project data leaks

### DIFF
--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -11,6 +11,7 @@ import {
   LlmWikiApiClient,
   type ApiFileNode,
   type ApiGraphNode,
+  type ApiProject,
   type ApiReviewItem,
   type ApiReviewsResponse,
   type ApiSearchResult,
@@ -22,9 +23,16 @@ const MAX_TEXT_BYTES = 120_000
 
 const client = new LlmWikiApiClient()
 
+const SERVER_INSTRUCTIONS =
+  "llm-wiki exposes a local desktop app that manages multiple independent projects. " +
+  "Each project is an isolated knowledge base. Always default to currentProject " +
+  "(project_id: 'current', the default on every tool); treat it as authoritative over " +
+  "name- or path-matching. Never query a non-current project, or enumerate multiple " +
+  "projects' contents, without explicit user confirmation."
+
 const server = new Server(
   { name: "llm-wiki", version: VERSION },
-  { capabilities: { tools: {} } },
+  { capabilities: { tools: {} }, instructions: SERVER_INSTRUCTIONS },
 )
 
 server.setRequestHandler(ListToolsRequestSchema, async () => ({
@@ -140,11 +148,12 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           client.health(),
           client.projects().catch(() => ({ projects: [], currentProject: null })),
         ])
-        return textResult(JSON.stringify({ ...health, ...projects }, null, 2))
+        return textResult(JSON.stringify({ ...health, ...projects, ...multiProjectWarning(projects.projects, projects.currentProject) }, null, 2))
       }
       case "llm_wiki_projects": {
         await assertMcpEnabled()
-        return textResult(JSON.stringify(await client.projects(), null, 2))
+        const projects = await client.projects()
+        return textResult(JSON.stringify({ ...projects, ...multiProjectWarning(projects.projects, projects.currentProject) }, null, 2))
       }
       case "llm_wiki_files": {
         await assertMcpEnabled()
@@ -211,6 +220,14 @@ async function assertMcpEnabled(): Promise<void> {
       ErrorCode.InvalidRequest,
       "LLM Wiki MCP access is disabled. Enable Settings -> API + MCP -> Enable MCP access in the desktop app.",
     )
+  }
+}
+
+function multiProjectWarning(projects: ApiProject[], currentProject: ApiProject | null): { warning?: string } {
+  if (projects.length <= 1) return {}
+  const current = currentProject ? `"${currentProject.name}" (id: ${currentProject.id})` : "none"
+  return {
+    warning: `${projects.length} projects registered — only currentProject (${current}) is active; confirm with user before targeting another.`,
   }
 }
 


### PR DESCRIPTION
**What this fixes**

When multiple projects exist, an AI assistant using the llm-wiki MCP server had no clear signal about which project it should be working with. That opened the door for a request meant for one project to accidentally pull data from a different one, without ever checking in with the user first.

**What changed**

1. Added usage guidance for AI assistants. The MCP server now tells connecting AI clients, up front: always use the currently active project unless the user says otherwise, and never poke around in a different project without asking first.
2. Added a visible warning when it matters. When there's more than one project registered, the status/projects responses now include a clear warning naming the active project and reminding the assistant to check with the user before targeting a different one — right at the moment it's making that decision, not buried in documentation.

**What this doesn't fix yet**

These two changes rely on the assistant reading and following the guidance — they're a strong nudge, not a hard guarantee. A separate, more involved fix (binding a session to one project, or having the server ask the user directly when it's unclear) would close this properly. That's being filed as a follow-up issue rather than bundled into this PR.

**Testing**

Type-checked and built cleanly (tsc --noEmit, npm run build). No behavior changes for the single-project case.