### PR TITLE
fix: reject project-internal archive exports

### DIFF
--- a/src-tauri/src/commands/project_maintenance.rs
+++ b/src-tauri/src/commands/project_maintenance.rs
@@ -76,6 +76,23 @@ mod tests {
         let _ = fs::remove_dir_all(target);
         let _ = fs::remove_file(archive);
     }
+
+    #[test]
+    fn export_rejects_lexically_external_destination_that_resolves_inside_project() {
+        let root = temp("export-inside-project");
+        fs::create_dir_all(root.join("wiki")).unwrap();
+        let root = root.canonicalize().unwrap();
+        let sibling = temp("export-sibling");
+        fs::create_dir_all(&sibling).unwrap();
+        let destination = sibling
+            .join("..")
+            .join(root.file_name().unwrap())
+            .join("wiki/archive.zip");
+
+        assert!(resolve_export_destination(&root, &destination).is_err());
+        let _ = fs::remove_dir_all(root);
+        let _ = fs::remove_dir_all(sibling);
+    }
 }
 
 #[tauri::command]
@@ -90,6 +107,27 @@ pub async fn export_project_archive(
     .map_err(|error| format!("Project export task failed: {error}"))?
 }
 
+fn resolve_export_destination(root: &Path, output: &Path) -> Result<PathBuf, String> {
+    let resolved = if output.exists() {
+        output.canonicalize().map_err(|e| e.to_string())?
+    } else {
+        let parent = output
+            .parent()
+            .ok_or_else(|| "Export destination must have a parent directory".to_string())?;
+        let filename = output
+            .file_name()
+            .ok_or_else(|| "Export destination must be a file path".to_string())?;
+        parent
+            .canonicalize()
+            .map_err(|e| e.to_string())?
+            .join(filename)
+    };
+    if resolved.starts_with(root) {
+        return Err("Export destination must be outside the project directory".into());
+    }
+    Ok(resolved)
+}
+
 fn export_project_archive_inner(project_path: String, destination: String) -> Result<(), String> {
     if !Path::new(&project_path).is_absolute() || !Path::new(&destination).is_absolute() {
         return Err("Project and archive paths must be absolute".into());
@@ -98,9 +136,7 @@ fn export_project_archive_inner(project_path: String, destination: String) -> Re
         .canonicalize()
         .map_err(|e| e.to_string())?;
     let output = PathBuf::from(destination);
-    if output.starts_with(&root) {
-        return Err("Export destination must be outside the project directory".into());
-    }
+    resolve_export_destination(&root, &output)?;
     let file = File::create(&output).map_err(|e| e.to_string())?;
     let mut zip = zip::ZipWriter::new(file);
     let options = SimpleFileOptions::default().compression_method(zip::CompressionMethod::Deflated);


### PR DESCRIPTION
## Summary

- Resolve archive export destinations before checking whether they are inside the project.
- Cover lexically external paths that normalize back into the project.
- Keep this security hardening separate from provider-routing changes in #590.

## Validation

- `cargo test --manifest-path src-tauri/Cargo.toml export_rejects_lexically_external_destination_that_resolves_inside_project --quiet`
- `cargo test --manifest-path src-tauri/Cargo.toml --lib --quiet` (352 passed, 1 ignored)
