### PR TITLE
fix: recover truncated ingest output and cap clip retries

### DIFF
--- a/src-tauri/src/clip_server.rs
+++ b/src-tauri/src/clip_server.rs
@@ -20,6 +20,15 @@ const MAX_RESTART_RETRIES: u32 = 10;
 const BIND_RETRY_DELAY_SECS: u64 = 2;
 const RESTART_DELAY_SECS: u64 = 5;
 
+const fn next_restart_count(current: u32) -> Option<u32> {
+    let next = current.saturating_add(1);
+    if next >= MAX_RESTART_RETRIES {
+        None
+    } else {
+        Some(next)
+    }
+}
+
 /// Get current daemon status as a string
 pub fn get_daemon_status() -> &'static str {
     match DAEMON_STATUS.load(Ordering::Relaxed) {
@@ -89,7 +98,6 @@ pub fn start_clip_server(app: AppHandle) {
             };
 
             DAEMON_STATUS.store(1, Ordering::Relaxed); // running
-            restart_count = 0; // Reset on successful bind
             println!("[Clip Server] Listening on http://{}", addr);
 
             for mut request in server.incoming_requests() {
@@ -293,15 +301,16 @@ pub fn start_clip_server(app: AppHandle) {
 
             // Server loop exited (shouldn't happen normally)
             DAEMON_STATUS.store(3, Ordering::Relaxed); // error
-            restart_count += 1;
-
-            if restart_count >= MAX_RESTART_RETRIES {
-                eprintln!(
-                    "[Clip Server] Exceeded max restarts ({}). Giving up.",
-                    MAX_RESTART_RETRIES
-                );
-                return;
-            }
+            restart_count = match next_restart_count(restart_count) {
+                Some(next) => next,
+                None => {
+                    eprintln!(
+                        "[Clip Server] Exceeded max restarts ({}). Giving up.",
+                        MAX_RESTART_RETRIES
+                    );
+                    return;
+                }
+            };
 
             eprintln!(
                 "[Clip Server] Crashed. Restarting in {}s (attempt {}/{})",
@@ -342,7 +351,7 @@ fn request_is_authorized(app: &AppHandle, request: &tiny_http::Request) -> bool 
 
 #[cfg(test)]
 mod lan_auth_tests {
-    use super::address_is_loopback;
+    use super::{address_is_loopback, next_restart_count, MAX_RESTART_RETRIES};
     use std::net::SocketAddr;
 
     #[test]
@@ -354,6 +363,16 @@ mod lan_auth_tests {
         assert!(address_is_loopback(Some(&ipv6)));
         assert!(!address_is_loopback(Some(&lan)));
         assert!(!address_is_loopback(None));
+    }
+
+    #[test]
+    fn restart_counter_stops_at_the_configured_limit() {
+        let mut count = 0;
+        for expected in 1..MAX_RESTART_RETRIES {
+            count = next_restart_count(count).unwrap();
+            assert_eq!(count, expected);
+        }
+        assert_eq!(next_restart_count(count), None);
     }
 }
 

--- a/src/lib/ingest-parse.test.ts
+++ b/src/lib/ingest-parse.test.ts
@@ -170,7 +170,7 @@ describe("parseFileBlocks — H2: truncated streams (surface, don't hide)", () =
       "---FILE: wiki/concepts/moe.md---",
       "# Mixture of Exp", // stream cut here
     ].join("\n")
-    const { blocks, warnings } = parseFileBlocks(text)
+    const { blocks, warnings, truncatedPaths } = parseFileBlocks(text)
     // Completed block makes it through.
     expect(blocks).toHaveLength(1)
     expect(blocks[0].path).toBe("wiki/entities/qwen.md")
@@ -178,6 +178,7 @@ describe("parseFileBlocks — H2: truncated streams (surface, don't hide)", () =
     expect(warnings).toHaveLength(1)
     expect(warnings[0]).toMatch(/wiki\/concepts\/moe\.md/)
     expect(warnings[0]).toMatch(/not closed/i)
+    expect(truncatedPaths).toEqual(["wiki/concepts/moe.md"])
   })
 
   it("warns when the only block is unclosed", () => {

--- a/src/lib/ingest-source-path-collision.test.ts
+++ b/src/lib/ingest-source-path-collision.test.ts
@@ -15,6 +15,7 @@ let sourceMarkers: string[] = []
 let failLongChunksOnce = new Set<number>()
 let extraReviewResponse = ""
 let generationSuffix = ""
+let truncatedRepairResponse = ""
 let abortDuringReview: AbortController | null = null
 let interactiveGenerationOverride = ""
 let mergeRequestCount = 0
@@ -87,6 +88,12 @@ vi.mock("./llm-client", () => ({
       return
     }
 
+    if (systemPrompt.startsWith("You are repairing truncated wiki FILE blocks")) {
+      cb.onToken(truncatedRepairResponse)
+      cb.onDone()
+      return
+    }
+
     const targetMatch = systemPrompt.match(
       /source summary page at \*\*(wiki\/sources\/[^*]+)\*\*/,
     )
@@ -142,6 +149,7 @@ describe("autoIngest source summary paths", () => {
     failLongChunksOnce = new Set()
     extraReviewResponse = ""
     generationSuffix = ""
+    truncatedRepairResponse = ""
     abortDuringReview = null
     interactiveGenerationOverride = ""
     mergeRequestCount = 0
@@ -623,6 +631,63 @@ describe("autoIngest source summary paths", () => {
       title: "Real Follow-up",
     })
     expect(reviews[0].description).not.toContain("Truncated Orphan")
+  })
+
+  it("retries a truncated FILE block with a targeted generation request", async () => {
+    if (!tmp) throw new Error("missing temp project")
+    sourceMarkers = ["project-a config"]
+    generationSuffix = [
+      "",
+      "---FILE: wiki/concepts/recovered.md---",
+      "---",
+      'title: "Recovered concept"',
+      'sources: ["project-a/config.yaml"]',
+      "---",
+      "",
+      "# Recovered concept",
+      "",
+      "This response was cut off",
+    ].join("\n")
+    truncatedRepairResponse = [
+      "---FILE: wiki/concepts/recovered.md---",
+      "---",
+      'title: "Recovered concept"',
+      'sources: ["project-a/config.yaml"]',
+      "---",
+      "",
+      "# Recovered concept",
+      "",
+      "This block was regenerated completely.",
+      "---END FILE---",
+      "",
+      "---FILE: wiki/concepts/stray.md---",
+      "# Stray concept",
+      "---END FILE---",
+    ].join("\n")
+
+    const written = await autoIngest(
+      tmp.path,
+      `${tmp.path}/raw/sources/project-a/config.yaml`,
+      useWikiStore.getState().llmConfig,
+      undefined,
+      "project-a",
+    )
+
+    expect(written).toContain("wiki/concepts/recovered.md")
+    await expect(
+      fs.readFile(`${tmp.path}/wiki/concepts/recovered.md`, "utf8"),
+    ).resolves.toContain("This block was regenerated completely.")
+    expect(written).not.toContain("wiki/concepts/stray.md")
+    await expect(
+      fs.readFile(`${tmp.path}/wiki/concepts/stray.md`, "utf8"),
+    ).rejects.toThrow()
+    expect(
+      mockStreamChat.mock.calls.some(([, messages]) =>
+        String(messages[0]?.content ?? "").startsWith(
+          "You are repairing truncated wiki FILE blocks",
+        ),
+      ),
+    ).toBe(true)
   })
 
   it("propagates cancellation that happens during the dedicated review stage", async () => {

--- a/src/lib/ingest.ts
+++ b/src/lib/ingest.ts
@@ -350,6 +350,7 @@ export interface ParseFileBlocksResult {
    *  one is also console.warn'd. UI can surface these so users see that
    *  something was skipped instead of silently getting fewer pages. */
   warnings: string[]
+  truncatedPaths: string[]
 }
 
 // Line-level openers / closers. Both are case-insensitive, tolerant of
@@ -460,6 +461,7 @@ export function parseFileBlocks(text: string): ParseFileBlocksResult {
 
   const blocks: ParsedFileBlock[] = []
   const warnings: string[] = []
+  const truncatedPaths: string[] = []
 
   let i = 0
   while (i < lines.length) {
@@ -520,6 +522,7 @@ export function parseFileBlocks(text: string): ParseFileBlocksResult {
       const msg = `FILE block "${pathLabel}" was not closed before end of stream — likely truncation (model hit max_tokens, timeout, or connection dropped). Block dropped.`
       console.warn(`[ingest] ${msg}`)
       warnings.push(msg)
+      if (isSafeIngestPath(path)) truncatedPaths.push(path)
       continue
     }
 
@@ -543,7 +546,7 @@ export function parseFileBlocks(text: string): ParseFileBlocksResult {
     blocks.push({ path, content: contentLines.join("\n") })
   }
 
-  return { blocks, warnings }
+  return { blocks, warnings, truncatedPaths }
 }
 
 /**
@@ -1122,6 +1125,99 @@ async function autoIngestImpl(
   const writtenPaths = writeResult.writtenPaths
   const writeWarnings = writeResult.warnings
   const hardFailures = writeResult.hardFailures
+  let unrecoveredTruncatedPaths = writeResult.truncatedPaths.filter((path) =>
+    !writtenPaths.some((writtenPath) => normalizePath(writtenPath) === normalizePath(path))
+  )
+
+  if (unrecoveredTruncatedPaths.length > 0 && !signal?.aborted) {
+    activity.updateItem(activityId, {
+      detail: `Retrying truncated wiki files: ${unrecoveredTruncatedPaths.join(", ")}`,
+    })
+    let repairOutput = ""
+    let repairFailed = false
+    try {
+      await streamChat(
+        llmConfig,
+        [
+          {
+            role: "system",
+            content: buildTruncatedFileRepairPrompt(
+              unrecoveredTruncatedPaths,
+              sourceIdentity,
+              {
+                schema,
+                purpose,
+                analysis,
+                sourceContext,
+                maxContextSize: llmConfig.maxContextSize,
+              },
+            ),
+          },
+          {
+            role: "user",
+            content: "Regenerate the requested FILE blocks now. Start immediately with `---FILE:`.",
+          },
+        ],
+        {
+          onToken: (token) => { repairOutput += token },
+          onDone: () => {},
+          onError: (err) => {
+            repairFailed = true
+            writeWarnings.push(`Truncated FILE repair failed: ${err.message}`)
+          },
+        },
+        signal,
+        {
+          temperature: 0.1,
+          reasoning: { mode: "off" },
+          max_tokens: computeIngestReviewMaxTokens(llmConfig.maxContextSize),
+        },
+      )
+      throwIfIngestAborted(signal, activityId)
+
+      if (!repairFailed && repairOutput.trim()) {
+        const filteredRepair = filterTruncatedFileRepairOutput(
+          repairOutput,
+          unrecoveredTruncatedPaths,
+        )
+        writeWarnings.push(...filteredRepair.warnings)
+        const repairResult = await writeFileBlocks(
+          pp,
+          filteredRepair.text,
+          llmConfig,
+          sourceIdentity,
+          sourceSummaryPath,
+          signal,
+          activityId,
+          onFileWritten,
+        )
+        const recoveredPaths = repairResult.writtenPaths.length === filteredRepair.paths.length
+          ? filteredRepair.paths
+          : []
+        for (const path of repairResult.writtenPaths) {
+          if (!writtenPaths.some((writtenPath) => normalizePath(writtenPath) === normalizePath(path))) {
+            writtenPaths.push(path)
+          }
+        }
+        for (const path of recoveredPaths) {
+          const warningPrefix = `FILE block "${path}" was not closed before end of stream`
+          for (let i = writeWarnings.length - 1; i >= 0; i--) {
+            if (writeWarnings[i].startsWith(warningPrefix)) writeWarnings.splice(i, 1)
+          }
+        }
+        writeWarnings.push(...repairResult.warnings)
+        hardFailures.push(...repairResult.hardFailures)
+        unrecoveredTruncatedPaths = unrecoveredTruncatedPaths.filter((path) =>
+          !recoveredPaths.includes(path)
+        )
+      }
+    } catch (err) {
+      throwIfIngestAborted(signal, activityId)
+      writeWarnings.push(
+        `Truncated FILE repair failed: ${err instanceof Error ? err.message : String(err)}`,
+      )
+    }
+  }
 
   try {
     if (await updateWikiIndexDeterministically(pp, writtenPaths)) {
@@ -1215,22 +1311,20 @@ async function autoIngestImpl(
   }
 
   // ── Step 5: Save to cache ───────────────────────────────────
-  // Skip cache when ANY block hit a hard FS failure: we'd otherwise
-  // freeze the partial-write result into the cache and a future
-  // re-ingest of the same source would silently replay only the
-  // pages that succeeded the first time, never giving the user a
-  // chance to recover the failed ones. Soft drops (language
-  // mismatch, path-traversal rejection, empty-path) are NOT failures
-  // — they represent deterministic decisions and caching them is
-  // safe.
-  if (writtenPaths.length > 0 && hardFailures.length === 0) {
+  // Skip cache when a write fails or a truncated path remains unrecovered;
+  // otherwise the partial result would be replayed without another LLM turn.
+  if (
+    writtenPaths.length > 0 &&
+    hardFailures.length === 0 &&
+    unrecoveredTruncatedPaths.length === 0
+  ) {
     await saveIngestCache(pp, sourceIdentity, sourceContent, writtenPaths)
     if (longSourceCheckpointPath) {
       await clearLongSourceCheckpoint(longSourceCheckpointPath)
     }
-  } else if (hardFailures.length > 0) {
+  } else if (hardFailures.length > 0 || unrecoveredTruncatedPaths.length > 0) {
     console.warn(
-      `[ingest] Skipping cache save for "${sourceIdentity}" — ${hardFailures.length} block(s) failed to write: ${hardFailures.join(", ")}`,
+      `[ingest] Skipping cache save for "${sourceIdentity}" — ${hardFailures.length} write failure(s), ${unrecoveredTruncatedPaths.length} truncated FILE block(s) still missing.`,
     )
   }
 
@@ -1688,8 +1782,8 @@ async function writeFileBlocks(
   signal?: AbortSignal,
   activityId?: string,
   onFileWritten?: (relativePath: string) => void,
-): Promise<{ writtenPaths: string[]; warnings: string[]; hardFailures: string[] }> {
-  const { blocks, warnings: parseWarnings } = parseFileBlocks(text)
+): Promise<{ writtenPaths: string[]; warnings: string[]; hardFailures: string[]; truncatedPaths: string[] }> {
+  const { blocks, warnings: parseWarnings, truncatedPaths } = parseFileBlocks(text)
   const warnings = [...parseWarnings]
   const writtenPaths: string[] = []
   // "Hard failures" = blocks we INTENDED to write but the FS rejected
@@ -1851,7 +1945,7 @@ async function writeFileBlocks(
     }
   }
 
-  return { writtenPaths, warnings, hardFailures }
+  return { writtenPaths, warnings, hardFailures, truncatedPaths }
 }
 
 function isOwnedOnlyBySource(content: string, sourceIdentity: string): boolean {
@@ -2229,6 +2323,63 @@ function buildReviewSuggestionPrompt(
     "## Generated Wiki Output",
     trimLongText(generation, sectionCap),
   ].filter(Boolean).join("\n")
+}
+
+type TruncatedFileRepairContext = {
+  readonly schema: string
+  readonly purpose: string
+  readonly analysis: string
+  readonly sourceContext: string
+  readonly maxContextSize: number | undefined
+}
+
+function buildTruncatedFileRepairPrompt(
+  paths: readonly string[],
+  sourceIdentity: string,
+  context: TruncatedFileRepairContext,
+): string {
+  const { schema, purpose, analysis, sourceContext, maxContextSize } = context
+  const { maxCtx } = computeContextBudget(maxContextSize)
+  const sectionCap = Math.max(4_000, Math.floor(maxCtx * 0.12))
+  return [
+    "You are repairing truncated wiki FILE blocks from an earlier generation.",
+    "Return exactly one complete FILE block for each requested path and no other files.",
+    "Every block must end with `---END FILE---`. Do not output a preamble, REVIEW blocks, or trailing commentary.",
+    "Preserve the requested paths exactly and include the source identity in each page's frontmatter `sources` field.",
+    "",
+    languageRule(sourceContext),
+    "",
+    "## Requested paths",
+    ...paths.map((path) => `- ${path}`),
+    "",
+    `## Source identity\n${sourceIdentity}`,
+    schema ? `## Project schema\n${trimLongText(schema, sectionCap)}` : "",
+    purpose ? `## Wiki purpose\n${trimLongText(purpose, sectionCap)}` : "",
+    `## Stage 1 analysis\n${trimLongText(analysis, sectionCap)}`,
+    `## Source context\n${trimLongText(sourceContext, sectionCap)}`,
+  ].filter(Boolean).join("\n")
+}
+
+function filterTruncatedFileRepairOutput(
+  text: string,
+  allowedPaths: readonly string[],
+): { text: string; paths: string[]; warnings: string[] } {
+  const allowed = new Set(allowedPaths.map(normalizePath))
+  const { blocks, warnings } = parseFileBlocks(text)
+  const kept = blocks.filter((block) => allowed.has(normalizePath(block.path)))
+  const dropped = blocks.filter((block) => !allowed.has(normalizePath(block.path)))
+  if (dropped.length > 0) {
+    warnings.push(
+      `Dropped ${dropped.length} unrequested FILE block(s) from truncated repair output: ${dropped.map((block) => block.path).join(", ")}`,
+    )
+  }
+  return {
+    text: kept
+      .map((block) => `---FILE: ${block.path}---\n${block.content.trimEnd()}\n---END FILE---`)
+      .join("\n\n"),
+    paths: kept.map((block) => block.path),
+    warnings,
+  }
 }
 
 function getStore() {


### PR DESCRIPTION
## Summary

- Retry incomplete `FILE` blocks once with a targeted, bounded generation request.
- Allow only the originally truncated paths in repair output and avoid caching unrecovered partial output.
- Enforce the clip server restart limit instead of resetting the counter after every successful bind.

## Root cause

- Provider streams can end mid-`FILE`; the parser dropped the incomplete block with a warning but did not attempt targeted recovery. CLI transports also cannot apply the configured `max_tokens` override.
- The clip server reset `restart_count` immediately after every bind, so repeated server-loop exits could never reach `MAX_RESTART_RETRIES`.

## Verification

- `npm run test:mocks` — 118 files, 1,722 tests passed
- `npm run typecheck`
- `npm run build`
- `npm --prefix mcp-server run build`
- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- `cargo test --manifest-path src-tauri/Cargo.toml --lib` — 348 passed, 1 ignored
- `cargo check --manifest-path src-tauri/Cargo.toml --message-format=short`
- `git diff --check upstream/main...HEAD`
