### PR TITLE
fix: surface buffered streaming errors

### DIFF
--- a/src/lib/llm-client.test.ts
+++ b/src/lib/llm-client.test.ts
@@ -91,6 +91,121 @@ const cfg: LlmConfig = {
   maxContextSize: 8192,
 }
 
+const customStreamingCfg: LlmConfig = {
+  ...cfg,
+  provider: "custom",
+  model: "local-openai-model",
+  customEndpoint: "http://127.0.0.1:13305/v1",
+}
+
+function openAiSseToken(content: string): string {
+  return `data: ${JSON.stringify({ choices: [{ delta: { content } }] })}`
+}
+
+describe("streamChat — buffered streaming responses", () => {
+  beforeEach(() => mockHttpFetch.mockReset())
+
+  it("surfaces a JSON endpoint error returned inside HTTP 200", async () => {
+    mockHttpFetch.mockResolvedValue(new Response(JSON.stringify({
+      error: { code: 400, message: "request exceeds available context" },
+    }), {
+      status: 200,
+      headers: { "Content-Type": "text/event-stream" },
+    }))
+    const onToken = vi.fn()
+    const onDone = vi.fn()
+    const onError = vi.fn()
+
+    await streamChat(
+      customStreamingCfg,
+      [{ role: "user", content: "hi" }],
+      { onToken, onDone, onError },
+    )
+
+    expect(onError).toHaveBeenCalledTimes(1)
+    expect(onError.mock.calls[0][0].message).toBe(
+      "LLM endpoint error 400: request exceeds available context",
+    )
+    expect(onToken).not.toHaveBeenCalled()
+    expect(onDone).not.toHaveBeenCalled()
+  })
+
+  it("parses every record from a fully buffered SSE body", async () => {
+    const body = [
+      openAiSseToken("Hello"),
+      "",
+      openAiSseToken(" world"),
+      "",
+      "data: [DONE]",
+      "",
+    ].join("\n")
+    mockHttpFetch.mockResolvedValue(new Response(body, {
+      status: 200,
+      headers: { "Content-Type": "text/event-stream" },
+    }))
+    const onToken = vi.fn()
+    const onDone = vi.fn()
+    const onError = vi.fn()
+
+    await streamChat(
+      customStreamingCfg,
+      [{ role: "user", content: "hi" }],
+      { onToken, onDone, onError },
+    )
+
+    expect(onToken.mock.calls.map(([token]) => token)).toEqual(["Hello", " world"])
+    expect(onDone).toHaveBeenCalledTimes(1)
+    expect(onError).not.toHaveBeenCalled()
+  })
+
+  it("normalizes escaped separators in a buffered SSE body", async () => {
+    const body = [
+      openAiSseToken("Hello"),
+      openAiSseToken(" world"),
+      "data: [DONE]",
+    ].join("\\n\\n")
+    mockHttpFetch.mockResolvedValue(new Response(body, {
+      status: 200,
+      headers: { "Content-Type": "text/event-stream" },
+    }))
+    const onToken = vi.fn()
+    const onDone = vi.fn()
+    const onError = vi.fn()
+
+    await streamChat(
+      customStreamingCfg,
+      [{ role: "user", content: "hi" }],
+      { onToken, onDone, onError },
+    )
+
+    expect(onToken.mock.calls.map(([token]) => token)).toEqual(["Hello", " world"])
+    expect(onDone).toHaveBeenCalledTimes(1)
+    expect(onError).not.toHaveBeenCalled()
+  })
+
+  it("does not split separator-like text inside streamed JSON content", async () => {
+    const content = "first line\n\ndata: still model output"
+    const body = [
+      openAiSseToken(content),
+      "data: [DONE]",
+    ].join("\\n\\n")
+    mockHttpFetch.mockResolvedValue(new Response(body, { status: 200 }))
+    const onToken = vi.fn()
+    const onDone = vi.fn()
+    const onError = vi.fn()
+
+    await streamChat(
+      customStreamingCfg,
+      [{ role: "user", content: "hi" }],
+      { onToken, onDone, onError },
+    )
+
+    expect(onToken).toHaveBeenCalledWith(content)
+    expect(onDone).toHaveBeenCalledTimes(1)
+    expect(onError).not.toHaveBeenCalled()
+  })
+})
+
 describe("streamChat — non-streaming HTTP responses", () => {
   beforeEach(() => mockHttpFetch.mockReset())
 

--- a/src/lib/llm-client.ts
+++ b/src/lib/llm-client.ts
@@ -53,13 +53,83 @@ async function streamViaCodexCli(
   return mod.streamCodexCli(config, messages, callbacks, signal, requestOverrides)
 }
 
-const DECODER = new TextDecoder()
-
-function parseLines(chunk: Uint8Array, buffer: string): [string[], string] {
-  const text = buffer + DECODER.decode(chunk, { stream: true })
+function parseLines(
+  decoder: TextDecoder,
+  chunk: Uint8Array,
+  buffer: string,
+): [string[], string] {
+  const text = buffer + decoder.decode(chunk, { stream: true })
   const lines = text.split("\n")
   const remaining = lines.pop() ?? ""
   return [lines, remaining]
+}
+
+interface EndpointErrorEnvelope {
+  error?: {
+    code?: string | number
+    message?: string
+  } | string
+}
+
+function parseEndpointErrorEnvelope(record: string): Error | null {
+  const payload = record.startsWith("data:")
+    ? record.slice(5).trim()
+    : record
+
+  if (!payload.startsWith("{")) return null
+
+  try {
+    const parsed = JSON.parse(payload) as EndpointErrorEnvelope
+    const message = typeof parsed.error === "string"
+      ? parsed.error
+      : parsed.error?.message
+    if (!message) return null
+
+    const code = typeof parsed.error === "object" && parsed.error?.code !== undefined
+      ? ` ${parsed.error.code}`
+      : ""
+    return new Error(`LLM endpoint error${code}: ${message}`)
+  } catch {
+    return null
+  }
+}
+
+function splitFinalStreamRecords(text: string): string[] {
+  // Some local transports expose a fully buffered SSE body with escaped
+  // record separators. Only split after a complete JSON SSE record; a model
+  // response can legitimately contain the text "\n\ndata:", and splitting
+  // that sequence while it is still inside a JSON string would corrupt it.
+  if (/[\r\n]/.test(text) || !/^\s*data:/.test(text)) {
+    return text.split(/\r?\n/)
+  }
+
+  const records: string[] = []
+  const separator = /(?:\\r)?\\n(?:\\r)?\\n(?=data:)/g
+  let recordStart = 0
+  let match: RegExpExecArray | null
+
+  while ((match = separator.exec(text)) !== null) {
+    const candidate = text.slice(recordStart, match.index).trim()
+    const payload = candidate.startsWith("data:")
+      ? candidate.slice(5).trim()
+      : ""
+    let complete = payload === "[DONE]"
+    if (!complete && payload.startsWith("{")) {
+      try {
+        JSON.parse(payload)
+        complete = true
+      } catch {
+        // The separator-like text is inside an incomplete JSON string.
+      }
+    }
+    if (complete) {
+      records.push(candidate)
+      recordStart = match.index + match[0].length
+    }
+  }
+
+  records.push(text.slice(recordStart))
+  return records
 }
 
 function isRequestCancelledError(err: unknown): boolean {
@@ -248,6 +318,9 @@ export async function streamChat(
   }
 
   const reader = response.body.getReader()
+  // TextDecoder keeps partial multi-byte state, so it must be scoped to this
+  // response rather than shared across concurrent research requests.
+  const decoder = new TextDecoder()
   let lineBuffer = ""
 
   // Diagnostic counters. Some OpenAI-compatible endpoints stream
@@ -273,32 +346,45 @@ export async function streamChat(
       callbacks.onReasoningToken?.(part)
     }
   }
+  const processRecord = (line: string): Error | null => {
+    const trimmed = line.trim()
+    if (!trimmed) return null
+
+    reasoningCharsObserved += countReasoningCharsInLine(trimmed)
+    recordReasoning(trimmed)
+    const token = providerConfig.parseStream(trimmed)
+    if (token !== null) {
+      recordToken(token)
+      return null
+    }
+    return parseEndpointErrorEnvelope(trimmed)
+  }
 
   try {
     while (true) {
       const { done, value } = await reader.read()
 
       if (done) {
-        if (lineBuffer.trim()) {
-          const trimmed = lineBuffer.trim()
-          reasoningCharsObserved += countReasoningCharsInLine(trimmed)
-          recordReasoning(trimmed)
-          const token = providerConfig.parseStream(trimmed)
-          if (token !== null) recordToken(token)
+        const finalText = lineBuffer + decoder.decode()
+        for (const line of splitFinalStreamRecords(finalText)) {
+          const endpointError = processRecord(line)
+          if (endpointError) {
+            onError(endpointError)
+            return
+          }
         }
         break
       }
 
-      const [lines, remaining] = parseLines(value, lineBuffer)
+      const [lines, remaining] = parseLines(decoder, value, lineBuffer)
       lineBuffer = remaining
 
       for (const line of lines) {
-        const trimmed = line.trim()
-        if (!trimmed) continue
-        reasoningCharsObserved += countReasoningCharsInLine(trimmed)
-        recordReasoning(trimmed)
-        const token = providerConfig.parseStream(trimmed)
-        if (token !== null) recordToken(token)
+        const endpointError = processRecord(line)
+        if (endpointError) {
+          onError(endpointError)
+          return
+        }
       }
     }
 


### PR DESCRIPTION
## Summary

- surface JSON endpoint error envelopes returned inside successful HTTP streaming responses
- parse fully buffered SSE payloads, including transports that expose escaped record separators
- flush and scope `TextDecoder` state per response so concurrent streams cannot share decoder state

## Root cause

`streamChat()` treated every HTTP 200 response as a valid stream. When an OpenAI-compatible endpoint returned a plain JSON error envelope with `Content-Type: text/event-stream`, the provider parser returned `null`, the record was ignored, and the request incorrectly completed successfully with no content.

The final-buffer path also passed the entire remaining payload to a parser that expects one SSE record. Buffered transports using escaped separators could therefore lose every token. Separator normalization now only splits after a complete JSON SSE record, so separator-like text inside model output remains intact.

## Impact

Ingestion now reports the original endpoint error instead of continuing with an empty result such as `(Analysis not available)`. Buffered local OpenAI-compatible streams emit all content tokens without changing normal incremental SSE behavior.

## Validation

- `npm run test:mocks` — 118 files, 1,738 tests passed
- `npm run typecheck`
- added regression coverage for HTTP 200 JSON errors, buffered SSE, escaped separators, and separator-like model content

Closes #619
