### PR TITLE
feat: open source files externally

### DIFF
--- a/src/components/sources/sources-view.tsx
+++ b/src/components/sources/sources-view.tsx
@@ -1,11 +1,11 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from "react"
 import { open } from "@tauri-apps/plugin-dialog"
-import { Plus, FileText, RefreshCw, BookOpen, Trash2, Folder, ChevronRight, ChevronDown, Link } from "lucide-react"
+import { Plus, FileText, RefreshCw, BookOpen, Trash2, Folder, ChevronRight, ChevronDown, Link, ExternalLink } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
 import { useWikiStore } from "@/stores/wiki-store"
-import { listDirectory, readFile } from "@/commands/fs"
+import { listDirectory, openPathInProject, readFile } from "@/commands/fs"
 import type { FileNode } from "@/types/wiki"
 import { useTranslation } from "react-i18next"
 import { normalizePath } from "@/lib/path-utils"
@@ -249,6 +249,19 @@ export function SourcesView() {
     }
   }
 
+  async function handleOpenSourceExternally(node: FileNode) {
+    if (!project) return
+    try {
+      await openPathInProject(project.path, node.path)
+    } catch (err) {
+      console.error("Failed to open source externally:", err)
+      window.alert(t("sources.openExternalFailed", {
+        name: node.name,
+        error: String(err),
+      }))
+    }
+  }
+
   async function handleDelete(node: FileNode) {
     if (!project) return
     const pp = normalizePath(project.path)
@@ -439,6 +452,7 @@ export function SourcesView() {
             <SourceTree
               nodes={sources}
               onOpen={handleOpenSource}
+              onOpenExternal={handleOpenSourceExternally}
               onIngest={handleIngest}
               onDelete={handleDelete}
               onDeleteFolder={handleDeleteFolder}
@@ -521,6 +535,7 @@ function flattenVisibleRows(
 function SourceTree({
   nodes,
   onOpen,
+  onOpenExternal,
   onIngest,
   onDelete,
   onDeleteFolder,
@@ -531,6 +546,7 @@ function SourceTree({
 }: {
   nodes: FileNode[]
   onOpen: (node: FileNode) => void
+  onOpenExternal: (node: FileNode) => void
   onIngest: (node: FileNode) => void
   onDelete: (node: FileNode) => void
   onDeleteFolder: (node: FileNode) => void
@@ -662,6 +678,16 @@ function SourceTree({
                 {t(`sources.ingestStatus.${ingestStatus}`)}
               </span>
             </button>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7 shrink-0"
+              title={t("sources.openExternal")}
+              aria-label={t("sources.openExternal")}
+              onClick={() => onOpenExternal(node)}
+            >
+              <ExternalLink className="h-4 w-4" />
+            </Button>
             <Button
               variant="ghost"
               size="icon"

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -184,6 +184,8 @@
     "refreshFolderHint": "Rescan the source folder and process new, changed, or deleted files.",
     "refreshFolderTooltip": "Rescan the project source folder with the same rules as automatic monitoring. New or modified allowed files are queued for ingest; deleted sources trigger the normal wiki and index cleanup; then the file tree is rebuilt.",
     "refreshFailed": "Failed to refresh sources: {{error}}",
+    "openExternal": "Open in default app",
+    "openExternalFailed": "Failed to open {{name}}: {{error}}",
     "ingest": "Ingest",
     "ingestStatus": {
       "not-ingested": "Not ingested",

--- a/src/i18n/zh.json
+++ b/src/i18n/zh.json
@@ -184,6 +184,8 @@
     "refreshFolderHint": "重新扫描资料文件夹，并处理新增、修改或删除的文件。",
     "refreshFolderTooltip": "按自动监控相同规则重新扫描当前项目的资料文件夹。允许的新增或修改文件会加入提取队列；已删除的资料会走正常的 Wiki 与索引清理流程；随后重建文件树。",
     "refreshFailed": "刷新原始资料失败：{{error}}",
+    "openExternal": "用默认应用打开",
+    "openExternalFailed": "无法打开「{{name}}」：{{error}}",
     "ingest": "提取到 Wiki",
     "ingestStatus": {
       "not-ingested": "未摄取",


### PR DESCRIPTION
## Summary

- add an external-open action to each file in the Sources view
- reuse the project-scoped backend opener so paths are canonicalized and cannot escape the current project
- add localized labels and actionable error feedback

## Why

Clicking a source currently opens only the in-app preview. Some source formats are more useful in their native desktop application, so users need a direct way to open the original file.

## Impact

Source files can now be opened externally with one click. If the platform cannot open a file directly, the existing backend falls back to revealing it in the file manager.

## Validation

- `npm exec vitest run src/i18n/i18n-parity.test.ts`
- `npm run typecheck`
- `npm run test:mocks`

Closes #320
