### PR TITLE
fix(enrich): drop wikilink substitutions whose target has no page

### DIFF
--- a/src/lib/enrich-wikilinks.test.ts
+++ b/src/lib/enrich-wikilinks.test.ts
@@ -13,12 +13,21 @@ vi.mock("@/commands/fs", () => ({
 
 import { enrichWithWikilinks } from "./enrich-wikilinks"
 import { streamChat } from "./llm-client"
-import { readFile, writeFile } from "@/commands/fs"
+import { readFile, writeFile, listDirectory } from "@/commands/fs"
 import { useWikiStore } from "@/stores/wiki-store"
+import type { FileNode } from "@/types/wiki"
 
 const mockStreamChat = vi.mocked(streamChat)
 const mockReadFile = vi.mocked(readFile)
 const mockWriteFile = vi.mocked(writeFile)
+const mockListDirectory = vi.mocked(listDirectory)
+
+// Materialize a flat list of wiki page nodes for the target-existence check.
+function wikiPages(...names: string[]): FileNode[] {
+  return names.map(
+    (name) => ({ name, path: `/p/wiki/${name}`, is_dir: false, children: [] }) as FileNode,
+  )
+}
 
 function fakeLlmConfig(): LlmConfig {
   return {
@@ -43,6 +52,8 @@ beforeEach(() => {
   mockStreamChat.mockReset()
   mockReadFile.mockReset()
   mockWriteFile.mockReset()
+  mockListDirectory.mockReset()
+  mockListDirectory.mockResolvedValue([])
   useWikiStore.getState().setOutputLanguage("auto")
 })
 
@@ -131,6 +142,29 @@ describe("enrichWithWikilinks — JSON-based substitution", () => {
     const written = vi.mocked(mockWriteFile).mock.calls[0][1] as string
     expect(written).toContain("[[Transformer]]")
     expect(written).toContain("[[Attention]]")
+  })
+
+  it("drops substitutions whose target is not an existing page (#535)", async () => {
+    // The page is named in Chinese; the LLM (wrongly) targets an English name
+    // with no page — that link would be broken and must not be written. A
+    // target that resolves to a real page is still linked.
+    mockListDirectory.mockResolvedValue(wikiPages("注意力机制.md"))
+    mockReadFile.mockResolvedValue("注意力 是 Transformer 的核心思想。")
+    mockStreamChatReturns(
+      JSON.stringify({
+        links: [
+          { term: "注意力", target: "attention" }, // no such page — broken, drop
+          { term: "Transformer", target: "注意力机制" }, // resolves to a page — keep
+        ],
+      }),
+    )
+
+    await enrichWithWikilinks("/p", "/p/f.md", fakeLlmConfig())
+
+    expect(mockWriteFile).toHaveBeenCalledOnce()
+    const written = vi.mocked(mockWriteFile).mock.calls[0][1] as string
+    expect(written).not.toContain("[[attention") // broken English target dropped
+    expect(written).toContain("[[注意力机制|Transformer]]") // valid target kept
   })
 
   it("does NOT overwrite when LLM returns an empty links list", async () => {

--- a/src/lib/enrich-wikilinks.ts
+++ b/src/lib/enrich-wikilinks.ts
@@ -1,8 +1,24 @@
-import { readFile, writeFile } from "@/commands/fs"
+import { readFile, writeFile, listDirectory } from "@/commands/fs"
 import { streamChat } from "./llm-client"
 import { useWikiStore, type LlmConfig } from "@/stores/wiki-store"
 import { buildLanguageDirective } from "./output-language"
 import { normalizePath } from "@/lib/path-utils"
+import type { FileNode } from "@/types/wiki"
+
+/** Normalize a wikilink target to its basename slug (matches how links resolve). */
+function targetSlug(target: string): string {
+  return (target.split("/").pop() ?? target).replace(/\.md$/i, "").trim().toLowerCase()
+}
+
+/** Collect the basename slug of every wiki page, for target-existence checks. */
+function collectPageSlugs(nodes: FileNode[], set: Set<string>): void {
+  for (const n of nodes) {
+    if (n.is_dir && n.children) collectPageSlugs(n.children, set)
+    else if (!n.is_dir && n.name.endsWith(".md")) {
+      set.add(n.name.replace(/\.md$/i, "").toLowerCase())
+    }
+  }
+}
 
 /**
  * Lightweight post-save enrichment: ask LLM to add [[wikilinks]] to a saved wiki page.
@@ -29,12 +45,19 @@ export async function enrichWithWikilinks(
 ): Promise<void> {
   const pp = normalizePath(projectPath)
   const fp = normalizePath(filePath)
-  const [content, index] = await Promise.all([
+  const [content, index, tree] = await Promise.all([
     readFile(fp),
     readFile(`${pp}/wiki/index.md`).catch(() => ""),
+    listDirectory(`${pp}/wiki`).catch(() => [] as FileNode[]),
   ])
 
   if (!content || !index) return
+
+  // The set of real page slugs, used to drop `target`s the LLM invented that
+  // don't resolve to any page (e.g. an English name for a Chinese-named page),
+  // which would otherwise be written as broken wikilinks (#535).
+  const validTargets = new Set<string>()
+  collectPageSlugs(tree, validTargets)
 
   // Ask the LLM to return a JSON list of {term, target} substitutions.
   // Much easier task than rewriting the whole page, and the model can't
@@ -93,7 +116,7 @@ export async function enrichWithWikilinks(
 
   // Apply substitutions to the ORIGINAL content. This guarantees the only
   // change is inserted [[...]] brackets.
-  const enriched = applyLinks(content, links)
+  const enriched = applyLinks(content, links, validTargets)
   if (enriched === content) return
 
   await writeFile(fp, enriched)
@@ -163,7 +186,7 @@ function parseLinkResponse(raw: string): LinkEntry[] {
  * already match case-insensitively. Skip terms that don't appear as a
  * literal substring. Skip terms already inside an existing wikilink.
  */
-function applyLinks(content: string, links: LinkEntry[]): string {
+function applyLinks(content: string, links: LinkEntry[], validTargets: Set<string>): string {
   // Split off YAML frontmatter so we don't touch it
   const fmEnd = content.startsWith("---\n") ? content.indexOf("\n---\n", 3) : -1
   const frontmatter = fmEnd > 0 ? content.slice(0, fmEnd + 5) : ""
@@ -175,6 +198,9 @@ function applyLinks(content: string, links: LinkEntry[]): string {
   for (const { term, target } of links) {
     if (linkedTargets.has(target.toLowerCase())) continue
     if (!term || !target) continue
+    // Drop invented targets that don't resolve to a real page (#535). When the
+    // page set is unknown (empty), keep prior behavior rather than drop all.
+    if (validTargets.size > 0 && !validTargets.has(targetSlug(target))) continue
 
     // Find first literal occurrence NOT already inside a [[...]] block
     const idx = findUnlinkedOccurrence(body, term)

--- a/src/test-helpers/scenarios/enrich-scenarios.ts
+++ b/src/test-helpers/scenarios/enrich-scenarios.ts
@@ -27,6 +27,8 @@ export const enrichScenarios: EnrichScenario[] = [
       "occurrence of each.",
     initialWiki: {
       "wiki/index.md": WIKI_INDEX_WITH_TRANSFORMER,
+      "wiki/transformer.md": "# Transformer\n\nThe Transformer architecture.\n",
+      "wiki/attention.md": "# Attention\n\nThe attention mechanism.\n",
       "wiki/survey.md":
         "# Deep Learning Survey\n\n" +
         "Modern NLP relies on Transformer architectures for most tasks. " +
@@ -61,6 +63,7 @@ export const enrichScenarios: EnrichScenario[] = [
       "LLM just returns the term→target list.",
     initialWiki: {
       "wiki/index.md": WIKI_INDEX_WITH_TRANSFORMER,
+      "wiki/encoder.md": "# Encoder\n\nThe encoder stack.\n",
       "wiki/attention.md":
         "---\n" +
         "title: Attention\n" +
@@ -117,6 +120,8 @@ export const enrichScenarios: EnrichScenario[] = [
       "Byte-accurate substitution through UTF-8.",
     initialWiki: {
       "wiki/index.md": "# 索引\n\n- [[注意力机制]]\n- [[transformer]]\n",
+      "wiki/注意力机制.md": "# 注意力机制\n\n注意力机制。\n",
+      "wiki/transformer.md": "# Transformer\n\nTransformer 架构。\n",
       "wiki/intro.md":
         "# 简介\n\n" +
         "注意力机制是 transformer 架构的核心组件之一。" +


### PR DESCRIPTION
## Why

`enrichWithWikilinks` asks the LLM for `{term, target}` substitutions (the LLM is told each `target` must be a page in the index), then `applyLinks` writes `[[target|term]]` **without verifying that `target` resolves to a real page**. When the LLM returns a name that doesn't match — e.g. an English `target` for a Chinese-named page — the result is a broken wikilink. #535 reports exactly this: generated pages have Chinese names but the inserted links use English names, so they don't resolve.

## What

Collect the basename slug of every wiki page (via `listDirectory`) and skip substitutions whose `target` doesn't resolve. When the page set can't be determined (empty/unreadable dir), prior behavior is kept rather than dropping every link.

Fixes #535

## Review notes

- **Match strategy:** targets are validated by basename slug (lowercased) — the way `[[links]]` resolve elsewhere (`resolveRelatedSlug` in `wiki-page-resolver.ts`). Titles aren't used for link resolution, so they aren't used here.
- **Empty-set guard:** validation only runs when at least one page slug is known, so a failed `listDirectory` can't silently drop every link.
- **Test fixtures:** three scenario fixtures (`adds-wikilinks`, `preserves-frontmatter`, `cjk-terms`) linked to targets with no corresponding page in their `initialWiki` — i.e. they encoded the old broken-link behavior. They're updated to include those pages so the targets resolve.

## Tests

Added a regression test in `enrich-wikilinks.test.ts`: a Chinese-named page whose LLM substitution targets an English name with no page — asserts the broken link is dropped while a target that resolves is still linked. Full unit suite: 1609 passed.

---

_Disclosure: produced by an AI agent (Claude Code) — root-cause analysis, fix, and regression test included; covered by the new test and the full suite passes; flagging for maintainer review. #535 had no reproduction details, so the scenario was inferred from the code path — glad to adjust if the intended case differs._
