### PR TITLE
feat(settings): add Cmd+,/Ctrl+, shortcut to open settings

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import { getLastProject, getRecentProjects, saveLastProject, loadLlmConfig, load
 import { loadReviewItems, loadLintItems, loadChatHistory, loadChatPreferences } from "@/lib/persist"
 import { setupAutoSave } from "@/lib/auto-save"
 import { startClipWatcher } from "@/lib/clip-watcher"
+import { useGlobalShortcut } from "@/hooks/use-global-shortcut"
 import { AppLayout } from "@/components/layout/app-layout"
 import { WelcomeScreen } from "@/components/project/welcome-screen"
 import { CreateProjectDialog } from "@/components/project/create-project-dialog"
@@ -124,6 +125,12 @@ function App() {
     setupAutoSave()
     startClipWatcher()
   }, [])
+
+  // Register global keyboard shortcuts
+  // Cmd+, on macOS or Ctrl+, on Windows/Linux opens settings
+  useGlobalShortcut({
+    ",": () => setActiveView("settings"),
+  })
 
   useEffect(() => {
     // Apply interface zoom globally, including welcome/settings screens. We

--- a/src/components/layout/icon-sidebar.tsx
+++ b/src/components/layout/icon-sidebar.tsx
@@ -189,6 +189,7 @@ export function IconSidebar({ onSwitchProject }: IconSidebarProps) {
             </TooltipTrigger>
             <TooltipContent side="right">
               {t("nav.settings")}
+              {t("nav.settingsShortcut")}
               {updateAvailable ? t("nav.updateAvailableSuffix") : ""}
             </TooltipContent>
           </Tooltip>

--- a/src/hooks/use-global-shortcut.ts
+++ b/src/hooks/use-global-shortcut.ts
@@ -56,21 +56,15 @@ function isTextInput(element: HTMLElement | null): boolean {
  * - Windows/Linux: Requires event.ctrlKey
  */
 function hasPlatformModifierKey(event: KeyboardEvent): boolean {
-  // Detect platform via user agent (Tauri sets this correctly)
-  const isMac = typeof navigator !== "undefined" && /Mac OS X/.test(navigator.userAgent)
-
-  if (isMac) {
-    return event.metaKey
-  } else {
-    return event.ctrlKey
-  }
+  // Reuse the platform class already set in main.tsx
+  const isMac = document.documentElement.classList.contains("platform-macos")
+  return isMac ? event.metaKey : event.ctrlKey
 }
 
 /**
  * Register global keyboard shortcuts.
  *
  * @param shortcuts - Map of key names to callback functions
- * @param deps - Optional dependency array to re-register shortcuts when values change
  *
  * Keys should be lowercase event.key values (e.g., "," for comma, "s" for S key).
  *
@@ -78,7 +72,7 @@ function hasPlatformModifierKey(event: KeyboardEvent): boolean {
  * - User is typing in a text input field
  * - User is composing text via IME (Chinese/Japanese/Korean input methods)
  */
-export function useGlobalShortcut(shortcuts: ShortcutMap, deps: unknown[] = []): void {
+export function useGlobalShortcut(shortcuts: ShortcutMap): void {
   const handleKeyDown = useCallback(
     (event: KeyboardEvent) => {
       // Suppress shortcuts when user is typing in a text input field
@@ -87,8 +81,8 @@ export function useGlobalShortcut(shortcuts: ShortcutMap, deps: unknown[] = []):
       }
 
       // Suppress shortcuts during IME composition (e.g., typing Chinese characters)
-      // keyCode 229 is the legacy "IME activity" signal
-      if (event.keyCode === 229) {
+      // Check both modern isComposing and legacy keyCode 229 signal (matches isImeComposing pattern)
+      if (event.isComposing || event.keyCode === 229) {
         return
       }
 
@@ -113,5 +107,5 @@ export function useGlobalShortcut(shortcuts: ShortcutMap, deps: unknown[] = []):
     return () => {
       window.removeEventListener("keydown", handleKeyDown)
     }
-  }, [handleKeyDown, ...deps])
+  }, [handleKeyDown])
 }

--- a/src/hooks/use-global-shortcut.ts
+++ b/src/hooks/use-global-shortcut.ts
@@ -1,0 +1,117 @@
+/**
+ * React hook for handling global keyboard shortcuts.
+ *
+ * Registers window-level keyboard event listeners that trigger callbacks
+ * when specific key combinations are pressed. Shortcuts are global within
+ * the application (work from any view) but are automatically suppressed when
+ * the user is typing in text input fields to avoid interference.
+ *
+ * @example
+ * ```ts
+ * useGlobalShortcut({
+ *   ",": () => setActiveView("settings"),
+ * })
+ * ```
+ *
+ * Platform conventions:
+ * - macOS: Cmd (⌘) + key
+ * - Windows/Linux: Ctrl + key
+ */
+
+import { useEffect, useCallback } from "react"
+
+export interface ShortcutMap {
+  [key: string]: () => void
+}
+
+/**
+ * Check if an element is a text input field that should suppress global shortcuts.
+ *
+ * Returns true for:
+ * - <input> elements (except checkboxes/radio/buttons)
+ * - <textarea> elements
+ * - Elements with contentEditable="true"
+ * - Elements with role="textbox"
+ */
+function isTextInput(element: HTMLElement | null): boolean {
+  if (!element) return false
+
+  const tag = element.tagName.toLowerCase()
+  if (tag === "textarea") return true
+  if (tag === "input") {
+    const inputType = (element as HTMLInputElement).type
+    // Allow shortcuts on checkboxes, radio buttons, and buttons
+    return !["checkbox", "radio", "submit", "button", "reset"].includes(inputType)
+  }
+  if (element.isContentEditable) return true
+  if (element.getAttribute("role") === "textbox") return true
+
+  return false
+}
+
+/**
+ * Check if the event has the appropriate modifier key for the current platform.
+ *
+ * - macOS: Requires event.metaKey (Cmd)
+ * - Windows/Linux: Requires event.ctrlKey
+ */
+function hasPlatformModifierKey(event: KeyboardEvent): boolean {
+  // Detect platform via user agent (Tauri sets this correctly)
+  const isMac = typeof navigator !== "undefined" && /Mac OS X/.test(navigator.userAgent)
+
+  if (isMac) {
+    return event.metaKey
+  } else {
+    return event.ctrlKey
+  }
+}
+
+/**
+ * Register global keyboard shortcuts.
+ *
+ * @param shortcuts - Map of key names to callback functions
+ * @param deps - Optional dependency array to re-register shortcuts when values change
+ *
+ * Keys should be lowercase event.key values (e.g., "," for comma, "s" for S key).
+ *
+ * Shortcuts are suppressed when:
+ * - User is typing in a text input field
+ * - User is composing text via IME (Chinese/Japanese/Korean input methods)
+ */
+export function useGlobalShortcut(shortcuts: ShortcutMap, deps: unknown[] = []): void {
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      // Suppress shortcuts when user is typing in a text input field
+      if (isTextInput(document.activeElement as HTMLElement | null)) {
+        return
+      }
+
+      // Suppress shortcuts during IME composition (e.g., typing Chinese characters)
+      // keyCode 229 is the legacy "IME activity" signal
+      if (event.keyCode === 229) {
+        return
+      }
+
+      // Check if the pressed key has a registered shortcut
+      const key = event.key.toLowerCase()
+      const callback = shortcuts[key]
+      if (!callback) return
+
+      // Require platform-appropriate modifier key (Cmd on macOS, Ctrl on others)
+      // This prevents triggering shortcuts during normal typing
+      if (!hasPlatformModifierKey(event)) return
+
+      // Prevent default browser behavior and execute the callback
+      event.preventDefault()
+      callback()
+    },
+    [shortcuts],
+  )
+
+  useEffect(() => {
+    window.addEventListener("keydown", handleKeyDown)
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown)
+    }
+  }, [handleKeyDown, ...deps])
+}

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -26,7 +26,7 @@
     "review": "Review",
     "skills": "Skills",
     "settings": "Settings",
-    "settingsShortcut": " (⌘,)",
+    "settingsShortcut": " (Cmd/Ctrl+,)",
     "switchProject": "Switch Project",
     "updateAvailable": "Update available",
     "updateAvailableSuffix": " · update"

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -26,6 +26,7 @@
     "review": "Review",
     "skills": "Skills",
     "settings": "Settings",
+    "settingsShortcut": " (⌘,)",
     "switchProject": "Switch Project",
     "updateAvailable": "Update available",
     "updateAvailableSuffix": " · update"

--- a/src/i18n/zh.json
+++ b/src/i18n/zh.json
@@ -26,7 +26,7 @@
     "review": "待审阅",
     "skills": "Skills",
     "settings": "设置",
-    "settingsShortcut": " (⌘,)",
+    "settingsShortcut": " (Cmd/Ctrl+,)",
     "switchProject": "切换项目",
     "updateAvailable": "有可用更新",
     "updateAvailableSuffix": " · 有更新"

--- a/src/i18n/zh.json
+++ b/src/i18n/zh.json
@@ -26,6 +26,7 @@
     "review": "待审阅",
     "skills": "Skills",
     "settings": "设置",
+    "settingsShortcut": " (⌘,)",
     "switchProject": "切换项目",
     "updateAvailable": "有可用更新",
     "updateAvailableSuffix": " · 有更新"


### PR DESCRIPTION
## What

macOS users expect Cmd+, to open Settings/Preferences. This PR adds platform-appropriate keyboard shortcuts (Cmd+, on macOS, Ctrl+, on Windows/Linux) to open the settings panel from any view in the application.

## Why

- Follows platform conventions — macOS users are conditioned to use Cmd+, for settings
- Global accessibility — works from any view (chat, wiki, sources, search, graph, etc.)
- Smart input suppression — automatically disabled when typing in text fields to avoid interference

## Changes

- Added reusable `useGlobalShortcut` hook for global keyboard event handling
- Integrated Cmd+,/Ctrl+, shortcut in App.tsx to open settings view
- Platform detection uses CSS class set by main.tsx instead of navigator.userAgent
- IME composition detection prevents accidental triggers during Chinese/Japanese input
- Updated Settings button tooltip to show shortcut hint
- Added i18n support (English/Chinese)

## Stats

- 5 files changed, 127 insertions(+), 15 deletions(-)
- Created `src/hooks/use-global-shortcut.ts` (117 lines)
- Type-safe, well-documented, follows existing patterns

## Testing

Manual testing performed:
- Cmd+, opens settings on macOS, Ctrl+, on Windows/Linux
- Shortcut does not trigger when typing in text input fields
- Shortcut suppressed during IME composition
- Tooltip displays shortcut hint for discoverability
