### PR TITLE
fix: resolve sources inside raw/sources dotfolders

### DIFF
--- a/src/lib/project-file-tree-refresh.test.ts
+++ b/src/lib/project-file-tree-refresh.test.ts
@@ -78,9 +78,46 @@ describe("refreshProjectFileTree", () => {
 
     expect(mocks.listDirectory).toHaveBeenNthCalledWith(1, project.path, { maxDepth: 2 })
     expect(mocks.listDirectory).toHaveBeenNthCalledWith(2, project.path, undefined)
+    expect(mocks.listDirectory).toHaveBeenNthCalledWith(3, `${project.path}/raw/sources`, {
+      includeHidden: true,
+    })
     expect(useWikiStore.getState().fileTree).toEqual(shallowTree)
     expect(useWikiStore.getState().projectPathIndex.byPath.has("/tmp/project/wiki/entities/alpha.md")).toBe(true)
     expect(useWikiStore.getState().dataVersion).toBe(1)
+  })
+
+  it("includes raw/sources dotfolders in the resolver index via a hidden scan", async () => {
+    const rawSourcesHiddenTree: FileNode[] = [
+      {
+        name: ".claude",
+        path: "/tmp/project/raw/sources/.claude",
+        is_dir: true,
+        children: [
+          {
+            name: "memory.md",
+            path: "/tmp/project/raw/sources/.claude/memory.md",
+            is_dir: false,
+          },
+        ],
+      },
+    ]
+    mocks.listDirectory.mockImplementation(
+      async (path: string, options?: { maxDepth?: number; includeHidden?: boolean }) => {
+        if (options?.maxDepth === 2) return shallowTree
+        if (path === "/tmp/project/raw/sources") return rawSourcesHiddenTree
+        return fullTree
+      },
+    )
+
+    await refreshProjectFileTree(project.path, {
+      projectId: project.id,
+      bumpDataVersion: true,
+    })
+    await flushMicrotasks()
+
+    const index = useWikiStore.getState().projectPathIndex
+    expect(index.byPath.has("/tmp/project/wiki/entities/alpha.md")).toBe(true)
+    expect(index.byPath.has("/tmp/project/raw/sources/.claude/memory.md")).toBe(true)
   })
 
   it("does not write stale results after the active project changes", async () => {
@@ -123,9 +160,11 @@ describe("refreshProjectFileTree", () => {
       await flushMicrotasks()
 
       expect(mocks.listDirectory).toHaveBeenNthCalledWith(1, project.path, { maxDepth: 2 })
-      expect(mocks.listDirectory).toHaveBeenNthCalledWith(2, project.path, undefined)
-      expect(mocks.listDirectory).toHaveBeenNthCalledWith(3, project.path, undefined)
-      expect(mocks.listDirectory).toHaveBeenNthCalledWith(4, project.path, undefined)
+      // The full project scan retries three times before giving up.
+      const fullScanCalls = mocks.listDirectory.mock.calls.filter(
+        ([path, options]) => path === project.path && options === undefined,
+      )
+      expect(fullScanCalls).toHaveLength(3)
       expect(useWikiStore.getState().fileTree).toEqual(shallowTree)
       expect(useWikiStore.getState().projectPathIndex.byPath.has("/tmp/project/wiki/entities/alpha.md")).toBe(true)
     } finally {

--- a/src/lib/project-file-tree-refresh.ts
+++ b/src/lib/project-file-tree-refresh.ts
@@ -78,10 +78,27 @@ export async function refreshProjectFileTree(
 
   if (refreshPathIndex) {
     if (!isStillCurrentProject(currentProjectId, normalizedProjectPath)) return
-    listDirectoryWithRetry(normalizedProjectPath, undefined, 3)
-      .then((fullTree) => {
+    // The full project scan hides dot-prefixed entries (`.git`,
+    // `.llm-wiki`, …), which is correct for most of the tree. But
+    // `raw/sources` may hold user-added dotfolders (`.claude`,
+    // `.codex`) whose files back real `sources:` references. Scan
+    // that subtree with `includeHidden` and merge it in so those
+    // sources resolve instead of rendering as "not found". The
+    // raw/sources scan is best-effort — a project without sources
+    // must still get a full index.
+    Promise.all([
+      listDirectoryWithRetry(normalizedProjectPath, undefined, 3),
+      listDirectoryWithRetry(
+        `${normalizedProjectPath}/raw/sources`,
+        { includeHidden: true },
+        3,
+      ).catch(() => [] as FileNode[]),
+    ])
+      .then(([fullTree, rawSourcesTree]) => {
         if (!isStillCurrentProject(currentProjectId, normalizedProjectPath)) return
-        useWikiStore.getState().setProjectPathIndexFromTree(fullTree)
+        useWikiStore
+          .getState()
+          .setProjectPathIndexFromTree([...fullTree, ...rawSourcesTree])
       })
       .catch((err) => {
         console.error("Failed to refresh project path index:", err)

--- a/src/lib/wiki-page-resolver.test.ts
+++ b/src/lib/wiki-page-resolver.test.ts
@@ -64,6 +64,27 @@ const STRAY_CHILDREN_INDEX = buildProjectPathIndexFromTree([
   },
 ])
 
+describe("buildProjectPathIndexFromTree", () => {
+  it("indexes each path once when overlapping trees are merged", () => {
+    // The full project scan and a hidden raw/sources rescan share the
+    // visible source files; merging them must not create duplicate
+    // filesByName entries, while still surfacing hidden-only files.
+    const rawSourcesRescan: FileNode[] = [
+      dir(`${SOURCES}`, [
+        file(`${SOURCES}/report.pdf`), // duplicate of the full scan
+        dir(`${SOURCES}/.claude`, [file(`${SOURCES}/.claude/memory.md`)]),
+      ]),
+    ]
+    const merged = buildProjectPathIndexFromTree([...TREE, ...rawSourcesRescan])
+
+    expect(merged.filesByName.get("report.pdf")).toHaveLength(1)
+    expect(merged.byPath.has(`${SOURCES}/.claude/memory.md`)).toBe(true)
+    expect(findInTreeByName(merged, "memory.md", `${SOURCES}/`)).toBe(
+      `${SOURCES}/.claude/memory.md`,
+    )
+  })
+})
+
 describe("unwrapWikilink", () => {
   it("unwraps a bare [[target]]", () => {
     expect(unwrapWikilink("[[nh3-n]]")).toEqual({ slug: "nh3-n", label: "nh3-n" })
@@ -262,6 +283,26 @@ describe("resolveSourceName", () => {
     )
     expect(resolveSourceName(INDEX, "wiki/sources/paper.md", SOURCES)).toBe(
       `${WIKI}/sources/paper.md`,
+    )
+  })
+
+  it("resolves a source that lives inside a raw/sources dotfolder", () => {
+    // Real frontmatter shape: sources: [".claude/projects/.../MEMORY.md"].
+    // These only resolve once the hidden raw/sources rescan puts the
+    // dotfolder file into the index.
+    const dotIndex = buildProjectPathIndexFromTree([
+      dir(`${PP}/raw`, [
+        dir(`${SOURCES}`, [
+          dir(`${SOURCES}/.claude`, [
+            dir(`${SOURCES}/.claude/projects`, [
+              file(`${SOURCES}/.claude/projects/MEMORY.md`),
+            ]),
+          ]),
+        ]),
+      ]),
+    ])
+    expect(resolveSourceName(dotIndex, ".claude/projects/MEMORY.md", SOURCES)).toBe(
+      `${SOURCES}/.claude/projects/MEMORY.md`,
     )
   })
 })

--- a/src/lib/wiki-page-resolver.ts
+++ b/src/lib/wiki-page-resolver.ts
@@ -20,15 +20,21 @@ export function buildProjectPathIndexFromTree(tree: FileNode[]): ProjectPathInde
 
   function walk(nodes: FileNode[]) {
     for (const node of nodes) {
-      const entry: ProjectPathIndexEntry = {
-        name: node.name,
-        path: node.path,
-      }
-      byPath.set(node.path, entry)
-      if (!node.is_dir) {
-        const bucket = filesByName.get(node.name)
-        if (bucket) bucket.push(entry)
-        else filesByName.set(node.name, [entry])
+      // Callers may pass overlapping trees (e.g. the full project
+      // scan plus a hidden `raw/sources` rescan share the visible
+      // source files). Index each path once so `filesByName` buckets
+      // don't accumulate duplicate entries.
+      if (!byPath.has(node.path)) {
+        const entry: ProjectPathIndexEntry = {
+          name: node.name,
+          path: node.path,
+        }
+        byPath.set(node.path, entry)
+        if (!node.is_dir) {
+          const bucket = filesByName.get(node.name)
+          if (bucket) bucket.push(entry)
+          else filesByName.set(node.name, [entry])
+        }
       }
       if (node.is_dir && node.children) walk(node.children)
     }


### PR DESCRIPTION
## Problem

When opening a Knowledge-tab entity, `sources:` entries that point at a file inside a **dot-prefixed folder** under `raw/sources` (e.g. `.claude`, `.codex`) render as a dashed "Source not found" card in the frontmatter panel — even though the file exists on disk and its non-hidden siblings resolve fine.

Concrete repro: an entity with

```yaml
sources:
  - ".claude/projects/-Users-me--claude/memory/MEMORY.md"
  - "agentic-coding-toolkit/README.md"   # resolves
```

The `.claude/...` card shows ⚠️; the sibling under a normal folder resolves.

## Root cause

The resolver path index (`projectPathIndex`) is built in `refreshProjectFileTree` from a single full-project `listDirectory(projectRoot)` scan, which defaults to `includeHidden: false`. `entry_is_visible` (fs.rs) then drops every dot-prefixed entry at each level, so `raw/sources/.claude/**` never enters the index. `resolveSourceName` looks the path up in that index, misses, and the `SourceCard` renders as unresolved.

This is the same class of bug already fixed for the Raw Sources tree and chat file tools (`c70da6a`, `a126829`), which scan `raw/sources` with `includeHidden: true`. The resolver index was simply never given the same treatment.

## Fix

- In `refreshProjectFileTree`, additionally rescan `raw/sources` with `includeHidden: true` (best-effort — a project without sources still gets a full index) and merge it into the tree passed to the resolver index. The full-project scan stays `includeHidden: false`, so internal dotfolders (`.git`, `.llm-wiki`) are still kept out of the index.
- Guard `buildProjectPathIndexFromTree` against duplicate paths so the overlapping scans don't inflate the `filesByName` buckets.

`related:` references live under `wiki/` (never hidden) and are unaffected.

## Tests

- `project-file-tree-refresh.test.ts`: new test asserting a `raw/sources/.claude/...` file lands in the index; updated the existing call-signature expectations for the added hidden scan.
- `wiki-page-resolver.test.ts`: dedup test for merged overlapping trees, and a resolver test using the real `.claude/projects/.../MEMORY.md` ref shape.

All existing tests pass; `tsc` clean.