### PR TITLE
feat: add OrcaRouter as a named provider preset

### DIFF
--- a/src/components/settings/llm-presets.ts
+++ b/src/components/settings/llm-presets.ts
@@ -214,6 +214,37 @@ export const LLM_PRESETS: LlmPreset[] = [
     suggestedContextSize: 128000,
   },
   {
+    id: "orcarouter",
+    label: "OrcaRouter",
+    hint: "api.orcarouter.ai",
+    provider: "custom",
+    baseUrl: "https://api.orcarouter.ai/v1",
+    defaultModel: "openai/gpt-5.5",
+    apiMode: "chat_completions",
+    // OrcaRouter is a multi-vendor model routing gateway exposing OpenAI,
+    // Anthropic, Google, DeepSeek, GLM, Kimi and other families behind a
+    // single OpenAI-compatible /v1/chat/completions endpoint, so it reuses
+    // the generic chat-completions wire like the other hosted gateways above.
+    // `orcarouter/auto` routes per request and is offered as a chip, but the
+    // default stays a concrete model. The full catalog is large and rotates;
+    // this is a practical subset and users can type any other id into the
+    // input.
+    suggestedModels: [
+      "orcarouter/auto",
+      "orcarouter/free",
+      "openai/gpt-5.5",
+      "openai/gpt-5.4-mini",
+      "anthropic/claude-sonnet-4.6",
+      "anthropic/claude-haiku-4.5",
+      "google/gemini-2.5-flash",
+      "deepseek/deepseek-v4-flash",
+      "deepseek/deepseek-v4-pro",
+      "z-ai/glm-5.2",
+      "kimi/kimi-k2.6",
+    ],
+    suggestedContextSize: 128000,
+  },
+  {
     id: "groq",
     label: "Groq",
     hint: "api.groq.com",

--- a/src/components/settings/preset-resolver.test.ts
+++ b/src/components/settings/preset-resolver.test.ts
@@ -41,6 +41,26 @@ describe("resolveConfig", () => {
     expect(atlas?.suggestedModels).toContain("deepseek-ai/deepseek-v4-pro")
   })
 
+  it("exposes OrcaRouter as an OpenAI-compatible chat-completions preset", () => {
+    const orca = LLM_PRESETS.find((preset) => preset.id === "orcarouter")
+
+    expect(orca?.provider).toBe("custom")
+    expect(orca?.baseUrl).toBe("https://api.orcarouter.ai/v1")
+    expect(orca?.apiMode).toBe("chat_completions")
+    expect(orca?.defaultModel).toBe("openai/gpt-5.5")
+    expect(orca?.suggestedModels).toContain("orcarouter/auto")
+  })
+
+  it("resolves the OrcaRouter preset into a custom chat-completions config", () => {
+    const orca = LLM_PRESETS.find((preset) => preset.id === "orcarouter")!
+    const resolved = resolveConfig(orca, undefined, fallbackConfig())
+
+    expect(resolved.provider).toBe("custom")
+    expect(resolved.customEndpoint).toBe("https://api.orcarouter.ai/v1")
+    expect(resolved.apiMode).toBe("chat_completions")
+    expect(resolved.model).toBe("openai/gpt-5.5")
+  })
+
   it("keeps Xiaomi MiMo presets aligned with current official and Token Plan endpoints", () => {
     const mimo = LLM_PRESETS.find((preset) => preset.id === "xiaomi-mimo")
 


### PR DESCRIPTION
## Summary

Adds a dedicated [OrcaRouter](https://www.orcarouter.ai) provider preset rather than relying on the generic OpenAI-compatible custom endpoint, mirroring how this repo already treats Atlas Cloud, DeepSeek, Groq and xAI style aggregators. Named routers such as `orcarouter/auto` pick an upstream per request. OrcaRouter is an OpenAI-compatible gateway that exposes 150+ models behind one API key, and it also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

I'm an engineer on the OrcaRouter team.

## What this changes

- `src/components/settings/llm-presets.ts`: registers the OrcaRouter preset with provider `custom`, base URL `https://api.orcarouter.ai/v1`, apiMode `chat_completions`, default model `openai/gpt-5.5`, and a suggested-models list spanning the OpenAI, Anthropic, Google, DeepSeek, GLM and Kimi families plus the `orcarouter/auto` and `orcarouter/free` routers.
- `src/components/settings/preset-resolver.test.ts`: adds unit tests for the preset shape and for `resolveConfig` producing a custom chat-completions config with `customEndpoint` set to `https://api.orcarouter.ai/v1`.

## Why a separate provider rather than the OpenAI-compatible escape hatch

This mirrors how the existing Atlas Cloud gateway is wired in this repo, so the model picker, config reference and docs stay consistent for users. Named routers such as `orcarouter/auto` pick an upstream per request.

## How to use it

1. Get an API key at https://www.orcarouter.ai/console (keys start with `sk-orca-`).
2. In Settings, choose the OrcaRouter preset and paste the key.
3. Pick a model id such as `openai/gpt-5.5`, `anthropic/claude-sonnet-4.6` or `google/gemini-2.5-flash`. The full catalog is at https://www.orcarouter.ai/models.

## Verification

- Unit tests: preset-resolver suite passes (14/14).
- Typecheck: `tsc --build` clean.
- Full mocked test suite: 1806/1806 pass.
- Live API: a real-key end-to-end stream through `streamChat` returns the expected marker for the default model and for `orcarouter/auto`; an invalid key fails with an explicit auth error.
