### PR TITLE
fix: don't mark deep research done when synthesis is empty

### DIFF
--- a/src/lib/deep-research.test.ts
+++ b/src/lib/deep-research.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest"
-import { collectResearchSources, makeDeepResearchFileName, noResearchSourcesTaskPatch, resolveReviewForSavedResearch } from "./deep-research"
+import { collectResearchSources, hasSubstantiveSynthesis, makeDeepResearchFileName, noResearchSourcesTaskPatch, resolveReviewForSavedResearch, stripSynthesisThinkBlocks } from "./deep-research"
 import type { SearchApiConfig } from "@/stores/wiki-store"
 import type { WebSearchResult } from "./web-search"
 import { useWikiStore } from "@/stores/wiki-store"
@@ -69,6 +69,33 @@ describe("noResearchSourcesTaskPatch", () => {
   })
 })
 
+describe("hasSubstantiveSynthesis", () => {
+  it("treats non-empty prose as substantive", () => {
+    expect(hasSubstantiveSynthesis("A real overview of the topic.")).toBe(true)
+  })
+
+  it("rejects empty or whitespace-only output", () => {
+    expect(hasSubstantiveSynthesis("")).toBe(false)
+    expect(hasSubstantiveSynthesis("   \n\n  ")).toBe(false)
+  })
+
+  it("rejects a thinking-only response with no visible content", () => {
+    expect(hasSubstantiveSynthesis("<think>let me plan the answer</think>")).toBe(false)
+    expect(hasSubstantiveSynthesis("<thinking>reasoning without an answer")).toBe(false)
+  })
+
+  it("keeps content that follows a thinking block", () => {
+    expect(hasSubstantiveSynthesis("<think>plan</think>\n\nFinal answer.")).toBe(true)
+  })
+})
+
+describe("stripSynthesisThinkBlocks", () => {
+  it("removes closed and unclosed thinking blocks and leading whitespace", () => {
+    expect(stripSynthesisThinkBlocks("<think>plan</think>\n\n## Overview\ntext")).toBe("## Overview\ntext")
+    expect(stripSynthesisThinkBlocks("<thinking>never closed")).toBe("")
+  })
+})
+
 describe("review-linked research", () => {
   const review: ReviewItem = {
     id: "review-1",
@@ -106,6 +133,31 @@ describe("review-linked research", () => {
       resolved: true,
       resolvedAction: "Research saved: wiki/queries/research-topic.md",
     })
+  })
+
+  it("does not resolve the review when the saved synthesis is empty", () => {
+    useWikiStore.setState({ project: { id: "p1", name: "Project", path: "/project" } })
+    useReviewStore.setState({ items: [review] })
+    useResearchStore.setState({
+      tasks: [{
+        id: "research-1",
+        topic: "topic",
+        sourceReviewId: review.id,
+        status: "done",
+        webResults: [],
+        synthesis: "<think>gave up</think>",
+        savedPath: "wiki/queries/research-topic.md",
+        error: null,
+        createdAt: 1,
+      }],
+    })
+
+    expect(resolveReviewForSavedResearch(
+      "/project",
+      "research-1",
+      "wiki/queries/research-topic.md",
+    )).toBe(false)
+    expect(useReviewStore.getState().items[0].resolved).toBe(false)
   })
 
   it("does not resolve another project's review", () => {

--- a/src/lib/deep-research.ts
+++ b/src/lib/deep-research.ts
@@ -49,6 +49,29 @@ export function noResearchSourcesTaskPatch(sourceErrors: string[]): {
   }
 }
 
+/**
+ * Remove <think>/<thinking> reasoning blocks (including an unclosed trailing
+ * block) from an LLM synthesis, matching exactly what is written to the wiki
+ * page before the References section is appended.
+ */
+export function stripSynthesisThinkBlocks(raw: string): string {
+  return raw
+    .replace(/<think(?:ing)?>\s*[\s\S]*?<\/think(?:ing)?>\s*/gi, "")
+    .replace(/<think(?:ing)?>\s*[\s\S]*$/gi, "") // unclosed thinking block
+    .trimStart()
+}
+
+/**
+ * A synthesis is only substantive if it still carries real content once the
+ * reasoning blocks are stripped. An empty result (dropped stream,
+ * thinking-only output, or truncation) would otherwise be saved as a
+ * References-only shell and wrongly mark the task done + resolve the linked
+ * review. See issue #637.
+ */
+export function hasSubstantiveSynthesis(synthesis: string): boolean {
+  return stripSynthesisThinkBlocks(synthesis).trim().length > 0
+}
+
 export function makeDeepResearchFileName(topic: string, now: Date = new Date()): {
   fileName: string
   date: string
@@ -94,7 +117,8 @@ export function resolveReviewForSavedResearch(
   if (
     !task?.sourceReviewId ||
     task.status !== "done" ||
-    task.savedPath !== savedPath
+    task.savedPath !== savedPath ||
+    !hasSubstantiveSynthesis(task.synthesis)
   ) return false
   const review = useReviewStore.getState().items.find((item) => item.id === task.sourceReviewId)
   if (!review || review.resolved) return false
@@ -318,10 +342,21 @@ async function executeResearch(
       .join("\n")
 
     // Strip <think>/<thinking> blocks before saving
-    const cleanedSynthesis = accumulated
-      .replace(/<think(?:ing)?>\s*[\s\S]*?<\/think(?:ing)?>\s*/gi, "")
-      .replace(/<think(?:ing)?>\s*[\s\S]*$/gi, "") // unclosed thinking block
-      .trimStart()
+    const cleanedSynthesis = stripSynthesisThinkBlocks(accumulated)
+
+    // If the model returned no usable content (empty stream, thinking-only
+    // output, or truncation), do not save a References-only shell, mark the
+    // task done, or resolve the linked review. Surface the failure so the user
+    // can retry and the review item stays open. See issue #637.
+    if (!hasSubstantiveSynthesis(cleanedSynthesis)) {
+      updateTaskIfActive(pp, taskId, {
+        status: "error",
+        synthesis: cleanedSynthesis,
+        error: "Research produced no content to save — the model may have hit a timeout or token limit. Please retry.",
+      })
+      if (isActiveProjectPath(pp)) onTaskFinished(pp, llmConfig, searchConfig)
+      return
+    }
 
     const pageContent = [
       "---",


### PR DESCRIPTION
Fixes #637

## Problem
Deep research saved the wiki page, set the task to `done`, and resolved the linked review item purely on reaching a saved state. When synthesis failed or produced no visible content (dropped stream, `<think>`-only output, or truncation), the page was written as a References-only shell and the review was resolved as if the research had succeeded — so users could not tell a successful run from an empty one.

## Fix
- Extract `stripSynthesisThinkBlocks` / `hasSubstantiveSynthesis` helpers so the emptiness check and the wiki-page cleanup share one definition.
- Before saving, if the synthesis is empty after stripping reasoning blocks, mark the task `error` (so the user can retry) and skip the write — leaving the linked review unresolved, matching the intent of the #614 fix.
- `resolveReviewForSavedResearch` now also requires a substantive synthesis, as defense-in-depth for any direct callers.

## Tests
Added unit tests for the helpers and a References-only (`<think>`-only) case that must not resolve the review.

- `src/lib/deep-research.test.ts`: 20 passing
- `tsc --build`: clean
