### PR TITLE
fix: use parseFrontmatter instead of an unbounded title: regex in 4 more places

### DIFF
--- a/src/lib/embedding.test.ts
+++ b/src/lib/embedding.test.ts
@@ -38,6 +38,7 @@ import {
   getEmbeddingCount,
   removePageEmbedding,
   resetEmbeddingOptimizeAccountingForTests,
+  extractEmbeddingTitle,
   type PageSearchResult,
 } from "./embedding"
 
@@ -1964,5 +1965,21 @@ describe("legacyVectorRowCount / dropLegacyVectorTable / getEmbeddingCount / rem
     mockInvoke.mockRejectedValueOnce(new Error("table missing"))
     // Must not throw — source-delete flow depends on silent failure.
     await expect(removePageEmbedding("/proj", "rope")).resolves.toBeUndefined()
+  })
+})
+
+describe("extractEmbeddingTitle", () => {
+  it("does not read a body prose line starting with title: as the frontmatter title", () => {
+    const content = "---\ntype: entity\n---\n# Real Heading\n\nSome text.\ntitle: not-frontmatter-at-all\n"
+    expect(extractEmbeddingTitle(content, "mypage")).toBe("mypage")
+  })
+
+  it("still uses a genuine frontmatter title", () => {
+    const content = "---\ntitle: Real Title\n---\n# Real Title\n"
+    expect(extractEmbeddingTitle(content, "mypage")).toBe("Real Title")
+  })
+
+  it("falls back to fallbackId when there is no frontmatter at all", () => {
+    expect(extractEmbeddingTitle("# Just a heading\n\nBody text.", "mypage")).toBe("mypage")
   })
 })

--- a/src/lib/embedding.ts
+++ b/src/lib/embedding.ts
@@ -27,6 +27,7 @@ import type { EmbeddingConfig } from "@/stores/wiki-store"
 import type { FileNode } from "@/types/wiki"
 import { normalizePath } from "@/lib/path-utils"
 import { chunkMarkdown, type Chunk } from "@/lib/text-chunker"
+import { parseFrontmatter } from "@/lib/frontmatter"
 
 // ── Error surfacing ──────────────────────────────────────────────────────
 
@@ -259,9 +260,10 @@ type PageEmbeddingPreparation =
   | { status: "empty" }
   | { status: "failed"; reason: string }
 
-function extractEmbeddingTitle(content: string, fallbackId: string): string {
-  const titleMatch = content.match(/^---\n[\s\S]*?^title:\s*["']?(.+?)["']?\s*$/m)
-  return titleMatch ? titleMatch[1].trim() : fallbackId
+/** @internal Exported for unit tests only. */
+export function extractEmbeddingTitle(content: string, fallbackId: string): string {
+  const title = parseFrontmatter(content).frontmatter?.title
+  return typeof title === "string" && title.trim() ? title.trim() : fallbackId
 }
 
 async function preparePageEmbeddingRows(

--- a/src/lib/ingest.ts
+++ b/src/lib/ingest.ts
@@ -1297,8 +1297,8 @@ async function autoIngestImpl(
         if (!pageId || ["index", "log", "overview"].includes(pageId)) continue
         try {
           const content = await readFile(`${pp}/${wpath}`)
-          const titleMatch = content.match(/^---\n[\s\S]*?^title:\s*["']?(.+?)["']?\s*$/m)
-          const title = titleMatch ? titleMatch[1].trim() : pageId
+          const fmTitle = parseFrontmatter(content).frontmatter?.title
+          const title = typeof fmTitle === "string" && fmTitle.trim() ? fmTitle.trim() : pageId
           await embedPage(pp, pageId, title, content, embCfg)
         } catch {
           // non-critical
@@ -3058,10 +3058,8 @@ async function reembedSourceSummary(
   const sourceSummaryFullPath = `${pp}/wiki/sources/${sourceSummarySlug}.md`
   try {
     const content = await readFile(sourceSummaryFullPath)
-    const titleMatch = content.match(
-      /^---\n[\s\S]*?^title:\s*["']?(.+?)["']?\s*$/m,
-    )
-    const title = titleMatch ? titleMatch[1].trim() : sourceIdentity
+    const fmTitle = parseFrontmatter(content).frontmatter?.title
+    const title = typeof fmTitle === "string" && fmTitle.trim() ? fmTitle.trim() : sourceIdentity
     const { embedPage } = await import("@/lib/embedding")
     await embedPage(pp, sourceSummarySlug, title, content, embCfg)
     console.log(`[ingest:caption] re-embedded ${sourceSummarySlug} with captioned alt text`)

--- a/src/lib/sweep-reviews-build-wiki-index.test.ts
+++ b/src/lib/sweep-reviews-build-wiki-index.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Regression test for buildWikiIndex's title extraction.
+ *
+ * buildWikiIndex previously matched `title:` with a regex anchored only at
+ * the opening `---`, never required to stop at the closing `---`. A page
+ * whose frontmatter has no title — but whose body happens to contain a
+ * later line starting with `title:` (plain prose, not YAML) — got that
+ * body line misread as the page's title and added to `byTitle`. Since
+ * `pageExists()` checks `byTitle` to decide whether a "missing page" review
+ * should auto-resolve, this could falsely mark a still-missing page as
+ * resolved.
+ */
+import { describe, it, expect, vi } from "vitest"
+import type { FileNode } from "@/types/wiki"
+
+const mockListDirectory = vi.fn()
+const mockReadFile = vi.fn()
+
+vi.mock("@/commands/fs", () => ({
+  listDirectory: (...args: unknown[]) => mockListDirectory(...args),
+  readFile: (...args: unknown[]) => mockReadFile(...args),
+}))
+
+async function loadBuildWikiIndex() {
+  const mod = await import("./sweep-reviews")
+  return mod.buildWikiIndex
+}
+
+function mdFile(name: string): FileNode {
+  return { name, path: `/project/wiki/${name}`, is_dir: false }
+}
+
+describe("buildWikiIndex", () => {
+  it("does not add a body prose line starting with title: to byTitle", async () => {
+    const buildWikiIndex = await loadBuildWikiIndex()
+    mockListDirectory.mockResolvedValue([mdFile("other.md")])
+    mockReadFile.mockResolvedValue(
+      "---\ntype: entity\n---\n# Real Heading\n\nSome text.\ntitle: Attention Mechanism\n",
+    )
+
+    const index = await buildWikiIndex("/project")
+
+    expect(index.byTitle.has("attention mechanism")).toBe(false)
+    expect(index.pages[0].title).toBeNull()
+  })
+
+  it("still indexes a genuine frontmatter title", async () => {
+    const buildWikiIndex = await loadBuildWikiIndex()
+    mockListDirectory.mockResolvedValue([mdFile("real.md")])
+    mockReadFile.mockResolvedValue("---\ntitle: Real Title\n---\n# Real Title\n")
+
+    const index = await buildWikiIndex("/project")
+
+    expect(index.byTitle.has("real title")).toBe(true)
+  })
+})

--- a/src/lib/sweep-reviews.ts
+++ b/src/lib/sweep-reviews.ts
@@ -19,6 +19,7 @@ import type { FileNode } from "@/types/wiki"
 import { normalizePath } from "@/lib/path-utils"
 import { normalizeReviewTitle } from "@/lib/review-utils"
 import { hasUsableLlm } from "@/lib/has-usable-llm"
+import { parseFrontmatter } from "@/lib/frontmatter"
 
 // ── Types ─────────────────────────────────────────────────────────────────
 
@@ -48,7 +49,7 @@ function flattenMdFiles(nodes: FileNode[]): FileNode[] {
 }
 
 /** Build an index of wiki pages: id (filename without .md) + title → normalized */
-async function buildWikiIndex(projectPath: string): Promise<WikiIndex> {
+export async function buildWikiIndex(projectPath: string): Promise<WikiIndex> {
   const pp = normalizePath(projectPath)
   const byId = new Set<string>()
   const byTitle = new Set<string>()
@@ -65,9 +66,9 @@ async function buildWikiIndex(projectPath: string): Promise<WikiIndex> {
       let title: string | null = null
       try {
         const content = await readFile(file.path)
-        const match = content.match(/^---\n[\s\S]*?^title:\s*["']?(.+?)["']?\s*$/m)
-        if (match) {
-          title = match[1].trim()
+        const fmTitle = parseFrontmatter(content).frontmatter?.title
+        if (typeof fmTitle === "string" && fmTitle.trim()) {
+          title = fmTitle.trim()
           byTitle.add(title.toLowerCase())
         }
       } catch {


### PR DESCRIPTION
## Follow-up to #577

While fixing the same bug pattern in `wiki-graph.ts` (#577), I found the identical unbounded regex reimplemented in 4 more places:

```ts
content.match(/^---\n[\s\S]*?^title:\s*["']?(.+?)["']?\s*$/m)
```

Anchored only at the opening `---`, with the lazy `[\s\S]*?` never required to stop at the closing `---`. A page whose frontmatter has no title — but whose body happens to contain a later line starting with `title:` (plain prose, not YAML) — gets that body line misread as the title.

The blast radius differs per site:
- **`embedding.ts`** (`extractEmbeddingTitle`): the bogus title gets prepended to every chunk's embedding text, silently corrupting the semantic vectors sent to the embedding model for that page.
- **`sweep-reviews.ts`** (`buildWikiIndex`): the bogus title is added to the wiki index's `byTitle` set, which `pageExists()` checks to decide whether a `missing-page` review should auto-resolve — a body line that happens to match a still-missing page's name can falsely mark that review as resolved, silently hiding a real gap from the user.
- **`ingest.ts`** (2 sites): the bogus title is passed to `embedPage()`, same corruption as the `embedding.ts` site.

## Fix

This codebase already has a correct, actively-used frontmatter parser — `src/lib/frontmatter.ts`'s `parseFrontmatter()`, built on `js-yaml`, already used in 10+ other files including **`ingest.ts` itself** at two other call sites. Rather than re-patch the regex 4 more times, I switched all 4 sites to use `parseFrontmatter()` instead.

Exported `extractEmbeddingTitle` and `buildWikiIndex` (previously module-private) so they're directly unit-testable, matching the existing `@internal — exported for tests only` pattern already used for `extractJsonObject` in `sweep-reviews.ts`.

## Testing

- Added regression tests for `extractEmbeddingTitle` (`embedding.test.ts`) and `buildWikiIndex` (new `sweep-reviews-build-wiki-index.test.ts`). Confirmed both fail against the pre-fix regex and pass with `parseFrontmatter`.
- Ran the full `npm run test:mocks` suite (1643 passed) and `npm run typecheck` (clean).

Disclosure: I used an AI coding assistant (Claude) to help identify this bug pattern and draft the fix. I independently confirmed `parseFrontmatter` was already the established convention elsewhere in the codebase (including inside `ingest.ts` itself) before choosing to switch these sites to it rather than just patching the regex in place, verified each site's exact blast radius, and ran the full local test suite plus typecheck before opening this PR.