### PR TITLE
fix: wire missing i18n strings, live Codex model discovery

### DIFF
--- a/src/components/layout/knowledge-tree.tsx
+++ b/src/components/layout/knowledge-tree.tsx
@@ -128,7 +128,7 @@ export function KnowledgeTree() {
   if (!project) {
     return (
       <div className="flex h-full items-center justify-center p-4 text-sm text-muted-foreground">
-        No project open
+        {t("fileTree.noProject", { defaultValue: "No project open" })}
       </div>
     )
   }

--- a/src/components/layout/preview-panel.tsx
+++ b/src/components/layout/preview-panel.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useCallback, useRef } from "react"
+import { useTranslation } from "react-i18next"
 import { X } from "lucide-react"
 import { useWikiStore } from "@/stores/wiki-store"
 import { readFile, writeFile } from "@/commands/fs"
@@ -8,6 +9,7 @@ import { FilePreview } from "@/components/editor/file-preview"
 import { getFileName } from "@/lib/path-utils"
 
 export function PreviewPanel() {
+  const { t } = useTranslation()
   const selectedFile = useWikiStore((s) => s.selectedFile)
   const fileContent = useWikiStore((s) => s.fileContent)
   const previewContentPath = useWikiStore((s) => s.previewContentPath)
@@ -94,7 +96,7 @@ export function PreviewPanel() {
   if (!selectedFile) {
     return (
       <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
-        Select a file to preview
+        {t("preview.selectFile", { defaultValue: "Select a file to preview" })}
       </div>
     )
   }

--- a/src/components/settings/llm-presets.ts
+++ b/src/components/settings/llm-presets.ts
@@ -86,17 +86,12 @@ export const LLM_PRESETS: LlmPreset[] = [
     label: "Claude Code CLI (local)",
     hint: "Uses the local `claude` binary — no API key needed",
     provider: "claude-code",
-    defaultModel: "claude-sonnet-4-6",
-    // Mirrors anthropic preset; the CLI forwards to the same Anthropic
-    // backend, so model ids are identical. Users with a subscription
-    // can pick Opus/Sonnet/Haiku here without paying an API key bill.
-    suggestedModels: [
-      "claude-opus-4-7",
-      "claude-opus-4-6",
-      "claude-sonnet-4-6",
-      "claude-sonnet-4-5-20250929",
-      "claude-haiku-4-5-20251001",
-    ],
+    defaultModel: "sonnet",
+    // claude-code-cli resolves bare tier aliases (opus/sonnet/fable/haiku) to
+    // whatever is currently "latest" for that tier by itself (confirmed via
+    // `claude --help`) — no dated model id to go stale, no discovery script
+    // needed. Mirrors anthropic preset naming only for the pinned fallback.
+    suggestedModels: ["sonnet", "opus", "fable", "haiku"],
     suggestedContextSize: 200000,
   },
   {
@@ -104,13 +99,11 @@ export const LLM_PRESETS: LlmPreset[] = [
     label: "Codex CLI (local)",
     hint: "Uses the local `codex` binary — no API key needed",
     provider: "codex-cli",
-    defaultModel: "gpt-5.4-mini",
+    defaultModel: "gpt-5.6-terra",
     suggestedModels: [
-      "gpt-5.4-mini",
-      "gpt-5.4",
-      "gpt-5.3-codex",
-      "gpt-5.3-codex-spark",
-      "gpt-5.2",
+      "gpt-5.6-terra",
+      "gpt-5.6-sol",
+      "gpt-5.6-luna",
     ],
     suggestedContextSize: 200000,
   },

--- a/src/components/settings/sections/llm-provider-section.tsx
+++ b/src/components/settings/sections/llm-provider-section.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react"
+import { useEffect, useMemo, useRef, useState } from "react"
 import { ChevronDown, ChevronRight, AlertCircle, CheckCircle2, Loader2, XCircle, Plus, Trash2 } from "lucide-react"
 import { useTranslation } from "react-i18next"
 import { invoke } from "@tauri-apps/api/core"
@@ -15,6 +15,7 @@ import { testLlmConnection, testLlmFunction, type ProviderTestResult } from "@/l
 import { projectLlmProfile, resolveProjectLlmConfig } from "@/lib/llm-task-routing"
 import { saveProjectLlmOverride } from "@/lib/project-store"
 import { normalizeReasoningForProvider, resolveReasoningCapabilities } from "@/lib/reasoning-capabilities"
+import { resolveCodexModels } from "@/lib/resolve-codex-models"
 
 const HTTP_HEADER_NAME_RE = /^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/
 
@@ -387,6 +388,37 @@ function PresetRow({
   const [headersText, setHeadersText] = useState(() => llmHeadersToText(ov.customHeaders))
   const isLocalCliProvider = preset.provider === "claude-code" || preset.provider === "codex-cli"
   const [testState, setTestState] = useState<ProviderTestState>({ kind: "idle" })
+
+  // Codex CLI has no bare tier alias (unlike claude-code-cli's opus/sonnet/
+  // fable), so `preset.suggestedModels` is a snapshot that goes stale the
+  // moment OpenAI ships a new model family. Fetch the live list once per
+  // session and, if the user never customized this field, upgrade the
+  // stored default so the picker doesn't silently keep pointing at a
+  // retired model. Any fetch failure leaves the static preset untouched.
+  const [liveCodexModels, setLiveCodexModels] = useState<{ models: string[]; recommended: string | null } | null>(null)
+  const appliedLiveDefaultRef = useRef(false)
+  useEffect(() => {
+    if (preset.provider !== "codex-cli") return
+    let cancelled = false
+    resolveCodexModels().then((info) => {
+      if (!cancelled && info) setLiveCodexModels(info)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [preset.provider])
+  useEffect(() => {
+    if (preset.provider !== "codex-cli" || !liveCodexModels?.recommended) return
+    if (appliedLiveDefaultRef.current) return
+    if (!ov.model && liveCodexModels.recommended !== preset.defaultModel) {
+      appliedLiveDefaultRef.current = true
+      onChange({ model: liveCodexModels.recommended })
+    }
+  }, [preset.provider, liveCodexModels, ov.model, preset.defaultModel, onChange])
+  const modelSuggestions =
+    preset.provider === "codex-cli" && liveCodexModels?.models.length
+      ? liveCodexModels.models
+      : preset.suggestedModels ?? []
   const hasConfig = !!apiKey || !!ov.baseUrl || !!ov.model || !!ov.azureApiVersion || !!ov.azureModelFamily
     || Object.keys(ov.customHeaders ?? {}).length > 0 || ov.streamingEnabled === false
   // Local CLI providers authenticate via their own existing login state
@@ -676,7 +708,7 @@ function PresetRow({
             </Label>
             <ModelPicker
               value={model}
-              suggestions={preset.suggestedModels ?? []}
+              suggestions={modelSuggestions}
               placeholder={preset.defaultModel ?? "e.g. gpt-4o"}
               onChange={(v) => onChange({ model: v })}
             />

--- a/src/lib/resolve-codex-models.ts
+++ b/src/lib/resolve-codex-models.ts
@@ -1,0 +1,73 @@
+// Live discovery of currently-valid Codex CLI model ids. `codex exec --model`
+// accepts a specific dated/named id (unlike claude-code-cli, which resolves
+// bare tier aliases like "sonnet" on its own) — the hardcoded list in
+// llm-presets.ts goes stale whenever OpenAI ships a new model family. This
+// fetches OpenAI's own live model guide and extracts whatever family is
+// current, so the Settings picker for Codex CLI never points at a retired
+// model. Best-effort: any failure (offline, page format changed) falls back
+// to the static preset list untouched — this must never break the UI.
+
+const LATEST_MODEL_DOC_URL = "https://developers.openai.com/api/docs/guides/latest-model.md"
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000 // 24h — this is a Settings picker, not a hot path
+
+export interface CodexModelInfo {
+  models: string[]
+  recommended: string | null
+}
+
+let cached: { info: CodexModelInfo; fetchedAt: number } | null = null
+let inFlight: Promise<CodexModelInfo | null> | null = null
+
+const BALANCED_PATTERNS = [
+  /`([a-z0-9.\-]+)`\s+for\s+a\s+balance\s+of\s+intelligence\s+and\s+cost/i,
+  /`([a-z0-9.\-]+)`[^`]{0,80}[Bb]alanced\s+quality,\s+latency,\s+and\s+cost/,
+]
+
+function parseModelIds(text: string): string[] {
+  const ids = new Set<string>()
+  const re = /`(gpt-[a-z0-9.\-]+)`/gi
+  let m: RegExpExecArray | null
+  while ((m = re.exec(text)) !== null) {
+    // The bare family alias (e.g. `gpt-5.6`) routes to the flagship model —
+    // useful as a fact, not as a distinct picker entry alongside its target.
+    if (/^gpt-\d+(\.\d+)?$/.test(m[1])) continue
+    ids.add(m[1])
+  }
+  return [...ids]
+}
+
+function parseRecommended(text: string): string | null {
+  for (const pattern of BALANCED_PATTERNS) {
+    const m = pattern.exec(text)
+    if (m) return m[1]
+  }
+  return null
+}
+
+async function fetchLive(): Promise<CodexModelInfo | null> {
+  try {
+    const res = await fetch(LATEST_MODEL_DOC_URL, { headers: { accept: "text/markdown,text/plain,*/*" } })
+    if (!res.ok) return null
+    const text = await res.text()
+    const models = parseModelIds(text)
+    if (models.length === 0) return null
+    const recommended = parseRecommended(text)
+    return { models, recommended: recommended && models.includes(recommended) ? recommended : models[0] }
+  } catch {
+    return null
+  }
+}
+
+/** Returns cached/live Codex model info, or null if unavailable (caller should keep its static fallback). Never throws. */
+export async function resolveCodexModels(): Promise<CodexModelInfo | null> {
+  const now = Date.now()
+  if (cached && now - cached.fetchedAt < CACHE_TTL_MS) return cached.info
+  if (inFlight) return inFlight
+
+  inFlight = fetchLive().then((info) => {
+    inFlight = null
+    if (info) cached = { info, fetchedAt: Date.now() }
+    return info
+  })
+  return inFlight
+}


### PR DESCRIPTION
## What

Two small independent fixes found while running a headless production deploy:

**1. Two hardcoded strings never went through i18n**, so they stayed English regardless of the active language even though matching keys already existed in every locale file:
- `preview-panel.tsx`: "Select a file to preview" → now uses `preview.selectFile`
- `knowledge-tree.tsx`: "No project open" → now uses `fileTree.noProject`

**2. `llm-presets.ts` suggested/default models for `codex-cli` and `claude-code-cli` pointed at retired model ids** (`gpt-5.4-mini` family, `claude-*-4.x` family) — picking any of them from the Settings dropdown would fail.

For `claude-code-cli`, the fix is permanent: `claude-code-cli` resolves bare tier aliases (`sonnet`/`opus`/`fable`/`haiku`) to whatever is current for that tier on its own (confirmed via `claude --help`), so the preset now uses those instead of a dated id — nothing to update again when Anthropic ships a new model.

`codex-cli` has no equivalent alias mechanism (`gpt-5.6-terra` etc. are specific ids, not tiers), so `resolve-codex-models.ts` (new) fetches OpenAI's own live model guide once per session and populates the Settings picker with whatever family is currently documented there, upgrading the stored default to the live-recommended "balanced" model if the user never customized the field. Any fetch failure (offline, page format changed) falls back to the static preset untouched — this never blocks or breaks the picker.

## Why

Ran into both while deploying a client instance today: the app defaulted to English for a client who needed Italian (the two strings above were the only ones actually broken — `it.json` itself was already 100% translated), and the Codex model dropdown only offered models that no longer exist.

## Testing

- `npm run typecheck` — clean
- Verified live in a running headless deploy: Settings → Codex CLI now shows the current `gpt-5.6-sol` / `gpt-5.6-terra` / `gpt-5.6-luna` chips instead of the retired list, with the balanced one pre-selected.