### PR TITLE
fix: preserve structured source data (DDL, schemas, tables) during ingest

### DIFF
--- a/src/lib/ingest-parse.test.ts
+++ b/src/lib/ingest-parse.test.ts
@@ -596,6 +596,13 @@ describe("generated ingest dates", () => {
     expect(prompt).toContain("Use this exact date")
     expect(prompt).not.toContain("created: 2026-04-29")
   })
+
+  it("instructs the model to preserve structured source data verbatim", () => {
+    const prompt = buildGenerationPrompt("", "", "", "schema.sql")
+
+    expect(prompt).toContain("Preserve structured source data verbatim")
+    expect(prompt).toContain("DDL")
+  })
 })
 
 describe("rewriteIngestPathFromTitleForTargetLanguage", () => {

--- a/src/lib/ingest.ts
+++ b/src/lib/ingest.ts
@@ -2233,6 +2233,7 @@ export function buildGenerationPrompt(
     "- If a page needs to mention another subject for comparison, write it explicitly as a comparison and cite which source/frontmatter `sources` entry supports that statement.",
     "- Use kebab-case filenames",
     "- Derive filenames from the page title in the mandatory output language, but short proper nouns and technical identifiers take precedence: preserve names such as OpenAI, GPT-5, Transformer, CLIP, ImageNet, PyTorch, CUDA, GitHub, arXiv, React, LanceDB, AnyTXT, MinerU, model names, dataset names, tool names, and code identifiers in their standard original form. Do not put raw URLs, citation strings, or full paper titles directly into file paths; convert surrounding descriptive prose to a safe readable title. For Chinese/Japanese/Korean prose titles, keep readable CJK characters in the filename instead of translating the slug to English.",
+    "- Preserve structured source data verbatim: copy SQL DDL / CREATE TABLE statements, schema definitions, API signatures, configuration, and tabular data into fenced code blocks (or Markdown tables) in the source summary page instead of paraphrasing them. Exact column names, types, constraints, primary/foreign keys, and indexes must survive ingest — a prose-only summary that drops them loses the structure the user imported the source to keep.",
     "- Follow the analysis recommendations on what to emphasize",
     "- If the analysis found connections to existing pages, add cross-references",
     "",


### PR DESCRIPTION
Fixes #507

## Problem
Importing SQL DDL, table schemas, API signatures, or config yielded only a prose summary — exact column names, types, constraints, primary/foreign keys, and indexes were lost because the two-stage summarize → generate pipeline compressed the structure at generation time. Users importing a schema got a description of it rather than the schema.

## Fix
Add a generation-prompt rule instructing the model to copy structured source data verbatim into fenced code blocks or Markdown tables in the source summary page instead of paraphrasing it.

## Note
This is a prompt-level change, so the effect is model-dependent. The added test asserts the instruction is present in the generation prompt.

- `src/lib/ingest-parse.test.ts`: 47 passing
- `tsc --build`: clean
