### PR TITLE
fix: getRelativePath must compare Windows drive-letter/UNC paths case-insensitively

### DIFF
--- a/src/lib/path-utils.test.ts
+++ b/src/lib/path-utils.test.ts
@@ -116,6 +116,20 @@ describe("getRelativePath", () => {
     // The impl adds '/' to base for matching, so this is handled.
     expect(getRelativePath("/projector/a", "/project")).toBe("/projector/a")
   })
+
+  it("matches Windows drive-letter paths case-insensitively", () => {
+    expect(getRelativePath("c:/users/me/inbox/sub/report.pdf", "C:/Users/Me/Inbox")).toBe(
+      "sub/report.pdf",
+    )
+  })
+
+  it("matches Windows UNC paths case-insensitively", () => {
+    expect(getRelativePath("//server/SHARE/sub/file.md", "//SERVER/share")).toBe("sub/file.md")
+  })
+
+  it("keeps Unix paths case-sensitive", () => {
+    expect(getRelativePath("/Project/wiki/note.md", "/project")).toBe("/Project/wiki/note.md")
+  })
 })
 
 describe("isAbsolutePath", () => {

--- a/src/lib/path-utils.ts
+++ b/src/lib/path-utils.ts
@@ -33,13 +33,23 @@ export function getFileStem(p: string): string {
   return lastDot > 0 ? name.slice(0, lastDot) : name
 }
 
+// Windows drive-letter and UNC paths are case-insensitive; fold them for
+// comparison purposes only (never for the paths actually returned/written).
+function caseFoldPath(normalized: string): string {
+  return /^[A-Za-z]:\//.test(normalized) || normalized.startsWith("//")
+    ? normalized.toLowerCase()
+    : normalized
+}
+
 /**
  * Get relative path from base.
  */
 export function getRelativePath(fullPath: string, basePath: string): string {
   const normalFull = normalizePath(fullPath)
   const normalBase = normalizePath(basePath).replace(/\/$/, "")
-  if (normalFull.startsWith(normalBase + "/")) {
+  const fullKey = caseFoldPath(normalFull)
+  const baseKey = caseFoldPath(normalBase)
+  if (fullKey.startsWith(baseKey + "/")) {
     return normalFull.slice(normalBase.length + 1)
   }
   return normalFull


### PR DESCRIPTION
### Problem

`getRelativePath()` (`src/lib/path-utils.ts`) strips a base-path prefix with
a case-sensitive `startsWith`:

```ts
export function getRelativePath(fullPath: string, basePath: string): string {
  const normalFull = normalizePath(fullPath)
  const normalBase = normalizePath(basePath).replace(/\/$/, "")
  if (normalFull.startsWith(normalBase + "/")) {
    return normalFull.slice(normalBase.length + 1)
  }
  return normalFull
}
```

Windows drive-letter and UNC paths are case-insensitive at the filesystem
level, but this comparison isn't. When a recursively-enumerated file's path
casing differs from the caller's base path (e.g. a folder-picker dialog
returns `"C:/Users/Me/Inbox"` but a filesystem walk yields
`"c:/users/me/inbox/sub/report.pdf"` for a file under it), the prefix check
fails and the function falls back to returning the **entire absolute path**
instead of a relative one.

The real call site, `importSourceFolder()` in `source-lifecycle.ts:322`,
joins that "relative" path onto a destination directory:

```ts
const relativeSourcePath = getRelativePath(file.path, sourceRoot)
const destPath = `${destDir}/${relativeSourcePath}`
const relPath = `raw/sources/${folderName}/${relativeSourcePath}`
```

With the casing mismatch, `destPath` becomes a malformed path with an
embedded drive letter (e.g.
`C:/project/raw/sources/Inbox/c:/users/me/inbox/sub/report.pdf`), and the
same corrupted value feeds `isPathAllowedBySourceWatch`, silently defeating
the source-watch filter for every file under a casing-mismatched root.

This is the same bug class already fixed for scheduled imports in
`a03c502` ("fix: preserve nested scheduled-import paths on
case-insensitive Windows roots"), which added a `caseFoldPath` helper to
`scheduled-import.ts`'s own containment check. `getRelativePath` is a
separate, more general helper (also used by `lint.ts`) that never got the
same treatment.

### Fix

Fold Windows drive-letter/UNC paths to lowercase for the comparison only
(mirroring `scheduled-import.ts`'s existing `caseFoldPath` pattern) — the
returned path keeps its original casing. Unix paths are unaffected and
remain case-sensitive.

### Testing

Added to `src/lib/path-utils.test.ts`:
- drive-letter casing mismatch (`c:/...` vs `C:/...`)
- UNC path casing mismatch (`//server/SHARE` vs `//SERVER/share`)
- companion test confirming Unix paths stay case-sensitive

Confirmed red against unfixed code (both new casing tests failed, returning
the full absolute path instead of the relative suffix), green after the fix,
with all pre-existing `getRelativePath` tests (including the Unix
case-sensitivity path) still passing.

Ran `source-lifecycle.test.ts` + `lint.test.ts` (the two callers of
`getRelativePath`): 28 passed. Full `npm run test:mocks`: 115 files / 1681
tests passed, no regressions. `npm run typecheck`: clean.

### Duplicate-work check

No open PR touches `path-utils.ts`; searched PR titles/bodies for
`getRelativePath` — no hits.

---

*Disclosure: I used AI assistance (Claude) to find this bug and draft the
fix and tests. I independently traced the real call site, reproduced the
casing-mismatch failure against unfixed code, verified the fix red→green,
and ran the full local test suite + typecheck before submitting.*