### PR TITLE
fix: normalize merged body wikilinks

### DIFF
--- a/src/lib/page-merge.test.ts
+++ b/src/lib/page-merge.test.ts
@@ -182,6 +182,43 @@ describe("mergePageContent — LLM merge", () => {
     expect(out).toContain("type: entity")
     expect(out).not.toContain("type: concept")
   })
+
+  it("strips directory prefixes from merged body wikilinks only", async () => {
+    const existing = PAGE(
+      "type: entity\ntitle: Foo",
+      "Existing notes link to [[clients/foo-overview]] and contain enough detail for merging.",
+    )
+    const incoming = PAGE(
+      "type: entity\ntitle: Foo",
+      "Incoming notes add a second detailed observation about the same subject.",
+    )
+    const mergedBody = [
+      "Existing and incoming notes are retained with additional context.",
+      "See [[clients/foo-overview]], [[concepts/bar#Details|Bar details]], and [[windows\\baz]].",
+      "Keep the ordinary path clients/foo-overview unchanged.",
+      "Keep the embed ![[media/charts/plot.png]] unchanged.",
+      "Keep inline code `[[examples/inline-link]]` unchanged.",
+      "```md",
+      "[[examples/fenced-link]]",
+      "```",
+      "Keep URI-like [[https://example.com/wiki/page]] targets unchanged.",
+    ].join("\n")
+    const merger = vi.fn().mockResolvedValue(
+      PAGE("type: entity\ntitle: Foo", mergedBody),
+    )
+
+    const out = await mergePageContent(incoming, existing, merger, baseOpts)
+
+    expect(out).toContain("[[foo-overview]]")
+    expect(out).toContain("[[bar#Details|Bar details]]")
+    expect(out).toContain("[[baz]]")
+    expect(out).not.toContain("[[clients/foo-overview]]")
+    expect(out).toContain("ordinary path clients/foo-overview unchanged")
+    expect(out).toContain("![[media/charts/plot.png]]")
+    expect(out).toContain("`[[examples/inline-link]]`")
+    expect(out).toContain("[[examples/fenced-link]]")
+    expect(out).toContain("[[https://example.com/wiki/page]]")
+  })
 })
 
 // ──────────────────────────────────────────────────────────────────

--- a/src/lib/page-merge.ts
+++ b/src/lib/page-merge.ts
@@ -197,7 +197,73 @@ export async function mergePageContent(
   const todayFn = opts.today ?? defaultToday
   final = setFrontmatterScalar(final, "updated", todayFn())
 
-  return final
+  return stripBodyWikilinkPathPrefixes(final)
+}
+
+/**
+ * Normalize page links after an LLM merge without touching frontmatter,
+ * prose paths, code examples, or Obsidian image/file embeds.
+ *
+ * Project schemas route pages into directories on disk, but cross-page links
+ * use bare slugs. Older page bodies may still contain targets such as
+ * `[[clients/foo-overview]]`; merge prompts intentionally preserve existing
+ * links, so the application must repair those targets deterministically.
+ */
+function stripBodyWikilinkPathPrefixes(content: string): string {
+  const frontmatter = content.match(/^---\r?\n[\s\S]*?\r?\n---(?:\r?\n|$)/)
+  if (!frontmatter) return content
+
+  const body = content.slice(frontmatter[0].length)
+  if (!body.includes("[[")) return content
+
+  const fencedParts = body.split(/(```[\s\S]*?```)/g)
+  const normalizedBody = fencedParts
+    .map((part, index) =>
+      index % 2 === 1 ? part : stripWikilinkPrefixesOutsideInlineCode(part),
+    )
+    .join("")
+
+  return `${frontmatter[0]}${normalizedBody}`
+}
+
+function stripWikilinkPrefixesOutsideInlineCode(text: string): string {
+  const inlineParts = text.split(/(`[^`\n]+`)/g)
+  return inlineParts
+    .map((part, index) => index % 2 === 1 ? part : replaceWikilinkPrefixes(part))
+    .join("")
+}
+
+const PAGE_WIKILINK_RE = /\[\[([^\]|\n]+)(?:\|([^\]\n]*))?\]\]/g
+
+function replaceWikilinkPrefixes(text: string): string {
+  return text.replace(
+    PAGE_WIKILINK_RE,
+    (match, rawTarget: string, rawAlias: string | undefined, offset: number) => {
+      if (offset > 0 && text[offset - 1] === "!") return match
+
+      const target = rawTarget.trim()
+      const normalizedTarget = bareWikilinkTarget(target)
+      if (normalizedTarget === target) return match
+
+      const alias = rawAlias === undefined ? "" : `|${rawAlias}`
+      return `[[${normalizedTarget}${alias}]]`
+    },
+  )
+}
+
+function bareWikilinkTarget(target: string): string {
+  if (!target || target.startsWith("#")) return target
+  // URI-like targets are not wiki page paths.
+  if (/^[a-z][a-z0-9+.-]*:/i.test(target)) return target
+
+  const fragmentIndex = target.indexOf("#")
+  const pageTarget = fragmentIndex >= 0 ? target.slice(0, fragmentIndex) : target
+  const fragment = fragmentIndex >= 0 ? target.slice(fragmentIndex) : ""
+  const normalizedPath = pageTarget.replace(/\\/g, "/")
+  if (!normalizedPath.includes("/")) return target
+
+  const leaf = normalizedPath.split("/").pop()
+  return leaf ? `${leaf}${fragment}` : target
 }
 
 async function tryBackup(


### PR DESCRIPTION
## Summary

- normalize directory-prefixed page links after an LLM page merge
- preserve aliases and heading fragments while leaving embeds, code examples, URI targets, and ordinary prose paths untouched
- add regression coverage for forward- and backslash-prefixed links

## Root cause

The page-merge prompt intentionally preserves existing wikilinks, so older body links such as `[[clients/foo-overview]]` survived even when the project schema requires bare slugs. Frontmatter was repaired deterministically, but body wikilinks were not.

## Impact

Merged pages now consistently use bare-slug wikilinks without relying on provider compliance.

## Validation

- `npm exec vitest run src/lib/page-merge.test.ts`
- `npm run typecheck`
- `npm run test:mocks`

Closes #576
