### PR TITLE
fix: render http(s) source references as external links

### DIFF
--- a/src/components/editor/frontmatter-panel.tsx
+++ b/src/components/editor/frontmatter-panel.tsx
@@ -14,11 +14,13 @@ import {
   Calendar,
   Tag as TagIcon,
 } from "lucide-react"
+import { openUrl } from "@tauri-apps/plugin-opener"
 import type { FrontmatterValue } from "@/lib/frontmatter"
 import { getWikiTypeStyle } from "@/lib/wiki-type-style"
 import {
   resolveRelatedSlug,
-  resolveSourceName,
+  resolveSourceReference,
+  type SourceReferenceResolution,
   unwrapWikilink,
 } from "@/lib/wiki-page-resolver"
 import { useWikiStore } from "@/stores/wiki-store"
@@ -80,6 +82,12 @@ export function FrontmatterPanel({ data }: FrontmatterPanelProps) {
   function handleNavigate(path: string | null) {
     if (!path) return
     openPathInPreview(path)
+  }
+
+  function handleOpenExternal(url: string) {
+    void openUrl(url).catch((err) => {
+      console.warn("[frontmatter] openUrl failed:", err)
+    })
   }
 
   return (
@@ -149,15 +157,23 @@ export function FrontmatterPanel({ data }: FrontmatterPanelProps) {
           <div className="flex flex-wrap gap-2">
             {sources.map((source) => {
               const { slug, label } = unwrapWikilink(source)
-              const path = sourcesRoot
-                ? resolveSourceName(projectPathIndex, slug, sourcesRoot)
-                : null
+              const resolution = resolveSourceReference(
+                projectPathIndex,
+                slug,
+                sourcesRoot,
+              )
+              const onClick =
+                resolution.kind === "local"
+                  ? () => handleNavigate(resolution.path)
+                  : resolution.kind === "external"
+                    ? () => handleOpenExternal(resolution.url)
+                    : undefined
               return (
                 <SourceCard
                   key={source}
                   name={label}
-                  resolved={!!path}
-                  onClick={() => handleNavigate(path)}
+                  status={resolution.kind}
+                  onClick={onClick}
                 />
               )
             })}
@@ -221,28 +237,37 @@ export function FrontmatterPanel({ data }: FrontmatterPanelProps) {
 
 function SourceCard({
   name,
-  resolved,
+  status,
   onClick,
 }: {
   name: string
-  resolved: boolean
-  onClick: () => void
+  status: SourceReferenceResolution["kind"]
+  onClick?: () => void
 }) {
-  const Icon = iconForSource(name)
+  const isMissing = status === "missing"
+  const Icon = status === "external" ? ArrowUpRight : iconForSource(name)
   return (
     <button
       type="button"
-      onClick={resolved ? onClick : undefined}
-      title={resolved ? `Open ${name}` : `Source not found in raw/sources/: ${name}`}
+      onClick={onClick}
+      title={
+        status === "external"
+          ? `Open external source ${name}`
+          : status === "local"
+            ? `Open ${name}`
+            : `Source not found in raw/sources/: ${name}`
+      }
       className={`group flex min-w-0 max-w-[200px] items-center gap-2 rounded-md border px-2.5 py-1.5 text-left text-xs transition-colors ${
-        resolved
-          ? "border-border/60 bg-background hover:border-primary/40 hover:bg-primary/5 cursor-pointer"
-          : "border-dashed border-border/50 bg-muted/20 text-muted-foreground/70 cursor-default"
+        isMissing
+          ? "border-dashed border-border/50 bg-muted/20 text-muted-foreground/70 cursor-default"
+          : "border-border/60 bg-background hover:border-primary/40 hover:bg-primary/5 cursor-pointer"
       }`}
     >
-      <Icon className={`h-4 w-4 shrink-0 ${resolved ? "text-foreground/70" : "text-muted-foreground/60"}`} />
+      <Icon className={`h-4 w-4 shrink-0 ${
+        isMissing ? "text-muted-foreground/60" : "text-foreground/70"
+      }`} />
       <span className="truncate">{name}</span>
-      {!resolved && <AlertTriangle className="h-3 w-3 shrink-0 text-amber-500/70" />}
+      {isMissing && <AlertTriangle className="h-3 w-3 shrink-0 text-amber-500/70" />}
     </button>
   )
 }

--- a/src/lib/wiki-page-resolver.test.ts
+++ b/src/lib/wiki-page-resolver.test.ts
@@ -5,6 +5,7 @@ import {
   createEmptyProjectPathIndex,
   findInTreeByName,
   resolveRelatedSlug,
+  resolveSourceReference,
   resolveSourceName,
   unwrapWikilink,
 } from "./wiki-page-resolver"
@@ -263,5 +264,51 @@ describe("resolveSourceName", () => {
     expect(resolveSourceName(INDEX, "wiki/sources/paper.md", SOURCES)).toBe(
       `${WIKI}/sources/paper.md`,
     )
+  })
+})
+
+describe("resolveSourceReference", () => {
+  it("treats HTTP and HTTPS URLs as external sources", () => {
+    expect(
+      resolveSourceReference(
+        INDEX,
+        "https://developer.apple.com/videos/play/wwdc2025/230/",
+        SOURCES,
+      ),
+    ).toEqual({
+      kind: "external",
+      url: "https://developer.apple.com/videos/play/wwdc2025/230/",
+    })
+    expect(
+      resolveSourceReference(INDEX, "http://example.com/source", SOURCES),
+    ).toEqual({
+      kind: "external",
+      url: "http://example.com/source",
+    })
+  })
+
+  it("keeps existing local and missing source behavior", () => {
+    expect(resolveSourceReference(INDEX, "report.pdf", SOURCES)).toEqual({
+      kind: "local",
+      path: `${SOURCES}/report.pdf`,
+    })
+    expect(resolveSourceReference(INDEX, "ghost.pdf", SOURCES)).toEqual({
+      kind: "missing",
+    })
+  })
+
+  it("recognizes external URLs before local source roots are available", () => {
+    expect(
+      resolveSourceReference(INDEX, "https://example.com/source", null),
+    ).toEqual({
+      kind: "external",
+      url: "https://example.com/source",
+    })
+  })
+
+  it("does not classify non-HTTP URL-like values as external sources", () => {
+    expect(resolveSourceReference(INDEX, "javascript:alert(1)", SOURCES)).toEqual({
+      kind: "missing",
+    })
   })
 })

--- a/src/lib/wiki-page-resolver.ts
+++ b/src/lib/wiki-page-resolver.ts
@@ -55,6 +55,24 @@ export function unwrapWikilink(s: string): { slug: string; label: string } {
   return { slug: target, label: alias && alias.length > 0 ? alias : target }
 }
 
+export type SourceReferenceResolution =
+  | { kind: "external"; url: string }
+  | { kind: "local"; path: string }
+  | { kind: "missing" }
+
+export function resolveSourceReference(
+  index: ProjectPathIndex,
+  ref: string,
+  sourcesRoot: string | null,
+): SourceReferenceResolution {
+  const trimmedRef = ref.trim()
+  if (isHttpUrl(trimmedRef)) return { kind: "external", url: trimmedRef }
+  if (!sourcesRoot) return { kind: "missing" }
+
+  const path = resolveSourceName(index, ref, sourcesRoot)
+  return path ? { kind: "local", path } : { kind: "missing" }
+}
+
 /**
  * Return the absolute path of the first indexed file whose basename
  * matches `targetName` and whose path contains `pathContains`.
@@ -159,4 +177,13 @@ export function resolveSourceName(
 function findInTreeByPath(index: ProjectPathIndex, targetPath: string): string | null {
   const found = index.byPath.get(targetPath)
   return found?.path ?? null
+}
+
+function isHttpUrl(ref: string): boolean {
+  try {
+    const url = new URL(ref)
+    return url.protocol === "http:" || url.protocol === "https:"
+  } catch {
+    return false
+  }
 }

--- a/src/lib/wiki-page-resolver.ts
+++ b/src/lib/wiki-page-resolver.ts
@@ -69,7 +69,7 @@ export function resolveSourceReference(
   if (isHttpUrl(trimmedRef)) return { kind: "external", url: trimmedRef }
   if (!sourcesRoot) return { kind: "missing" }
 
-  const path = resolveSourceName(index, ref, sourcesRoot)
+  const path = resolveSourceName(index, trimmedRef, sourcesRoot)
   return path ? { kind: "local", path } : { kind: "missing" }
 }
 


### PR DESCRIPTION
## Problem
Wiki pages sometimes carry an `http(s)` URL in their `sources:` frontmatter — e.g. an LLM-emitted web citation. The frontmatter panel resolves every `sources:` entry against `raw/sources/` and, when no local file matches, renders the card with a dashed border and an amber "Source not found in raw/sources/" warning.

A URL is not a missing local file, so this flags a valid external reference as broken. The existing data model keeps `sources:` for local file references (ingest, web-clip, and the deep-research import in #178 all materialize content into `raw/sources/`), so URL entries only reach `sources:` via LLM output or manual edits — and today they degrade to a misleading warning rather than a usable link.

## Change
- Add `resolveSourceReference()` in `wiki-page-resolver.ts` that classifies a `sources:` entry as:
  - `external` — an `http:`/`https:` URL (validated via `new URL()`)
  - `local` — resolves to a file under `raw/sources/` or `wiki/sources/`
  - `missing` — neither
- Render `external` sources as clickable cards opened in the system browser via `tauri-plugin-opener` (same pattern as the About / API-server links), with no warning icon.
- `local` and `missing` behavior is unchanged. Non-http URL-like values (e.g. `javascript:`) are treated as `missing`, not external.

## Test plan
- `npm run test:mocks` — 1600 tests pass, incl. new `resolveSourceReference` cases (http/https external, local, missing, null source root, `javascript:` rejection)
- `npm run typecheck` — clean
- Manual: open a wiki page whose `sources:` contains an `https://` URL → the card renders as an external link and opens the browser on click, with no amber "not found" warning