### PR TITLE
fix(ingest): drop system wiki files from LLM-generated sources (#538)

### DIFF
--- a/src/lib/ingest-parse.test.ts
+++ b/src/lib/ingest-parse.test.ts
@@ -28,7 +28,9 @@ import {
   aggregatePathsNeedingRepair,
   filterAggregateRepairOutput,
   rewriteIngestPathFromTitleForTargetLanguage,
+  canonicalizeSourcesField,
 } from "./ingest"
+import { parseSources } from "./sources-merge"
 
 // ── Happy paths ─────────────────────────────────────────────────────
 
@@ -623,5 +625,42 @@ describe("rewriteIngestPathFromTitleForTargetLanguage", () => {
     expect(
       rewriteIngestPathFromTitleForTargetLanguage("wiki/index.md", content, "Chinese"),
     ).toBe("wiki/index.md")
+  })
+})
+
+describe("canonicalizeSourcesField — system files are not valid sources (#538)", () => {
+  it("drops wiki system files (log / index / overview) from the sources field", () => {
+    const content = [
+      "---",
+      "type: entity",
+      "title: Foo",
+      'sources: ["raw/sources/report.pdf", "wiki/log.md", "wiki/index.md", "wiki/overview.md"]',
+      "---",
+      "",
+      "# Foo",
+      "",
+    ].join("\n")
+
+    const sources = parseSources(canonicalizeSourcesField(content, "raw/sources/report.pdf"))
+
+    expect(sources).toContain("raw/sources/report.pdf")
+    expect(sources).not.toContain("wiki/log.md")
+    expect(sources).not.toContain("wiki/index.md")
+    expect(sources).not.toContain("wiki/overview.md")
+  })
+
+  it("drops nested log.md and keeps the real source identity", () => {
+    const content = [
+      "---",
+      "type: entity",
+      "title: Bar",
+      'sources: ["wiki/log.md", "notes/log.md"]',
+      "---",
+      "",
+    ].join("\n")
+
+    const sources = parseSources(canonicalizeSourcesField(content, "raw/sources/notes.md"))
+
+    expect(sources).toEqual(["raw/sources/notes.md"])
   })
 })

--- a/src/lib/ingest.ts
+++ b/src/lib/ingest.ts
@@ -1463,12 +1463,18 @@ function isAggregateRepairSafe(
   return true
 }
 
-function canonicalizeSourcesField(content: string, sourceIdentity: string): string {
+export function canonicalizeSourcesField(content: string, sourceIdentity: string): string {
   if (!/^---\n/.test(content)) return content
 
   const identityKey = normalizePath(sourceIdentity).toLowerCase()
   const identityBaseName = getFileName(sourceIdentity).toLowerCase()
-  const sourceValues = parseSources(content)
+  // Drop system-generated wiki files the LLM sometimes lists as sources
+  // (e.g. wiki/log.md, wiki/index.md, wiki/overview.md). They are never user
+  // materials, break source traceability, and can feed ingest loops (#538).
+  const sourceValues = parseSources(content).filter((source) => {
+    const normalized = normalizePath(source)
+    return !isLogPath(normalized) && !isListingPath(normalized)
+  })
   const canonicalValues = sourceValues.map((source) => {
     const normalized = normalizePath(source)
     const key = normalized.toLowerCase()


### PR DESCRIPTION
## Why

Some entity pages end up with system-generated wiki files in their `sources` frontmatter — e.g. `sources: ["wiki/log.md"]` — instead of the real material under `raw/sources/`. `wiki/log.md`, `wiki/index.md`, and `wiki/overview.md` are LLM Wiki's own generated files, not user materials, so listing them as sources:

- breaks source traceability (clicking the source jumps to the system log, not the original material), and
- risks feeding an ingest loop if the `wiki/` tree is ever scanned as material.

This is #538.

## What

`canonicalizeSourcesField` is the choke point that normalizes a page's `sources` field on write. It now drops system wiki files before canonicalizing and deduping, reusing the existing `isLogPath` / `isListingPath` predicates (which already recognize `log.md`, `index.md`, `overview.md` and their nested variants). Genuine materials and the source identity are untouched.

## Tests

Added two cases to `ingest-parse.test.ts` (`canonicalizeSourcesField — system files are not valid sources`): they fail on `main` (the system files survive) and pass with the fix. Full mock suite: **1610 passed**; `tsc` clean.

## Areas worth a careful look

- The filter is intentionally limited to files the codebase already treats as system-generated (`isLogPath` / `isListingPath`) rather than a broad "must live under `raw/sources/`" rule, to avoid dropping legitimate sources whose path layout varies across projects.
- `canonicalizeSourcesField` was made `export`ed only so it can be unit-tested directly (same pattern as the other exported helpers in `ingest.ts`).

---

🤖 *AI disclosure:* investigated, implemented, and tested with Claude Code (an AI coding agent). The regression is pinned by the new tests above; happy to adjust the scope of the filter if you'd prefer a stricter `raw/sources/` allowlist.

Fixes #538
