### PR TITLE
fix: caption images in the configured output language

### DIFF
--- a/src/lib/image-caption-pipeline.test.ts
+++ b/src/lib/image-caption-pipeline.test.ts
@@ -116,6 +116,23 @@ describe("captionMarkdownImages", () => {
     })
   })
 
+  it("forwards outputLanguage to captionImage", async () => {
+    mockReadBase64.mockResolvedValue({ base64: "AAAA", mimeType: "image/png" })
+    mockCaption.mockResolvedValue("ein rotes Quadrat")
+
+    await captionMarkdownImages("/proj", "![](/abs/img-1.png)", cfg, {
+      outputLanguage: "German",
+    })
+
+    expect(mockCaption).toHaveBeenCalledWith(
+      "AAAA",
+      "image/png",
+      cfg,
+      undefined,
+      expect.objectContaining({ outputLanguage: "German" }),
+    )
+  })
+
   it("dedupes by SHA-256: two refs to the same bytes → one LLM call, both rewritten", async () => {
     // Both URLs return the same base64 bytes — same hash → single
     // caption call, both alt-texts populated.

--- a/src/lib/image-caption-pipeline.ts
+++ b/src/lib/image-caption-pipeline.ts
@@ -260,6 +260,8 @@ export interface CaptionPipelineOptions {
    * passes the user's chosen value.
    */
   concurrency?: number
+  /** Language requested for factual captions (for example, "German"). */
+  outputLanguage?: string
   /**
    * Progress hook fired after each image finishes (ok or failed),
    * with running counts. Used by ingest to update the activity
@@ -401,7 +403,11 @@ export async function captionMarkdownImages(
         bytes.mimeType,
         llmConfig,
         options?.signal,
-        { contextBefore: before, contextAfter: after },
+        {
+          contextBefore: before,
+          contextAfter: after,
+          outputLanguage: options?.outputLanguage,
+        },
       )
       cache[hash] = {
         caption,

--- a/src/lib/ingest.ts
+++ b/src/lib/ingest.ts
@@ -324,9 +324,9 @@ function resolveCaptionConfig(
     maxContextSize: mainLlm.maxContextSize,
   }
 }
-import { buildLanguageDirective } from "@/lib/output-language"
+import { buildLanguageDirective, getOutputLanguage } from "@/lib/output-language"
 import { detectLanguage } from "@/lib/detect-language"
-import { sameScriptFamily } from "@/lib/language-metadata"
+import { getLanguagePromptName, sameScriptFamily } from "@/lib/language-metadata"
 import {
   loadProjectWikiSchemaRouting,
   validateWikiPageRouting,
@@ -812,6 +812,7 @@ async function autoIngestImpl(
                     isSavedImagePromptUrl(pp, sourceSummarySlug, url),
                   urlToAbsPath: (url) => promptImageUrlToAbs(pp, url),
                   concurrency: mmCfg.concurrency,
+                  outputLanguage: getLanguagePromptName(getOutputLanguage(sourceContent)),
                   onProgress: (done, total) =>
                     activity.updateItem(activityId, {
                       detail: `Captioning images... ${done}/${total}`,
@@ -961,6 +962,7 @@ async function autoIngestImpl(
           shouldCaption: (url) => url.startsWith(ourMediaPrefix) || isSavedImagePromptUrl(pp, sourceSummarySlug, url),
           urlToAbsPath: (url) => promptImageUrlToAbs(pp, url),
           concurrency: mmCfg.concurrency,
+          outputLanguage: getLanguagePromptName(getOutputLanguage(enrichedSourceContent)),
           onProgress: (done, total) =>
             activity.updateItem(activityId, {
               detail: `Captioning images... ${done}/${total}`,

--- a/src/lib/vision-caption.test.ts
+++ b/src/lib/vision-caption.test.ts
@@ -173,6 +173,46 @@ describe("captionImage", () => {
     expect(CAPTION_PROMPT).toMatch(/no markdown/)
   })
 
+  it("adds the configured caption language while preserving visible source text", async () => {
+    await captionImage(TINY_B64, "image/png", cfg, undefined, {
+      outputLanguage: "German",
+    })
+    const messages = mockStreamChat.mock.calls[0]?.[1] as ChatMessage[]
+    const textBlock = Array.isArray(messages?.[0]?.content)
+      ? messages[0].content[0]
+      : null
+    expect(textBlock).toMatchObject({ type: "text" })
+    if (!textBlock || textBlock.type !== "text") {
+      throw new Error("expected text prompt block")
+    }
+    expect(textBlock.text).toContain("Write the description in German")
+    expect(textBlock.text).toContain("Preserve visible text verbatim")
+  })
+
+  it("appends the language instruction to the context-aware prompt too", async () => {
+    await captionImage(TINY_B64, "image/png", cfg, undefined, {
+      contextBefore: "Figure 3: Q2 revenue chart",
+      outputLanguage: "German",
+    })
+    const messages = mockStreamChat.mock.calls[0]?.[1] as ChatMessage[]
+    const blocks = messages[0].content as Array<{ type: string; text?: string }>
+    const promptText = blocks[0].text ?? ""
+    expect(promptText).toContain("Figure 3: Q2 revenue chart")
+    expect(promptText).toContain("Write the description in German")
+  })
+
+  it('treats "auto" (and absent) outputLanguage as no language directive', async () => {
+    await captionImage(TINY_B64, "image/png", cfg, undefined, {
+      outputLanguage: "auto",
+    })
+    const messages = mockStreamChat.mock.calls[0]?.[1] as ChatMessage[]
+    const blocks = messages[0].content as Array<{ type: string; text?: string }>
+    // "auto" means "follow the source" — resolving it is the caller's
+    // job (ingest resolves via detectLanguage), so here it must fall
+    // back to the unmodified prompt rather than "Write in auto".
+    expect(blocks[0].text).toBe(CAPTION_PROMPT)
+  })
+
   it("uses the no-context prompt when context is empty / whitespace-only", async () => {
     mockStreamChat.mockImplementation(async (_c, _m, cb) => {
       cb.onDone()

--- a/src/lib/vision-caption.ts
+++ b/src/lib/vision-caption.ts
@@ -69,6 +69,12 @@ import { streamChat, type ChatMessage } from "./llm-client"
 export const CAPTION_PROMPT =
   "Describe this image factually for a knowledge-base index. Include: any visible text verbatim, chart axes and values, diagram structure (boxes/arrows/labels), key visual elements. Do NOT speculate or editorialize. 2 to 4 sentences. Output plain text only — no markdown, no preamble."
 
+function captionLanguageInstruction(outputLanguage?: string): string {
+  const language = outputLanguage?.trim()
+  if (!language || language.toLowerCase() === "auto") return ""
+  return `Write the description in ${language}. Preserve visible text verbatim in its original language.`
+}
+
 /**
  * Build the prompt that gets used WHEN the caller supplies
  * surrounding text. Wraps the no-context prompt with an explicit
@@ -83,6 +89,7 @@ export const CAPTION_PROMPT =
 export function buildCaptionPromptWithContext(
   before: string,
   after: string,
+  outputLanguage?: string,
 ): string {
   const fmt = (s: string) => {
     const trimmed = s.trim()
@@ -100,7 +107,8 @@ export function buildCaptionPromptWithContext(
     "This surrounding text MAY help describe the image — for example, a sentence like \"Figure 3: Q2 revenue chart\" tells you what the chart actually plots. It MAY ALSO be unrelated body text that just happens to flank the image. Use your judgment: if a passage clearly identifies, references, or labels the image, anchor your caption to it; if not, ignore the surrounding text and describe what you see.",
     "",
     "Now describe the image factually for a knowledge-base index. Include: any visible text verbatim, chart axes and values, diagram structure (boxes/arrows/labels), key visual elements. If the surrounding text contains a relevant figure number / caption / referent, incorporate that specifically. Do NOT invent details that aren't visible in the image or directly stated in the surrounding text. 2 to 4 sentences. Output plain text only — no markdown, no preamble.",
-  ].join("\n")
+    captionLanguageInstruction(outputLanguage),
+  ].filter(Boolean).join("\n")
 }
 
 export interface CaptionOptions {
@@ -134,6 +142,8 @@ export interface CaptionOptions {
    */
   contextBefore?: string
   contextAfter?: string
+  /** Output language for the description. Visible source text stays verbatim. */
+  outputLanguage?: string
 }
 
 /**
@@ -172,8 +182,10 @@ export async function captionImage(
   const after = options?.contextAfter?.trim() ?? ""
   const promptText =
     before.length > 0 || after.length > 0
-      ? buildCaptionPromptWithContext(before, after)
-      : CAPTION_PROMPT
+      ? buildCaptionPromptWithContext(before, after, options?.outputLanguage)
+      : [CAPTION_PROMPT, captionLanguageInstruction(options?.outputLanguage)]
+          .filter(Boolean)
+          .join("\n")
 
   const messages: ChatMessage[] = [
     {


### PR DESCRIPTION
## Problem

Image captions are always generated in English, regardless of the wiki's configured output language. The caption prompt (`CAPTION_PROMPT` / `buildCaptionPromptWithContext`) never mentions a target language, so on non-English wikis the ingest pipeline produces English alt text inside otherwise localized source summaries. Beyond the visual inconsistency, this hurts retrieval: caption embeddings end up in a different language than the user's queries.

## Fix

Thread an optional `outputLanguage` through the caption pipeline:

- **`vision-caption.ts`** — new `captionLanguageInstruction()` appends a language line ("Write the description in X. Preserve visible text verbatim in its original language.") to both the no-context and the context-aware prompt. Absent or `"auto"` values leave the prompts byte-identical to before, so existing caption caches and prompt regression tests are unaffected.
- **`image-caption-pipeline.ts`** — `CaptionPipelineOptions.outputLanguage` is passed through to `captionImage`.
- **`ingest.ts`** — both caption call sites resolve the configured language with `getOutputLanguage()` + `getLanguagePromptName()`, the same resolution `buildLanguageDirective` already uses for page generation. This means `"auto"` resolves from the source content (instead of leaking the literal string `auto` into the prompt), and captions follow the same language rules as the rest of the generated wiki.

Visible text in images (labels, chart axes, OCR content) is still captured verbatim in its original language — only the descriptive prose follows the output language setting.

## Tests

- Language instruction present for both prompt variants (no-context and context-aware)
- `"auto"` / absent `outputLanguage` fall back to the unmodified `CAPTION_PROMPT`
- Pipeline forwards `outputLanguage` to `captionImage`

`npx tsc --noEmit` clean, full mock suite green (1808 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)