### PR TITLE
fix: getFileCategory must strip the directory before matching basename entries

### DIFF
--- a/src/lib/file-types.test.ts
+++ b/src/lib/file-types.test.ts
@@ -33,4 +33,11 @@ describe("file types", () => {
     expect(getFileCategory("C:\\project\\diagram.MERMAID")).toBe("code")
     expect(getCodeLanguage("/project/diagram.mmd")).toBe("mermaid")
   })
+
+  it("classifies extensionless basenames (Dockerfile/Makefile) under a directory as code", () => {
+    // Bare names already worked; path-prefixed ones regressed to "unknown" (binary).
+    expect(getFileCategory("Dockerfile")).toBe("code")
+    expect(getFileCategory("/project/Dockerfile")).toBe("code")
+    expect(getFileCategory("C:\\project\\Makefile")).toBe("code")
+  })
 })

--- a/src/lib/file-types.ts
+++ b/src/lib/file-types.ts
@@ -129,7 +129,10 @@ const EXT_MAP: Record<string, FileCategory> = {
 }
 
 export function getFileCategory(filePath: string): FileCategory {
-  const ext = filePath.split(".").pop()?.toLowerCase() ?? ""
+  // Strip the directory first (like getFileExtension) so basename entries such as
+  // "dockerfile"/"makefile" resolve; fall back to the basename when there's no dot.
+  const fileName = filePath.split(/[\\/]/).pop() ?? ""
+  const ext = fileName.includes(".") ? fileName.split(".").pop()?.toLowerCase() ?? "" : fileName.toLowerCase()
   return EXT_MAP[ext] ?? "unknown"
 }
 


### PR DESCRIPTION
### Problem

`getFileCategory` extracts the extension with `filePath.split(".").pop()` on the **full path**:

```ts
export function getFileCategory(filePath: string): FileCategory {
  const ext = filePath.split(".").pop()?.toLowerCase() ?? ""
  return EXT_MAP[ext] ?? "unknown"
}
```

`EXT_MAP` has two extensionless basename entries — `dockerfile: "code"` and `makefile: "code"` — but a path-prefixed file with no `.` returns the whole path as the "extension", so they never match. Every caller passes a full path (`preview.path`, `selectedFile`, …):

```
getFileCategory("Dockerfile")            -> "code"     (bare name works)
getFileCategory("/project/Dockerfile")   -> "unknown"  (bug)
getFileCategory("/a/b/Makefile")         -> "unknown"  (bug)
```

`unknown` is in `isBinary()`'s list, so a Dockerfile/Makefile is treated as a non-previewable **binary** instead of previewable **code**.

### Fix

Mirror the sibling `getFileExtension()` (which already strips the directory first), then fall back to the basename itself when it has no dot, so the two basename entries resolve.

### Test

Added a case to `file-types.test.ts` covering bare and path-prefixed `Dockerfile`/`Makefile`; it fails before the fix and passes after. Existing tests unchanged.

Prepared with AI assistance and reviewed before submission.