### PR TITLE
fix: use CJK filenames for CJK pages under the default auto language

### DIFF
--- a/src/lib/ingest-parse.test.ts
+++ b/src/lib/ingest-parse.test.ts
@@ -621,6 +621,49 @@ describe("rewriteIngestPathFromTitleForTargetLanguage", () => {
     ).toBe("wiki/concepts/反硝化除磷技术.md")
   })
 
+  it("renames CJK pages under the default auto language by detecting the content language", () => {
+    const content = [
+      "---",
+      "type: concept",
+      "title: 反硝化除磷技术",
+      "created: 2026-06-18",
+      "---",
+      "",
+      "# 反硝化除磷技术",
+      "",
+      "这是一段中文正文，用于检测语言。",
+    ].join("\n")
+
+    expect(
+      rewriteIngestPathFromTitleForTargetLanguage(
+        "wiki/concepts/denitrifying-phosphorus-removal.md",
+        content,
+        "auto",
+      ),
+    ).toBe("wiki/concepts/反硝化除磷技术.md")
+  })
+
+  it("leaves English pages untouched under the default auto language", () => {
+    const content = [
+      "---",
+      "type: concept",
+      "title: Denitrifying phosphorus removal",
+      "---",
+      "",
+      "# Denitrifying phosphorus removal",
+      "",
+      "This is an English body used for language detection.",
+    ].join("\n")
+
+    expect(
+      rewriteIngestPathFromTitleForTargetLanguage(
+        "wiki/concepts/denitrifying-phosphorus-removal.md",
+        content,
+        "auto",
+      ),
+    ).toBe("wiki/concepts/denitrifying-phosphorus-removal.md")
+  })
+
   it("does not rewrite source summaries or aggregate pages", () => {
     const content = "---\ntitle: 反硝化除磷技术\n---\n# 反硝化除磷技术"
 

--- a/src/lib/ingest.ts
+++ b/src/lib/ingest.ts
@@ -1461,7 +1461,15 @@ export function rewriteIngestPathFromTitleForTargetLanguage(
   content: string,
   targetLang: string | undefined,
 ): string {
-  if (!targetLang || targetLang === "auto" || !CJK_OUTPUT_LANGUAGES.has(targetLang)) {
+  // "auto" (the default output language) means "follow the source", so resolve
+  // it from the page content. Without this, auto short-circuited here and
+  // Chinese/Japanese/Korean pages kept ASCII/pinyin filenames even though
+  // their titles and content were CJK, leaving the vault hard to browse.
+  // See issue #585.
+  const effectiveLang = !targetLang || targetLang === "auto"
+    ? detectLanguage(content)
+    : targetLang
+  if (!CJK_OUTPUT_LANGUAGES.has(effectiveLang)) {
     return relativePath
   }
   if (
@@ -2231,7 +2239,7 @@ export function buildGenerationPrompt(
     "- Preserve subject boundaries: when a source discusses multiple entities/models/products/methods, keep claims, evaluations, limitations, benchmark results, and recommendations attached to the exact subject they describe.",
     "- Do not merge or generalize a claim about one subject into another subject's page solely because they share terms (for example context window size, benchmark name, dataset, architecture, or feature name).",
     "- If a page needs to mention another subject for comparison, write it explicitly as a comparison and cite which source/frontmatter `sources` entry supports that statement.",
-    "- Use kebab-case filenames",
+    "- Use kebab-case for Latin-script filenames; for Chinese/Japanese/Korean titles keep the CJK characters (do NOT romanize to pinyin/romaji or translate to English)",
     "- Derive filenames from the page title in the mandatory output language, but short proper nouns and technical identifiers take precedence: preserve names such as OpenAI, GPT-5, Transformer, CLIP, ImageNet, PyTorch, CUDA, GitHub, arXiv, React, LanceDB, AnyTXT, MinerU, model names, dataset names, tool names, and code identifiers in their standard original form. Do not put raw URLs, citation strings, or full paper titles directly into file paths; convert surrounding descriptive prose to a safe readable title. For Chinese/Japanese/Korean prose titles, keep readable CJK characters in the filename instead of translating the slug to English.",
     "- Follow the analysis recommendations on what to emphasize",
     "- If the analysis found connections to existing pages, add cross-references",


### PR DESCRIPTION
Fixes #585
Fixes #132

## Problem
With Output Language on the default `auto`, AI content was generated in the source language (e.g. Chinese) but wiki folder/page filenames stayed ASCII — English or romanized pinyin. `rewriteIngestPathFromTitleForTargetLanguage()` early-returned whenever the target language was `auto`, so the CJK-title rename path was never reached. The result was an unbrowsable vault of pinyin/English filenames for CJK content (#585), with the pinyin-vs-CJK inconsistency reported in #132.

## Fix
- Resolve `auto` to the page's detected content language before the CJK check, so CJK pages get CJK filenames while explicit non-CJK languages keep their current behavior.
- Scope the "kebab-case filenames" generation-prompt rule to Latin-script titles — it directly contradicted the adjacent CJK rule and pushed the model toward pinyin.

## Tests
Added cases: `auto` + CJK content renames to the CJK title; `auto` + English content is left unchanged.

- `src/lib/ingest-parse.test.ts`: 48 passing
- `tsc --build`: clean
