### PR TITLE
fix: compare Windows scheduled-import paths case-insensitively

### DIFF
--- a/src/lib/scheduled-import.test.ts
+++ b/src/lib/scheduled-import.test.ts
@@ -116,6 +116,27 @@ describe("scheduled import path handling", () => {
     ).toBe(false)
   })
 
+  it("detects Windows project paths case-insensitively", () => {
+    expect(
+      isProjectManagedScheduledImportPath(
+        "C:/Users/Me/Wiki",
+        "c:\\users\\me\\wiki\\raw\\sources",
+      ),
+    ).toBe(true)
+    expect(
+      isProjectManagedScheduledImportPath(
+        "//Server/Share/Wiki",
+        "//server/share/wiki/raw/sources",
+      ),
+    ).toBe(true)
+    expect(
+      isProjectManagedScheduledImportPath(
+        "/Users/Me/Wiki",
+        "/users/me/wiki/raw/sources",
+      ),
+    ).toBe(false)
+  })
+
   it("sanitizes Windows-unsafe destination path segments with a stable suffix", () => {
     const dest = scheduledImportDestinationForFile(
       projectPath,

--- a/src/lib/scheduled-import.ts
+++ b/src/lib/scheduled-import.ts
@@ -105,8 +105,8 @@ function cloneDb(db: ImportDb): ImportDb {
 }
 
 function isPathInside(path: string, parent: string): boolean {
-  const normalizedPath = normalizePath(path)
-  const normalizedParent = normalizePath(parent).replace(/\/+$/, "")
+  const normalizedPath = dbDirectoryKey(path)
+  const normalizedParent = dbDirectoryKey(parent).replace(/\/+$/, "")
   return (
     normalizedPath === normalizedParent ||
     normalizedPath.startsWith(`${normalizedParent}/`)


### PR DESCRIPTION
## Why

The scheduled-import self-import guard compares normalized paths case-sensitively. On Windows, the same project can therefore appear unrelated when a drive-letter or UNC path uses different casing, allowing a project-managed directory to be selected as an external scheduled-import root.

## What

Reuse the existing scheduled-import database path key for both sides of containment checks. That key case-folds drive-letter and UNC paths while leaving POSIX paths case-sensitive.

## Tests

- Added regression coverage for drive-letter paths, UNC paths, and POSIX case sensitivity
- Parent commit repro: 1 failed / 12 passed (`false`, expected `true`)
- `npm run test:mocks -- src/lib/scheduled-import.test.ts` (13 passed)
- `npm run test:mocks` (115 files, 1676 tests passed)
- `npm run typecheck`
- `npm run build`

---

Disclosure: this focused change was produced with AI assistance and validated with the regression test, full mock suite, typecheck, and production build.