### PR TITLE
fix(lint): drop missing-page findings for pages that already exist

### DIFF
--- a/src/lib/lint.test.ts
+++ b/src/lib/lint.test.ts
@@ -118,6 +118,48 @@ describe("runSemanticLint — language directive", () => {
   })
 })
 
+describe("runSemanticLint — missing-page false positives (#537)", () => {
+  it("drops missing-page findings when the entity page already exists", async () => {
+    const pages = [
+      makeFileNode("概念页.md", "介绍 [[维特根斯坦]]、[[阿德勒]] 和 [[尼采]] 的概念页"),
+      makeFileNode("维特根斯坦.md", "维特根斯坦是一位哲学家。"), // entity page EXISTS
+      makeFileNode("阿德勒.md", "阿德勒是一位心理学家。"), // entity page EXISTS
+    ]
+    mockListDirectory.mockResolvedValue(pages.map((p) => p.node))
+    mockReadFile.mockImplementation(async (path) => {
+      const match = pages.find((p) => p.node.path === path)
+      return match?.content ?? ""
+    })
+    // The LLM wrongly reports missing-page for entities that already have pages,
+    // using free-form Chinese titles that don't match a known "缺失页面:" prefix.
+    const llm = [
+      "---LINT: missing-page | warning | 维特根斯坦---", // bare name, page exists
+      "维特根斯坦在概念页中被引用但未建立独立实体页。",
+      "PAGES: 概念页.md",
+      "---END LINT---",
+      "---LINT: missing-page | warning | 阿德勒实体页缺失---", // name + suffix, page exists
+      "阿德勒被引用但缺少页面。",
+      "PAGES: 概念页.md",
+      "---END LINT---",
+      "---LINT: missing-page | warning | 尼采---", // genuinely missing (no page)
+      "尼采被引用但没有页面。",
+      "PAGES: 概念页.md",
+      "---END LINT---",
+    ].join("\n")
+    mockStreamChat.mockImplementation(async (_c, _m, cb) => {
+      cb.onToken(llm)
+      cb.onDone()
+    })
+
+    const results = await runSemanticLint("/project", fakeLlmConfig())
+
+    const missingPages = results.filter((r) => r.detail.includes("[missing-page]"))
+    // The two existing-entity false positives are filtered; only 尼采 remains.
+    expect(missingPages).toHaveLength(1)
+    expect(missingPages[0].page).toBe("尼采")
+  })
+})
+
 describe("runSemanticLint — activity & early returns", () => {
   it("logs a running activity item and marks done", async () => {
     mockListDirectory.mockResolvedValue([makeFileNode("a.md", "content").node])

--- a/src/lib/lint.ts
+++ b/src/lib/lint.ts
@@ -62,6 +62,35 @@ function normalizeLinkTarget(target: string): string {
     .toLowerCase()
 }
 
+/**
+ * Normalize a name for missing-page existence comparison. NFKC folds full-width
+ * and compatibility forms so CJK / full-width variants compare equal.
+ */
+function normalizeForExistence(s: string): string {
+  return s.normalize("NFKC").trim().toLowerCase()
+}
+
+/**
+ * Decide whether an LLM `missing-page` finding actually refers to a page that
+ * already exists. The LLM does not reliably cross-reference the file list, so it
+ * flags entities whose page is already present — especially in non-English wikis
+ * where its free-form titles ("维特根斯坦", "阿德勒实体页缺失", "缺失页面：X") don't
+ * match a fixed prefix. Drop the finding when a known page name matches exactly
+ * or appears within the finding title (guarded by length to avoid over-matching).
+ */
+function missingPageAlreadyExists(
+  llmTitle: string,
+  existingPageNames: Set<string>,
+): boolean {
+  const norm = normalizeForExistence(llmTitle)
+  if (!norm) return false
+  if (existingPageNames.has(norm)) return true
+  for (const name of existingPageNames) {
+    if (name.length >= 2 && norm.includes(name)) return true
+  }
+  return false
+}
+
 function extractTitle(content: string, fallbackPath: string): string {
   const frontmatter = content.match(/^---\s*\n([\s\S]*?)\n---/)
   if (frontmatter) {
@@ -329,13 +358,20 @@ export async function runSemanticLint(
     (f) => f.name !== "log.md"
   )
 
-  // Build a compact summary of each page (frontmatter + first 500 chars)
+  // Build a compact summary of each page (frontmatter + first 500 chars), and
+  // collect the set of existing page names (basename + frontmatter title) used
+  // to filter out `missing-page` findings for pages that already exist (#537).
   const summaries: string[] = []
+  const existingPageNames = new Set<string>()
   for (const f of wikiFiles) {
+    const basename = f.name.replace(/\.md$/i, "")
+    if (basename) existingPageNames.add(normalizeForExistence(basename))
     try {
       const content = await readFile(f.path)
       const preview = content.slice(0, 500) + (content.length > 500 ? "..." : "")
       const shortPath = getRelativePath(f.path, wikiRoot)
+      const title = extractTitle(content, shortPath)
+      if (title) existingPageNames.add(normalizeForExistence(title))
       summaries.push(`### ${shortPath}\n${preview}`)
     } catch {
       // skip
@@ -412,8 +448,12 @@ export async function runSemanticLint(
     const title = match[3].trim()
     const body = match[4].trim()
 
-    // semantic results always use type "semantic"
-    void rawType
+    // Drop `missing-page` findings whose page already exists — the LLM often
+    // flags entities that already have a page, especially in non-English wikis
+    // where its free-form titles don't match a fixed prefix (#537).
+    if (rawType === "missing-page" && missingPageAlreadyExists(title, existingPageNames)) {
+      continue
+    }
 
     const pagesMatch = body.match(/^PAGES:\s*(.+)$/m)
     const affectedPages = pagesMatch


### PR DESCRIPTION
## Why

`runSemanticLint` passed the LLM's `missing-page` findings straight to the Review tab without validating them against the actual page set. The LLM doesn't reliably cross-reference the file list, so it flags entities whose page **already exists** — especially in non-English wikis, where its free-form titles (`维特根斯坦`, `阿德勒实体页缺失`, `缺失页面：X`) don't match a fixed prefix. The reporter saw 30 of 41 missing-page findings as false positives, drowning out the 11 genuine ones.

On the reported root-cause guesses in #537: the scan already covers `entities/` (every `wiki/*.md` except `log.md` is summarized), so it isn't a "only scans `concepts/`" problem — the findings come from the LLM and simply weren't filtered against existing pages.

## What

While summarizing pages, collect the set of existing page names (basename + frontmatter title, NFKC-normalized). Drop a `missing-page` finding when a known page name matches its title exactly or appears within it.

Fixes #537

## Review notes

- **Match strategy / over-match guard:** exact match handles bare names; a substring fallback (guarded to names ≥ 2 chars) handles free-form/suffixed titles like `阿德勒实体页缺失`. The substring pass could in principle drop a *genuine* missing-page whose title happens to contain a short existing page name. I chose the more permissive version because the reported problem is over-reporting — but if you'd prefer a stricter rule (exact-match only, or a higher length threshold), I'm glad to adjust.
- NFKC normalization folds full-width/compatibility forms so CJK/full-width variants compare equal.
- Only `missing-page` findings are filtered; other semantic types are untouched.

## Tests

Added a regression test in `lint.test.ts`: an entity page exists but the (mocked) LLM reports it as `missing-page` with free-form Chinese titles — asserts the false positives are dropped and a genuinely-missing entity is kept. Fails before the change, passes after. Full unit suite: 1609 passed.

---

_Disclosure: this change was produced by an AI agent (Claude Code) — root-cause analysis, fix, and regression test included. It's covered by the new test and the full unit suite passes; flagging for maintainer review._
