### PR TITLE
fix: strip code fences around generated frontmatter

### DIFF
--- a/src/lib/ingest-sanitize.test.ts
+++ b/src/lib/ingest-sanitize.test.ts
@@ -30,6 +30,11 @@ describe("sanitizeIngestedFileContent", () => {
     expect(sanitizeIngestedFileContent(input)).toBe("---\ntype: x\n---\nbody")
   })
 
+  it("strips a ```yaml fence wrapping only the frontmatter", () => {
+    const input = "```yaml\n---\ntype: x\n---\n```\n\n# Body"
+    expect(sanitizeIngestedFileContent(input)).toBe("---\ntype: x\n---\n\n# Body")
+  })
+
   it("does NOT strip a non-fence-wrapped document containing a fenced code block in the body", () => {
     const input =
       "---\ntype: x\n---\n\n# Heading\n\n```js\nconsole.log('hi')\n```\n\nmore body"

--- a/src/lib/ingest-sanitize.ts
+++ b/src/lib/ingest-sanitize.ts
@@ -58,12 +58,14 @@
 export function sanitizeIngestedFileContent(content: string): string {
   let cleaned = content
 
-  // (1) Strip an outer code fence wrapping the whole document.
+  // (1) Strip a code fence wrapping the whole document or just its
+  // frontmatter block.
   // We only act when the FIRST non-empty line is an opening fence
   // (`\`\`\`yaml`, `\`\`\`md`, `\`\`\`markdown`, or just `\`\`\``)
-  // AND the LAST non-empty line is a matching closing fence. This
-  // avoids touching pages that legitimately end with an unclosed
-  // fence (we don't try to "fix" mid-stream truncation here).
+  // with a matching close either at the end of the document or directly
+  // after a complete frontmatter block. This avoids touching pages that
+  // legitimately start with an unclosed fence (we don't try to "fix"
+  // mid-stream truncation here).
   cleaned = stripOuterCodeFence(cleaned)
 
   // (2) Strip a stray `frontmatter:` line that prefixes the real
@@ -86,7 +88,7 @@ export function sanitizeIngestedFileContent(content: string): string {
   return cleaned
 }
 
-/** Top-level fence wrapper. Removes the open + close fence lines. */
+/** Top-level fence wrapper. Removes the open + matching close fence lines. */
 function stripOuterCodeFence(content: string): string {
   const open = content.match(/^[ \t]*```(?:yaml|md|markdown)?[ \t]*\r?\n/)
   if (!open) return content
@@ -95,8 +97,16 @@ function stripOuterCodeFence(content: string): string {
   // Closing fence: a final ``` on its own line, ignoring trailing
   // whitespace/newlines after it.
   const close = afterOpen.match(/\r?\n[ \t]*```[ \t]*\r?\n?\s*$/)
-  if (!close) return content
-  return afterOpen.slice(0, close.index)
+  if (close) return afterOpen.slice(0, close.index)
+
+  // Some models close the fence immediately after the frontmatter and
+  // continue with an unfenced Markdown body. Only strip this shape when
+  // the fenced section is exactly a complete `---` frontmatter block.
+  const frontmatterOnly = afterOpen.match(
+    /^(---[ \t]*\r?\n[\s\S]*?\r?\n---[ \t]*\r?\n)[ \t]*```[ \t]*(?:\r?\n|$)/,
+  )
+  if (!frontmatterOnly) return content
+  return frontmatterOnly[1] + afterOpen.slice(frontmatterOnly[0].length)
 }
 
 /**


### PR DESCRIPTION
## Why

LLM-generated pages can put only the YAML frontmatter inside a `yaml` code fence while leaving the Markdown body outside. The existing sanitizer handles whole-document wrappers, but this variant reaches disk with both fence lines intact, so frontmatter readers no longer see `---` at the start of the file.

## What

Extend the existing write-boundary sanitizer to remove a top-level fence when its fenced section is exactly one complete frontmatter block. Other leading or unclosed fences remain untouched.

Fixes #575

## Tests

- Added a regression fixture for the frontmatter-only wrapper (fails before the fix, passes after)
- `npx vitest run src/lib/ingest-sanitize.test.ts` (16 passed)
- `npm run test:mocks` (115 files, 1660 tests passed)
- `npm run typecheck`
- `npm run build`

---

Disclosure: this focused change was produced with AI assistance and validated with the regression test, full mock suite, typecheck, and production build.