### PR TITLE
ci: build and release macOS Intel (x86_64) bundle

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,13 @@ jobs:
           - platform: macos-latest
             args: '--target aarch64-apple-darwin'
             rust_target: aarch64-apple-darwin
+          # macos-13 is the last GitHub-hosted Intel (x86_64) macOS
+          # runner, so this row is a NATIVE x86_64 build rather than a
+          # cross-compile from Apple Silicon — the same way we validate
+          # the bundle locally. Produces the *_x64.dmg for Intel Macs.
+          - platform: macos-13
+            args: '--target x86_64-apple-darwin'
+            rust_target: x86_64-apple-darwin
           - platform: ubuntu-22.04
             args: ''
             rust_target: ''
@@ -88,6 +95,18 @@ jobs:
         run: |
           cp src-tauri/pdfium/libpdfium-arm64.so src-tauri/pdfium/libpdfium.so
           file src-tauri/pdfium/libpdfium.so
+
+      # The committed libpdfium.dylib is arm64, which macos-latest
+      # bundles as-is. The Intel runner instead swaps in the x86_64
+      # dylib so the framework baked into the *_x64.dmg matches the
+      # x86_64 app — mirror of the Ubuntu ARM swap above. Runs AFTER
+      # the checksum step so SHA256SUMS still verifies the committed
+      # (arm64) libpdfium.dylib before it is replaced.
+      - name: Use x86_64 pdfium binary (macOS Intel only)
+        if: matrix.platform == 'macos-13'
+        run: |
+          cp src-tauri/pdfium/libpdfium-x86_64.dylib src-tauri/pdfium/libpdfium.dylib
+          file src-tauri/pdfium/libpdfium.dylib
 
       - name: Install protoc (Windows)
         if: matrix.platform == 'windows-latest'


### PR DESCRIPTION
## Problem

The `Build & Release` matrix only builds an Apple Silicon (`aarch64-apple-darwin`) macOS bundle, so every release has shipped **no Intel `.dmg`** — even though `README.md` already advertises _"macOS (ARM + Intel)"_ and _".dmg (Apple Silicon + Intel)"_. Intel Mac users have had nothing to download.

## Change

Add a second macOS matrix row that produces a **native x86_64** build:

- Runs on `macos-13`, the last GitHub-hosted **Intel** runner, so it's a native build (not a cross-compile from Apple Silicon), matching how the bundle was validated locally.
- Before bundling, swaps the committed arm64 `libpdfium.dylib` for the already-committed `libpdfium-x86_64.dylib`, mirroring the existing **Use ARM64 pdfium binary (Ubuntu ARM only)** step. This is required because `tauri.macos.conf.json` always bundles `pdfium/libpdfium.dylib`, whose committed content is arm64 — without the swap an x86_64 app would ship an arm64 pdfium and fail to load PDFs at runtime.
- The swap runs **after** the `Verify PDFium binary checksums` step, so `SHA256SUMS` still validates the committed (arm64) `libpdfium.dylib`.

The existing `Install protoc (macOS)` step already matches `macos-*`, so the new row gets protoc for free. Tauri names the two artifacts distinctly (`*_aarch64.dmg` vs `*_x64.dmg`), so there is no release-asset collision. No Tauri updater is configured (the app checks the GitHub Releases API directly), so a second macOS artifact needs no `latest.json`/signature changes.

## Verification

Built locally on an Intel Mac with `npm run tauri build -- --target x86_64-apple-darwin` (with the pdfium swap applied):

- Bundle: `LLM Wiki_0.6.7_x64.dmg`
- `Contents/MacOS/llm-wiki` → `Mach-O 64-bit executable x86_64`
- `Contents/Frameworks/libpdfium.dylib` → `Mach-O 64-bit dynamically linked shared library x86_64`

🤖 Generated with [Claude Code](https://claude.com/claude-code)