### PR TITLE
fix(agent): neutralize `:` in cancellation registry keys to prevent delimiter collision

### DIFF
--- a/src-tauri/src/agent/cancel.rs
+++ b/src-tauri/src/agent/cancel.rs
@@ -114,7 +114,10 @@ fn cancel_key(project_id: &str, session_id: &str, run_id: &str) -> String {
 }
 
 fn normalize_key(value: &str) -> String {
-    value.replace(['\\', '/'], "_")
+    // `:` must be neutralized too, not just path separators: cancel_key joins
+    // fields with `::`, so an unescaped `:` in one field can shift the split and
+    // collide with a different (session_id, run_id) pair's key.
+    value.replace(['\\', '/', ':'], "_")
 }
 
 #[cfg(test)]
@@ -149,6 +152,18 @@ mod tests {
         registry.finish("p2", "same", "r1");
         assert!(registry.cancel("p2", "same", Some("r2")));
         assert!(r2.is_cancelled());
+    }
+
+    #[test]
+    fn cancellation_registry_does_not_collide_on_embedded_delimiter() {
+        let registry = AgentCancellationRegistry::default();
+        // (session "a::b", run "c") and (session "a", run "b::c") must not
+        // collapse to the same key just because "::" is also the field delimiter.
+        let target = registry.start("p1", "a::b", "c");
+        let unrelated = registry.start("p1", "a", "b::c");
+        assert!(registry.cancel("p1", "a::b", Some("c")));
+        assert!(target.is_cancelled());
+        assert!(!unrelated.is_cancelled());
     }
 
     #[test]


### PR DESCRIPTION
### Problem

`cancel_key(project_id, session_id, run_id)` joins the three fields with a
literal `"::"` delimiter, but `normalize_key()` only neutralized path
separators (`\` and `/`), not `:`:

```rust
fn normalize_key(value: &str) -> String {
    value.replace(['\\', '/'], "_")
}
```

`session_id` / `run_id` are unrestricted `Option<String>` fields (no charset
validation, unlike `agent/session.rs`'s `sanitize_session_id`) and are
reachable from the local HTTP API's `POST /projects/:id/chat` body and the
`agent_chat` / `agent_start_turn_stream` Tauri commands. When a field contains
the substring `"::"`, two distinct `(session_id, run_id)` pairs collapse onto
the same registry key — e.g. `(session_id="a::b", run_id="c")` and
`(session_id="a", run_id="b::c")` both key to `"p1::a::b::c"` — so cancelling
one turn cross-cancels an unrelated turn's cancellation token. The no-`run_id`
prefix-search path in `cancel()` has the same exposure.

### Fix

Extend `normalize_key` to also replace `:` → `_`, matching its existing
`\` / `/` → `_` pattern, so the `::` delimiter can no longer appear inside a
field value.

### Test

Added `cancellation_registry_does_not_collide_on_embedded_delimiter` to the
existing `#[cfg(test)] mod tests`, asserting the two colliding pairs above stay
independent.
