### PR TITLE
docs: document protoc and mcp-server build steps for source builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,10 +405,14 @@ Download from [Releases](https://github.com/nashsu/llm_wiki/releases):
 ### Build from Source
 
 ```bash
-# Prerequisites: Node.js 20+, Rust 1.70+
+# Prerequisites: Node.js 20+, Rust 1.70+, protoc
+#   macOS:  brew install protobuf
+#   Linux:  sudo apt install protobuf-compiler
+#   Windows: choco install protoc
 git clone https://github.com/nashsu/llm_wiki.git
 cd llm_wiki
 npm install
+npm --prefix mcp-server ci && npm run mcp:build   # mcp-server/dist is bundled as a Tauri resource
 npm run tauri dev      # Development
 npm run tauri build    # Production build
 ```

--- a/README_CN.md
+++ b/README_CN.md
@@ -405,10 +405,14 @@ LLM Wiki 是一个跨平台桌面应用，能将你的文档自动转化为有�
 ### 从源码构建
 
 ```bash
-# 前置条件：Node.js 20+, Rust 1.70+
+# 前置条件：Node.js 20+, Rust 1.70+, protoc
+#   macOS：  brew install protobuf
+#   Linux：  sudo apt install protobuf-compiler
+#   Windows：choco install protoc
 git clone https://github.com/nashsu/llm_wiki.git
 cd llm_wiki
 npm install
+npm --prefix mcp-server ci && npm run mcp:build   # mcp-server/dist 会作为 Tauri 资源打包
 npm run tauri dev      # 开发模式
 npm run tauri build    # 生产构建
 ```

--- a/README_JA.md
+++ b/README_JA.md
@@ -414,10 +414,14 @@ LLM Wiki は、手元の文書を整理された相互リンク付きの知識�
 ### ソースからビルド
 
 ```bash
-# 前提条件: Node.js 20+, Rust 1.70+
+# 前提条件: Node.js 20+, Rust 1.70+, protoc
+#   macOS:   brew install protobuf
+#   Linux:   sudo apt install protobuf-compiler
+#   Windows: choco install protoc
 git clone https://github.com/nashsu/llm_wiki.git
 cd llm_wiki
 npm install
+npm --prefix mcp-server ci && npm run mcp:build   # mcp-server/dist は Tauri リソースとして同梱されます
 npm run tauri dev      # 開発モード
 npm run tauri build    # 本番ビルド
 ```

--- a/README_KO.md
+++ b/README_KO.md
@@ -414,10 +414,14 @@ LLM Wiki는 문서를 자동으로 정리되고 서로 연결된 지식 베이�
 ### 소스에서 빌드
 
 ```bash
-# Prerequisites: Node.js 20+, Rust 1.70+
+# Prerequisites: Node.js 20+, Rust 1.70+, protoc
+#   macOS:   brew install protobuf
+#   Linux:   sudo apt install protobuf-compiler
+#   Windows: choco install protoc
 git clone https://github.com/nashsu/llm_wiki.git
 cd llm_wiki
 npm install
+npm --prefix mcp-server ci && npm run mcp:build   # mcp-server/dist is bundled as a Tauri resource
 npm run tauri dev      # Development
 npm run tauri build    # Production build
 ```


### PR DESCRIPTION
## Problem

Building from source on a clean machine fails twice before it succeeds, and neither cause is in the README.

**1. Missing `protoc`**

`lancedb` pulls in `lance-encoding`, whose build script runs `prost-build`:

```
error: failed to run custom build command for `lance-encoding v4.0.0`
Error: Custom { kind: NotFound, error: "Could not find `protoc`. ..." }
```

CI already installs it on all three platforms (`.github/workflows/ci.yml`, `build.yml`), so the dependency is known — it just isn't documented for local builds.

**2. `mcp-server/dist` not built**

`tauri.conf.json` bundles `../mcp-server/dist` as a resource, so a fresh clone panics:

```
thread 'main' panicked at build.rs:5:35:
failed to run tauri build script: resource path `../mcp-server/dist` doesn't exist
```

`npm run build:desktop` handles this, but the documented flow (`npm install` → `npm run tauri dev`) doesn't.

## Change

Adds `protoc` (with the per-platform install command) to the prerequisites line and an explicit `npm --prefix mcp-server ci && npm run mcp:build` step, in all four READMEs. Docs only — no code changes.
