### PR TITLE
fix: scope title:/type: extraction to the frontmatter block, not the whole file

### DIFF
--- a/src/lib/__tests__/wiki-graph.test.ts
+++ b/src/lib/__tests__/wiki-graph.test.ts
@@ -1,0 +1,57 @@
+/**
+ * wiki-graph.test.ts — regression tests for frontmatter-scoped title/type extraction
+ *
+ * extractTitle/extractType previously searched for `title:`/`type:` anywhere in the
+ * whole file content, not just inside the `---...---` frontmatter block, because the
+ * lazy `[\s\S]*?` in their regexes was never required to stop at the closing `---`.
+ * A body line that merely starts with `title:` or `type:` (plain prose, not YAML)
+ * could be misread as the frontmatter value.
+ */
+import { describe, it, expect, vi } from "vitest"
+import type { FileNode } from "@/types/wiki"
+
+const mockListDirectory = vi.fn()
+const mockReadFile = vi.fn()
+
+vi.mock("@/commands/fs", () => ({
+  listDirectory: (...args: unknown[]) => mockListDirectory(...args),
+  readFile: (...args: unknown[]) => mockReadFile(...args),
+}))
+
+async function loadBuildWikiGraph() {
+  const mod = await import("../wiki-graph")
+  return mod.buildWikiGraph
+}
+
+function mdFile(name: string): FileNode {
+  return { name, path: `/project/wiki/${name}`, is_dir: false }
+}
+
+describe("buildWikiGraph frontmatter extraction", () => {
+  it("does not read a title: line from the document body as the frontmatter title", async () => {
+    const buildWikiGraph = await loadBuildWikiGraph()
+    mockListDirectory.mockResolvedValue([mdFile("page.md")])
+    mockReadFile.mockResolvedValue(
+      "---\ntype: entity\n---\n# Real Heading\n\nSome text.\ntitle: not-frontmatter-at-all\n",
+    )
+
+    const graph = await buildWikiGraph("/project")
+
+    expect(graph.nodes).toHaveLength(1)
+    expect(graph.nodes[0].label).toBe("Real Heading")
+  })
+
+  it("does not read a type: line from the document body as the frontmatter type", async () => {
+    const buildWikiGraph = await loadBuildWikiGraph()
+    mockListDirectory.mockResolvedValue([mdFile("page.md")])
+    mockReadFile.mockResolvedValue(
+      "---\ntitle: Real Page\n---\n# Real Page\n\nSome text.\ntype: query\nMore text.\n",
+    )
+
+    const graph = await buildWikiGraph("/project")
+
+    // A misread type of "query" would match HIDDEN_TYPES and silently drop the page.
+    expect(graph.nodes).toHaveLength(1)
+    expect(graph.nodes[0].type).toBe("other")
+  })
+})

--- a/src/lib/wiki-graph.ts
+++ b/src/lib/wiki-graph.ts
@@ -126,8 +126,14 @@ function flattenMdFiles(nodes: FileNode[]): FileNode[] {
   return files
 }
 
+function extractFrontmatterBlock(content: string): string {
+  const fmMatch = content.match(/^---\n([\s\S]*?)\n---/)
+  return fmMatch ? fmMatch[1] : ""
+}
+
 function extractTitle(content: string, fileName: string): string {
-  const frontmatterTitleMatch = content.match(/^---\n[\s\S]*?^title:\s*["']?(.+?)["']?\s*$/m)
+  const frontmatter = extractFrontmatterBlock(content)
+  const frontmatterTitleMatch = frontmatter.match(/^title:\s*["']?(.+?)["']?\s*$/m)
   if (frontmatterTitleMatch) return frontmatterTitleMatch[1].trim()
 
   const headingMatch = content.match(/^#\s+(.+)$/m)
@@ -137,7 +143,8 @@ function extractTitle(content: string, fileName: string): string {
 }
 
 function extractType(content: string): string {
-  const frontmatterTypeMatch = content.match(/^---\n[\s\S]*?^type:\s*["']?(.+?)["']?\s*$/m)
+  const frontmatter = extractFrontmatterBlock(content)
+  const frontmatterTypeMatch = frontmatter.match(/^type:\s*["']?(.+?)["']?\s*$/m)
   if (frontmatterTypeMatch) return frontmatterTypeMatch[1].trim().toLowerCase()
   return "other"
 }


### PR DESCRIPTION
## Problem

`extractTitle()`/`extractType()` in `src/lib/wiki-graph.ts` match `title:`/`type:` with:

```ts
content.match(/^---\n[\s\S]*?^title:\s*["']?(.+?)["']?\s*$/m)
```

This is anchored at the opening `---`, but the lazy `[\s\S]*?` is never required to stop at the closing `---`. A page whose frontmatter has no `title`/`type` — but whose body happens to contain a later line starting with `title:` or `type:` (plain prose, not YAML) — gets that body line misread as the frontmatter value.

The more severe case: a misread `type` of `"query"` matches `HIDDEN_TYPES`, silently dropping the entire page from the wiki graph.

`graph-relevance.ts`'s `extractFrontmatter()` already handles this correctly — it isolates the `---...---` block first (`/^---\n([\s\S]*?)\n---/`) before searching it for `title:`/`type:`.

## Fix

Extract the same isolated frontmatter block via a small shared helper, and search only within it for both functions.

## Testing

Added `src/lib/__tests__/wiki-graph.test.ts` with two regression tests (mocking `@/commands/fs`):
- A page with `type: entity` frontmatter (no `title`) and a body line `title: not-frontmatter-at-all` — confirms the label still falls back to the `# Real Heading`, not the body line.
- A page with `title: Real Page` frontmatter (no `type`) and a body line `type: query` — confirms the page isn't misclassified and dropped from the graph.

Both fail against the pre-fix code and pass after. Ran the full `npm run test:mocks` suite (1640 passed across 114 files — no regressions) and `npm run typecheck` (clean).

Disclosure: I used an AI coding assistant (Claude) to help identify this bug and draft the fix. I independently traced the misread-and-drop mechanism through `HIDDEN_TYPES`, wrote/verified the regression tests in both red and green states, and ran the full local test suite before opening this PR.