### PR TITLE
feat: add option to ignore ssl cert error behind http proxy

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -28,7 +28,7 @@ chrono = { version = "0.4", features = ["clock"] }
 tauri-plugin-dialog = "2.7.1"
 pdfium-render = "0.9"
 tauri-plugin-store = "2.4.2"
-tauri-plugin-http = { version = "2", features = ["unsafe-headers"] }
+tauri-plugin-http = { version = "2", features = ["unsafe-headers", "dangerous-settings"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
 tiny_http = "0.12"
 zip = "2"

--- a/src-tauri/src/agent/provider.rs
+++ b/src-tauri/src/agent/provider.rs
@@ -138,7 +138,7 @@ impl AgentLlmProvider for LlmClient {
 
 impl LlmClient {
     pub fn new(config: LlmConfig) -> Result<Self, String> {
-        let client = reqwest::Client::builder()
+        let client = crate::proxy::configure_http_client(reqwest::Client::builder())
             .timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS))
             .build()
             .map_err(|err| format!("Failed to build LLM HTTP client: {err}"))?;

--- a/src-tauri/src/agent/tools.rs
+++ b/src-tauri/src/agent/tools.rs
@@ -1181,7 +1181,7 @@ pub async fn run_web_search(
         return Err("Web search provider is not configured.".to_string());
     }
     let max_results = web_search_result_limit(&provider, top_k);
-    let client = reqwest::Client::builder()
+    let client = crate::proxy::configure_http_client(reqwest::Client::builder())
         .timeout(std::time::Duration::from_secs(WEB_SEARCH_TIMEOUT_SECS))
         .build()
         .map_err(|err| format!("Failed to build web search client: {err}"))?;
@@ -1242,7 +1242,7 @@ pub async fn run_anytxt_search(
         .filter_ext
         .filter(|value| !value.trim().is_empty())
         .unwrap_or_else(|| "*".to_string());
-    let client = reqwest::Client::builder()
+    let client = crate::proxy::configure_http_client(reqwest::Client::builder())
         .timeout(std::time::Duration::from_secs(WEB_SEARCH_TIMEOUT_SECS))
         .build()
         .map_err(|err| format!("Failed to build AnyTXT client: {err}"))?;

--- a/src-tauri/src/commands/search.rs
+++ b/src-tauri/src/commands/search.rs
@@ -1107,7 +1107,7 @@ async fn fetch_embedding_batch(
     }
 
     let endpoint = volcengine_embedding_endpoint(cfg);
-    let mut req = reqwest::Client::builder()
+    let mut req = crate::proxy::configure_http_client(reqwest::Client::builder())
         .timeout(std::time::Duration::from_secs(
             SEARCH_EMBEDDING_TIMEOUT_SECS,
         ))
@@ -1236,7 +1236,7 @@ async fn fetch_embedding_once(
     } else {
         volcengine_embedding_endpoint(cfg)
     };
-    let mut req = reqwest::Client::builder()
+    let mut req = crate::proxy::configure_http_client(reqwest::Client::builder())
         .timeout(std::time::Duration::from_secs(
             SEARCH_EMBEDDING_TIMEOUT_SECS,
         ))

--- a/src-tauri/src/proxy.rs
+++ b/src-tauri/src/proxy.rs
@@ -13,12 +13,20 @@
 //! Cost is one duplicated key name (`proxyConfig`) — see
 //! src/lib/project-store.ts for the matching write site.
 
-use std::path::Path;
+use std::{
+    path::Path,
+    sync::atomic::{AtomicBool, Ordering},
+};
 
 use serde::{Deserialize, Serialize};
 
 const DEFAULT_BYPASS_LIST: &str =
     "localhost,127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,*.local";
+
+// reqwest clients are created in several modules. Keep the live, effective
+// TLS policy in one process-wide flag so every newly-built client observes a
+// settings change without an app restart.
+static IGNORE_SSL_CERTIFICATE_ERRORS: AtomicBool = AtomicBool::new(false);
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ProxyConfig {
@@ -28,6 +36,8 @@ pub struct ProxyConfig {
     pub url: String,
     #[serde(default = "default_true", rename = "bypassLocal")]
     pub bypass_local: bool,
+    #[serde(default, rename = "ignoreSslCertificateErrors")]
+    pub ignore_ssl_certificate_errors: bool,
 }
 
 // Hand-written Default impl so its `bypass_local` matches what
@@ -43,6 +53,7 @@ impl Default for ProxyConfig {
             enabled: false,
             url: String::new(),
             bypass_local: true,
+            ignore_ssl_certificate_errors: false,
         }
     }
 }
@@ -90,6 +101,7 @@ pub fn apply_proxy_env(config: &ProxyConfig) -> String {
     let invalid_scheme = !url.starts_with("http://") && !url.starts_with("https://");
 
     if !config.enabled || url.is_empty() || invalid_scheme {
+        IGNORE_SSL_CERTIFICATE_ERRORS.store(false, Ordering::Relaxed);
         clear_proxy_env();
         return if !config.enabled {
             "disabled".to_string()
@@ -102,6 +114,8 @@ pub fn apply_proxy_env(config: &ProxyConfig) -> String {
         };
     }
 
+    IGNORE_SSL_CERTIFICATE_ERRORS.store(config.ignore_ssl_certificate_errors, Ordering::Relaxed);
+
     std::env::set_var("HTTP_PROXY", url);
     std::env::set_var("HTTPS_PROXY", url);
     if config.bypass_local {
@@ -112,10 +126,21 @@ pub fn apply_proxy_env(config: &ProxyConfig) -> String {
         std::env::remove_var("NO_PROXY");
     }
     format!(
-        "enabled ({}, bypass_local={})",
+        "enabled ({}, bypass_local={}, ignore_ssl_certificate_errors={})",
         redact_url(url),
-        config.bypass_local
+        config.bypass_local,
+        config.ignore_ssl_certificate_errors
     )
+}
+
+/// Apply the current proxy TLS policy to a newly-created reqwest client.
+/// Certificate verification can only be disabled while a valid proxy is
+/// active; disabling or invalidating the proxy resets the flag above.
+pub fn configure_http_client(builder: reqwest::ClientBuilder) -> reqwest::ClientBuilder {
+    let ignore_errors = IGNORE_SSL_CERTIFICATE_ERRORS.load(Ordering::Relaxed);
+    builder
+        .danger_accept_invalid_certs(ignore_errors)
+        .danger_accept_invalid_hostnames(ignore_errors)
 }
 
 /// Strip embedded basic-auth credentials from a URL before logging.
@@ -210,6 +235,7 @@ mod tests {
                 enabled: false,
                 url: "http://x:1".into(),
                 bypass_local: true,
+                ignore_ssl_certificate_errors: false,
             });
             assert!(s.contains("disabled"));
             assert!(std::env::var("HTTP_PROXY").is_err());
@@ -224,6 +250,7 @@ mod tests {
                 enabled: true,
                 url: "http://127.0.0.1:7890".into(),
                 bypass_local: true,
+                ignore_ssl_certificate_errors: false,
             });
             assert_eq!(
                 std::env::var("HTTP_PROXY").unwrap(),
@@ -248,6 +275,7 @@ mod tests {
                 enabled: true,
                 url: "http://x:1".into(),
                 bypass_local: false,
+                ignore_ssl_certificate_errors: false,
             });
             // The stale value must be cleared so the user's intent
             // (everything goes through the proxy) is honored.
@@ -262,6 +290,7 @@ mod tests {
                 enabled: true,
                 url: "socks5://x:1".into(),
                 bypass_local: true,
+                ignore_ssl_certificate_errors: false,
             });
             assert!(std::env::var("HTTP_PROXY").is_err());
         });
@@ -274,6 +303,7 @@ mod tests {
                 enabled: true,
                 url: "   ".into(),
                 bypass_local: true,
+                ignore_ssl_certificate_errors: false,
             });
             assert!(std::env::var("HTTP_PROXY").is_err());
         });
@@ -291,6 +321,7 @@ mod tests {
                 enabled: true,
                 url: "http://127.0.0.1:7890".into(),
                 bypass_local: true,
+                ignore_ssl_certificate_errors: false,
             });
             assert_eq!(
                 std::env::var("HTTP_PROXY").unwrap(),
@@ -301,6 +332,7 @@ mod tests {
                 enabled: false,
                 url: "http://127.0.0.1:7890".into(),
                 bypass_local: true,
+                ignore_ssl_certificate_errors: false,
             });
             assert!(std::env::var("HTTP_PROXY").is_err());
             assert!(std::env::var("HTTPS_PROXY").is_err());
@@ -319,11 +351,13 @@ mod tests {
                 enabled: true,
                 url: "http://127.0.0.1:7890".into(),
                 bypass_local: true,
+                ignore_ssl_certificate_errors: false,
             });
             apply_proxy_env(&ProxyConfig {
                 enabled: true,
                 url: "socks5://x:1".into(),
                 bypass_local: true,
+                ignore_ssl_certificate_errors: true,
             });
             assert!(std::env::var("HTTP_PROXY").is_err());
         });
@@ -336,6 +370,7 @@ mod tests {
                 enabled: true,
                 url: "https://proxy.corp:443".into(),
                 bypass_local: false,
+                ignore_ssl_certificate_errors: false,
             });
             assert_eq!(
                 std::env::var("HTTPS_PROXY").unwrap(),
@@ -376,6 +411,7 @@ mod tests {
                 enabled: true,
                 url: "http://secretuser:secretpass@proxy.corp:8080".into(),
                 bypass_local: true,
+                ignore_ssl_certificate_errors: false,
             });
             assert!(!summary.contains("secretpass"));
             assert!(!summary.contains("secretuser"));
@@ -398,9 +434,14 @@ mod tests {
             default_via_trait.bypass_local, default_via_serde.bypass_local,
             "Default trait and serde-default must agree on bypass_local",
         );
+        assert_eq!(
+            default_via_trait.ignore_ssl_certificate_errors,
+            default_via_serde.ignore_ssl_certificate_errors,
+        );
         // And both should be the safe default: bypass on, proxy off.
         assert!(!default_via_trait.enabled);
         assert!(default_via_trait.bypass_local);
+        assert!(!default_via_trait.ignore_ssl_certificate_errors);
     }
 
     #[test]
@@ -412,6 +453,35 @@ mod tests {
         assert!(cfg.enabled);
         assert_eq!(cfg.url, "http://x:1");
         assert!(!cfg.bypass_local);
+        assert!(!cfg.ignore_ssl_certificate_errors);
+    }
+
+    #[test]
+    fn ssl_errors_can_only_be_ignored_while_proxy_is_active() {
+        isolated(|| {
+            apply_proxy_env(&ProxyConfig {
+                enabled: true,
+                url: "http://127.0.0.1:7890".into(),
+                bypass_local: true,
+                ignore_ssl_certificate_errors: true,
+            });
+            assert!(IGNORE_SSL_CERTIFICATE_ERRORS.load(Ordering::Relaxed));
+
+            apply_proxy_env(&ProxyConfig {
+                enabled: false,
+                url: "http://127.0.0.1:7890".into(),
+                bypass_local: true,
+                ignore_ssl_certificate_errors: true,
+            });
+            assert!(!IGNORE_SSL_CERTIFICATE_ERRORS.load(Ordering::Relaxed));
+        });
+    }
+
+    #[test]
+    fn parses_camelcase_ssl_error_field() {
+        let json = r#"{"enabled":true,"url":"http://x:1","ignoreSslCertificateErrors":true}"#;
+        let cfg: ProxyConfig = serde_json::from_str(json).unwrap();
+        assert!(cfg.ignore_ssl_certificate_errors);
     }
 
     #[test]

--- a/src/components/settings/sections/network-section.tsx
+++ b/src/components/settings/sections/network-section.tsx
@@ -97,6 +97,31 @@ export function NetworkSection({ draft, setDraft }: Props) {
         </div>
       </label>
 
+      <label className="flex items-start gap-2">
+        <input
+          type="checkbox"
+          checked={draft.proxyIgnoreSslCertificateErrors}
+          onChange={(e) =>
+            setDraft("proxyIgnoreSslCertificateErrors", e.target.checked)
+          }
+          disabled={!draft.proxyEnabled}
+          className="mt-0.5 h-4 w-4"
+        />
+        <div className="space-y-1">
+          <span className="text-sm">
+            {t("settings.sections.network.ignoreSslCertificateErrors", {
+              defaultValue: "Ignore SSL certificate errors behind proxy",
+            })}
+          </span>
+          <p className="text-xs text-destructive">
+            {t("settings.sections.network.ignoreSslCertificateErrorsHelp", {
+              defaultValue:
+                "Use only when a trusted proxy inspects HTTPS traffic. This disables certificate verification for external requests and can expose traffic to interception.",
+            })}
+          </p>
+        </div>
+      </label>
+
     </div>
   )
 }

--- a/src/components/settings/settings-types.ts
+++ b/src/components/settings/settings-types.ts
@@ -57,11 +57,12 @@ export interface SettingsDraft {
   maxHistoryMessages: number
 
   // Network — global outbound HTTP proxy. Persisted to app-state.json
-  // and read by the Rust setup hook on app launch (changes apply
-  // after restart). See src/lib/proxy-config.ts.
+  // and read by the Rust setup hook on app launch; Save also applies
+  // changes live. See src/lib/proxy-config.ts.
   proxyEnabled: boolean
   proxyUrl: string
   proxyBypassLocal: boolean
+  proxyIgnoreSslCertificateErrors: boolean
 
   // Scheduled Import
   scheduledImportEnabled: boolean

--- a/src/components/settings/settings-view.tsx
+++ b/src/components/settings/settings-view.tsx
@@ -155,6 +155,7 @@ function initialDraft(
     proxyEnabled: proxy.enabled,
     proxyUrl: proxy.url,
     proxyBypassLocal: proxy.bypassLocal,
+    proxyIgnoreSslCertificateErrors: proxy.ignoreSslCertificateErrors === true,
     scheduledImportEnabled: scheduledImport.enabled,
     scheduledImportPath: displayPath,
     scheduledImportInterval: scheduledImport.interval,
@@ -400,6 +401,7 @@ export function SettingsView() {
       enabled: draft.proxyEnabled,
       url: draft.proxyUrl.trim(),
       bypassLocal: draft.proxyBypassLocal,
+      ignoreSslCertificateErrors: draft.proxyIgnoreSslCertificateErrors,
     }
     const newSourceWatch = normalizeSourceWatchConfig(draft.sourceWatchConfig)
     const newScheduledImport = {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -702,7 +702,9 @@
         "url": "Proxy URL",
         "urlHelp": "Full URL with scheme. Supported: http://, https://. (SOCKS5 not supported in this version.)",
         "bypassLocal": "Bypass proxy for local addresses (recommended)",
-        "bypassLocalHelp": "Requests to localhost, 127.0.0.0/8, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, and *.local don't go through the proxy. Keep this on if you use Ollama / LM Studio / other local or LAN-deployed LLMs."
+        "bypassLocalHelp": "Requests to localhost, 127.0.0.0/8, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, and *.local don't go through the proxy. Keep this on if you use Ollama / LM Studio / other local or LAN-deployed LLMs.",
+        "ignoreSslCertificateErrors": "Ignore SSL certificate errors behind proxy",
+        "ignoreSslCertificateErrorsHelp": "Use only when a trusted proxy inspects HTTPS traffic. This disables certificate verification for external requests and can expose traffic to interception."
       },
       "sourceWatch": {
         "title": "Source Folder Auto Watch",

--- a/src/i18n/zh.json
+++ b/src/i18n/zh.json
@@ -702,7 +702,9 @@
         "url": "代理地址",
         "urlHelp": "完整 URL，必须带协议头。支持：http://、https://（当前版本不支持 SOCKS5）。",
         "bypassLocal": "本地地址不走代理（推荐）",
-        "bypassLocalHelp": "对 localhost、127.0.0.0/8、10.0.0.0/8、172.16.0.0/12、192.168.0.0/16 以及 *.local 的请求会绕过代理。如果你用 Ollama / LM Studio 或局域网内的 LLM 服务，请保持开启。"
+        "bypassLocalHelp": "对 localhost、127.0.0.0/8、10.0.0.0/8、172.16.0.0/12、192.168.0.0/16 以及 *.local 的请求会绕过代理。如果你用 Ollama / LM Studio 或局域网内的 LLM 服务，请保持开启。",
+        "ignoreSslCertificateErrors": "忽略代理后的 SSL 证书错误",
+        "ignoreSslCertificateErrorsHelp": "仅在受信任的代理检查 HTTPS 流量时使用。此选项会关闭外部请求的证书验证，并可能使流量遭到拦截。"
       },
       "sourceWatch": {
         "title": "资料文件夹自动监控",

--- a/src/lib/proxy-config.ts
+++ b/src/lib/proxy-config.ts
@@ -8,8 +8,8 @@
  * those up automatically and routes every outbound HTTP request
  * through the configured proxy.
  *
- * Changes apply on app restart; the UI surfaces a "Restart now"
- * button so users don't have to do it manually.
+ * Changes are also sent to Rust on Save so newly-created HTTP clients
+ * observe the proxy and TLS policy without an app restart.
  *
  * v1 supports HTTP and HTTPS proxies only. SOCKS5 needs a reqwest
  * cargo feature flag and is deferred.
@@ -31,12 +31,19 @@ export interface ProxyConfig {
    * get sent to the external proxy and fail.
    */
   bypassLocal: boolean
+  /**
+   * Accept invalid/expired TLS certificates for outbound requests while
+   * the proxy is active. This is intentionally opt-in because it disables
+   * server certificate verification and exposes traffic to interception.
+   */
+  ignoreSslCertificateErrors?: boolean
 }
 
 export const DEFAULT_PROXY_CONFIG: ProxyConfig = {
   enabled: false,
   url: "",
   bypassLocal: true,
+  ignoreSslCertificateErrors: false,
 }
 
 /**

--- a/src/lib/tauri-fetch.test.ts
+++ b/src/lib/tauri-fetch.test.ts
@@ -14,7 +14,50 @@
  * run crash with "window is not defined").
  */
 import { describe, it, expect } from "vitest"
-import { getHttpFetch, isFetchNetworkError } from "./tauri-fetch"
+import {
+  getHttpFetch,
+  getProxyDangerSettings,
+  isFetchNetworkError,
+} from "./tauri-fetch"
+
+describe("getProxyDangerSettings", () => {
+  it("enables the bypass only for an active proxy with explicit opt-in", () => {
+    expect(
+      getProxyDangerSettings({
+        enabled: true,
+        url: "http://127.0.0.1:7890",
+        bypassLocal: true,
+        ignoreSslCertificateErrors: true,
+      }),
+    ).toEqual({ acceptInvalidCerts: true, acceptInvalidHostnames: true })
+  })
+
+  it("stays safe for disabled, invalid, and legacy proxy configs", () => {
+    expect(
+      getProxyDangerSettings({
+        enabled: false,
+        url: "http://127.0.0.1:7890",
+        bypassLocal: true,
+        ignoreSslCertificateErrors: true,
+      }),
+    ).toBeUndefined()
+    expect(
+      getProxyDangerSettings({
+        enabled: true,
+        url: "not-a-url",
+        bypassLocal: true,
+        ignoreSslCertificateErrors: true,
+      }),
+    ).toBeUndefined()
+    expect(
+      getProxyDangerSettings({
+        enabled: true,
+        url: "http://127.0.0.1:7890",
+        bypassLocal: true,
+      }),
+    ).toBeUndefined()
+  })
+})
 
 describe("getHttpFetch — Node fallback", () => {
   it("returns a callable function under Node (typeof window === undefined)", async () => {

--- a/src/lib/tauri-fetch.ts
+++ b/src/lib/tauri-fetch.ts
@@ -17,6 +17,28 @@
  * from any environment without crashing at module load.
  */
 
+import { isProxyActive, type ProxyConfig } from "./proxy-config"
+import { useWikiStore } from "@/stores/wiki-store"
+
+interface ProxyDangerSettings {
+  acceptInvalidCerts: true
+  acceptInvalidHostnames: true
+}
+
+/** Only expose the dangerous plugin setting for an explicitly enabled,
+ * valid proxy. Older persisted configs omit the new field and stay safe. */
+export function getProxyDangerSettings(
+  config: ProxyConfig,
+): ProxyDangerSettings | undefined {
+  if (!isProxyActive(config) || config.ignoreSslCertificateErrors !== true) {
+    return undefined
+  }
+  return {
+    acceptInvalidCerts: true,
+    acceptInvalidHostnames: true,
+  }
+}
+
 let pluginFetchPromise: Promise<typeof globalThis.fetch> | null = null
 
 /**
@@ -45,7 +67,21 @@ export function getHttpFetch(): Promise<typeof globalThis.fetch> {
       pluginFetchPromise = Promise.resolve(globalThis.fetch.bind(globalThis))
     } else {
       pluginFetchPromise = import("@tauri-apps/plugin-http")
-        .then((m) => m.fetch as unknown as typeof globalThis.fetch)
+        .then((m) => {
+          const pluginFetch = m.fetch
+          return (async (input: RequestInfo | URL, init?: RequestInit) => {
+            const proxyConfig = useWikiStore.getState().proxyConfig
+            const danger = getProxyDangerSettings(proxyConfig)
+            if (danger) {
+              const pluginInit = {
+                ...init,
+                danger,
+              }
+              return pluginFetch(input, pluginInit)
+            }
+            return pluginFetch(input, init)
+          }) as typeof globalThis.fetch
+        })
         .catch(() => globalThis.fetch.bind(globalThis))
     }
   }

--- a/src/stores/wiki-store.ts
+++ b/src/stores/wiki-store.ts
@@ -185,12 +185,13 @@ interface EmbeddingConfig {
  * http(s) URL, the Rust setup hook reads this on app launch and
  * sets HTTP_PROXY / HTTPS_PROXY / NO_PROXY env vars before the
  * reqwest client used by tauri-plugin-http is constructed. Changes
- * apply on app restart only.
+ * Changes are applied live when Settings is saved.
  */
 interface ProxyConfig {
   enabled: boolean
   url: string
   bypassLocal: boolean
+  ignoreSslCertificateErrors?: boolean
 }
 
 interface ScheduledImportConfig {
@@ -605,6 +606,7 @@ export const useWikiStore = create<WikiState>((set) => ({
     enabled: false,
     url: "",
     bypassLocal: true,
+    ignoreSslCertificateErrors: false,
   },
 
   scheduledImportConfig: {


### PR DESCRIPTION
Close #644 

For http proxy servers using self-signed ssl certificates, proxied https request will always fail with ssl cert invalid error at client side.

In that case, add extra network setting option for user to ingnore SSL error for trusted proxy server to make external API request work.