### PR TITLE
fix: preserve nested scheduled-import paths on case-insensitive Windows roots

### DIFF
--- a/src/lib/scheduled-import.test.ts
+++ b/src/lib/scheduled-import.test.ts
@@ -81,6 +81,21 @@ describe("scheduled import path handling", () => {
     )
   })
 
+  it("preserves nested relative paths when the import root differs only in case (Windows)", () => {
+    const dest = scheduledImportDestinationForFile(
+      "C:/Users/Me/Wiki",
+      "C:/Users/Me/Inbox",
+      {
+        name: "report.pdf",
+        path: "c:/users/me/inbox/sub/report.pdf",
+      },
+    )
+
+    expect(dest).toBe(
+      "C:/Users/Me/Wiki/raw/sources/scheduled-import/sub/report.pdf",
+    )
+  })
+
   it("does not copy files that are already under raw/sources", () => {
     const dest = scheduledImportDestinationForFile(
       projectPath,

--- a/src/lib/scheduled-import.ts
+++ b/src/lib/scheduled-import.ts
@@ -91,7 +91,12 @@ function dbFilePath(projectPath: string): string {
 }
 
 function dbDirectoryKey(importPath: string): string {
-  const normalized = normalizePath(importPath)
+  return caseFoldPath(normalizePath(importPath))
+}
+
+// Windows drive-letter and UNC paths are case-insensitive; fold them for
+// comparison purposes only (never for the paths actually written to disk).
+function caseFoldPath(normalized: string): string {
   return /^[A-Za-z]:\//.test(normalized) || normalized.startsWith("//")
     ? normalized.toLowerCase()
     : normalized
@@ -256,8 +261,10 @@ export function scheduledImportDestinationForFile(
   }
 
   const importRoot = normalizePath(importPath).replace(/\/+$/, "")
+  const sourceKey = caseFoldPath(source)
+  const importRootKey = caseFoldPath(importRoot)
   const relative =
-    source === importRoot || !source.startsWith(`${importRoot}/`)
+    sourceKey === importRootKey || !sourceKey.startsWith(`${importRootKey}/`)
       ? file.name
       : source.slice(importRoot.length + 1)
 


### PR DESCRIPTION
## Why

`scheduledImportDestinationForFile()`'s containment check compares `source === importRoot` / `source.startsWith(importRoot + "/")` case-sensitively, but Windows drive-letter and UNC paths are case-insensitive. When a source file's casing differs from the configured import root (e.g. root `C:/Users/Me/Inbox`, source `c:/users/me/inbox/sub/report.pdf`), the containment check fails and the file falls back to `file.name` only — silently flattening its nested directory structure and risking same-name collisions from different folders.

## What

Reuse the existing drive-letter/UNC case-folding logic already used by `dbDirectoryKey` (extracted into a shared `caseFoldPath` helper) for the containment comparison only. The returned destination path still uses the source file's original casing.

Note: distinct from #582 (also open, same file) — that fixes `isPathInside()`'s self-import-guard case sensitivity; this fixes `scheduledImportDestinationForFile()`'s relative-path calculation for external import roots. No functional overlap between the two.

## Tests

- New test: nested path preserved when import root differs only in case (Windows drive-letter). Red before fix (flattened to `file.name`), green after.
- `npm run test:mocks -- src/lib/scheduled-import.test.ts` (13 passed)
- `npm run test:mocks` (115 files, 1679 tests passed)
- `npm run typecheck`

---

Disclosure: this focused change was produced with AI assistance and validated with the regression test, full mock suite, and typecheck.