### PR TITLE
feat: add Czech to AI output language options

### DIFF
--- a/src/lib/language-metadata.ts
+++ b/src/lib/language-metadata.ts
@@ -56,6 +56,12 @@ const LANGUAGE_METADATA: Record<string, LanguageMetadata> = {
     direction: "ltr",
     scriptFamily: "cjk",
   },
+  Czech: {
+    promptName: "Czech / čeština",
+    htmlLang: "cs",
+    direction: "ltr",
+    scriptFamily: "latin",
+  },
 }
 
 const DEFAULT_METADATA: LanguageMetadata = {

--- a/src/lib/output-language-options.ts
+++ b/src/lib/output-language-options.ts
@@ -34,6 +34,7 @@ export const OUTPUT_LANGUAGE_OPTIONS = [
   { value: "Turkish", label: "Türkçe (Turkish)" },
   { value: "Dutch", label: "Nederlands (Dutch)" },
   { value: "Polish", label: "Polski (Polish)" },
+  { value: "Czech", label: "Čeština (Czech)" },
   { value: "Swedish", label: "Svenska (Swedish)" },
   { value: "Indonesian", label: "Bahasa Indonesia (Indonesian)" },
   { value: "Thai", label: "ไทย (Thai)" },

--- a/src/stores/wiki-store.ts
+++ b/src/stores/wiki-store.ts
@@ -303,6 +303,7 @@ type OutputLanguage =
   | "Turkish"
   | "Dutch"
   | "Polish"
+  | "Czech"
   | "Swedish"
   | "Indonesian"
   | "Thai"


### PR DESCRIPTION
## Summary

Adds Czech (čeština) as a selectable AI output language.

Interestingly, the language detector in `detect-language.ts` already returns `"Czech"` for auto-detected Czech text, but the value was missing from the `OutputLanguage` union and the settings dropdown — so the auto path could produce a language the user could never select explicitly. This PR fixes that inconsistency.

## Changes

- add `"Czech"` to the `OutputLanguage` union in `wiki-store.ts`
- add `Čeština (Czech)` to `OUTPUT_LANGUAGE_OPTIONS`
- add explicit language metadata (`htmlLang: "cs"`, latin script, LTR)

## Testing

- `npm run typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)