### PR TITLE
fix: support MinerU 3.0-3.2 backend names

### DIFF
--- a/src/lib/mineru.test.ts
+++ b/src/lib/mineru.test.ts
@@ -385,6 +385,31 @@ describe("parseWithMineru", () => {
     }
   })
 
+  it.each([
+    ["2.1.11", "hybrid-engine"],
+    ["3.1.15", "hybrid-auto-engine"],
+    ["3.4.4", "hybrid-engine"],
+  ])("submits the backend name supported by MinerU %s", async (version, expectedBackend) => {
+    mockHttpFetch
+      .mockResolvedValueOnce(jsonResponse({ status: "healthy", version }))
+      .mockResolvedValueOnce(jsonResponse({ task_id: "task-1" }, { status: 202 }))
+      .mockResolvedValueOnce(jsonResponse({ status: "completed" }))
+      .mockResolvedValueOnce(jsonResponse({
+        results: { report: { md_content: "# Parsed locally" } },
+      }))
+
+    await expect(parseWithMineru({
+      enabled: true,
+      backend: "local",
+      localBackend: "hybrid-engine",
+      token: "",
+      modelVersion: "vlm",
+    }, "/tmp/report.pdf")).resolves.toBe("# Parsed locally")
+
+    const form = mockHttpFetch.mock.calls[1]?.[1]?.body as FormData
+    expect(form.get("backend")).toBe(expectedBackend)
+  })
+
   it("rejects oversized local-backend files before reading or uploading", async () => {
     fsMocks.getFileSize.mockResolvedValueOnce(__mineruTest.MAX_ACCURATE_PARSE_BYTES + 1)
 
@@ -401,6 +426,7 @@ describe("parseWithMineru", () => {
 
   it("rejects an empty local-backend result instead of caching it as success", async () => {
     mockHttpFetch
+      .mockResolvedValueOnce(jsonResponse({ status: "healthy", version: "3.1.15" }))
       .mockResolvedValueOnce(jsonResponse({ task_id: "task-1" }, { status: 202 }))
       .mockResolvedValueOnce(jsonResponse({ status: "completed" }))
       .mockResolvedValueOnce(jsonResponse({ results: { doc: { md_content: "  " } } }))
@@ -415,6 +441,7 @@ describe("parseWithMineru", () => {
 
   it("saves and rewrites images returned by the official local API", async () => {
     mockHttpFetch
+      .mockResolvedValueOnce(jsonResponse({ status: "healthy", version: "3.1.15" }))
       .mockResolvedValueOnce(jsonResponse({ task_id: "task-1" }, { status: 202 }))
       .mockResolvedValueOnce(jsonResponse({ status: "completed" }))
       .mockResolvedValueOnce(jsonResponse({
@@ -443,12 +470,13 @@ describe("parseWithMineru", () => {
       "/project/wiki/media/doc/mineru/images/image-1.png",
       btoa("image bytes"),
     )
-    const form = mockHttpFetch.mock.calls[0]?.[1]?.body as FormData
+    const form = mockHttpFetch.mock.calls[1]?.[1]?.body as FormData
     expect(form.get("return_images")).toBe("true")
   })
 
   it("uses the data URI MIME type when the MinerU filename extension disagrees", async () => {
     mockHttpFetch
+      .mockResolvedValueOnce(jsonResponse({ status: "healthy", version: "3.1.15" }))
       .mockResolvedValueOnce(jsonResponse({ task_id: "task-1" }, { status: 202 }))
       .mockResolvedValueOnce(jsonResponse({ status: "completed" }))
       .mockResolvedValueOnce(jsonResponse({

--- a/src/lib/mineru.ts
+++ b/src/lib/mineru.ts
@@ -673,6 +673,23 @@ async function downloadAndExtractMarkdown(
 
 // ── Local backend ──
 
+const MINERU_3_0_TO_3_2_BACKENDS: Partial<
+  Record<NonNullable<MineruConfig["localBackend"]>, string>
+> = {
+  "vlm-engine": "vlm-auto-engine",
+  "hybrid-engine": "hybrid-auto-engine",
+}
+
+function localMineruBackendForVersion(
+  backend: NonNullable<MineruConfig["localBackend"]>,
+  version: unknown,
+): string {
+  if (typeof version === "string" && /^3\.[0-2](?:\.|$)/.test(version.trim())) {
+    return MINERU_3_0_TO_3_2_BACKENDS[backend] ?? backend
+  }
+  return backend
+}
+
 /**
  * Parse a document through the official `mineru-api` asynchronous protocol.
  * Files are submitted as multipart/form-data to `/tasks`; the task status and
@@ -688,7 +705,8 @@ async function parseWithLocalMineru(
 ): Promise<MineruExtractedMarkdown> {
   const httpFetch = await getHttpFetch()
   const apiBase = localMineruApiBase(config.localEndpoint)
-  if (config.localBackend?.endsWith("http-client") && !config.localServerUrl?.trim()) {
+  const configuredBackend = config.localBackend || "hybrid-engine"
+  if (configuredBackend.endsWith("http-client") && !config.localServerUrl?.trim()) {
     throw new Error("MinerU HTTP client backends require a model server URL")
   }
   const fileSize = await getFileSize(sourcePath)
@@ -696,6 +714,22 @@ async function parseWithLocalMineru(
     throw new Error("MinerU accurate parsing supports files up to 200 MB")
   }
   throwIfAborted(signal)
+  let serverVersion: unknown
+  if (configuredBackend.endsWith("-engine")) {
+    try {
+      const healthRes = await httpFetch(
+        `${apiBase}/health`,
+        localMineruRequestInit(config.localToken, { signal }),
+      )
+      if (healthRes.ok) {
+        const health = await healthRes.json() as { version?: unknown }
+        serverVersion = health.version
+      }
+    } catch (err) {
+      if (signal?.aborted) throw err
+    }
+  }
+  const localBackend = localMineruBackendForVersion(configuredBackend, serverVersion)
   const { base64 } = await readFileAsBase64(sourcePath)
   const bytes = decodeBase64ToBytes(base64)
   const fileBuffer = bytes.buffer.slice(
@@ -705,7 +739,7 @@ async function parseWithLocalMineru(
   const form = new FormData()
   form.append("files", new Blob([fileBuffer], { type: "application/pdf" }), fileName)
   form.append("lang_list", config.localLanguage || "ch")
-  form.append("backend", config.localBackend || "hybrid-engine")
+  form.append("backend", localBackend)
   form.append("effort", config.localEffort || "medium")
   form.append("parse_method", config.localParseMethod || "auto")
   form.append("formula_enable", String(config.localFormulaEnabled !== false))


### PR DESCRIPTION
## Summary

Fix self-hosted MinerU parsing with MinerU 3.0–3.2 while preserving compatibility
with MinerU 2.x backend names and configurations written by earlier LLM Wiki
versions.

MinerU 3.0–3.2 renamed the local inference backends:

| MinerU 2.x | MinerU 3.0–3.2 |
|---|---|
| `hybrid-engine` | `hybrid-auto-engine` |
| `vlm-engine` | `vlm-auto-engine` |

LLM Wiki previously sent the 2.x names unconditionally. MinerU 3.0–3.2 accepts the
task submission with HTTP 202, but the task then fails asynchronously with
`Unsupported backend: engine`. Because PDF ingestion falls back to the built-in
extractor, this failure can be difficult to notice.

MinerU 3.3+ restored `hybrid-engine` and `vlm-engine` as its canonical names and
accepts the `*-auto-engine` forms as compatibility aliases. The affected server
range is therefore MinerU 3.0–3.2, not every MinerU 3.x release.

## Changes

- Keep the existing `hybrid-engine` and `vlm-engine` values unchanged in the UI,
  persisted configuration, and public TypeScript types.
- Read `/health.version` before submitting local engine tasks and select the
  matching wire value:
  - MinerU 3.0–3.2 receives `hybrid-auto-engine` or `vlm-auto-engine`.
  - MinerU 2.x and MinerU 3.3+ retain `hybrid-engine` or `vlm-engine`.
- Leave `pipeline`, `vlm-http-client`, and `hybrid-http-client` unchanged because
  those identifiers are shared by both versions.
- Keep the version mapping local to the MinerU request boundary.
- Add regression coverage for MinerU 2.x, affected 3.1.15, and current 3.4.4
  request values.

The version probe is only performed for the renamed local engine backends. It
does not add a request for `pipeline` or either HTTP-client backend.

## Compatibility

- MinerU 3.0–3.2 receives the affected-release `*-auto-engine` form.
- MinerU 2.x, MinerU 3.3+, and unrecognized versions retain the canonical
  `*-engine` form.

MinerU 3.1.15 was verified end to end against a real local `mineru-api` server.
The MinerU 2.x request mapping is covered by automated tests but has not been
validated against a live 2.x server in this change.

The version boundary was also checked against every MinerU release tag from
3.0.0 through 3.4.4: 3.0.0–3.2.3 expose only the `*-auto-engine` names, while
3.3.0+ restores `*-engine` and retains `*-auto-engine` as an alias.

## Verification

- `npm run typecheck`
- `npx vitest run src/lib/mineru.test.ts`
  - 44 tests passed
- `npm run test:mocks`
  - 124 test files passed
  - 1810 tests passed
- `git diff --check`

## Reproduction

Observed against MinerU 3.1.15 with the same PDF and form fields, varying only
`backend`:

| Backend | Submission | Result |
|---|---|---|
| `hybrid-engine` | HTTP 202 | Failed: `Unsupported backend: engine` |
| `vlm-engine` | HTTP 202 | Failed: `Unsupported backend: engine` |
| `hybrid-auto-engine` | HTTP 202 | Completed successfully |
| `pipeline` | HTTP 202 | Completed successfully |

Detailed request/response captures, reproduction scripts, and server logs are
available on request.
