### PR TITLE
fix: resolve wiki-root-relative wikilinks

### DIFF
--- a/src-tauri/src/api_server.rs
+++ b/src-tauri/src/api_server.rs
@@ -2511,13 +2511,30 @@ fn extract_wikilinks(content: &str) -> Vec<String> {
 }
 
 fn resolve_link(raw: &str, ids: &BTreeSet<String>) -> Option<String> {
-    if ids.contains(raw) {
-        return Some(raw.to_string());
+    let normalized_raw = raw
+        .trim()
+        .replace('\\', "/")
+        .trim_start_matches('/')
+        .trim_start_matches("wiki/")
+        .trim_end_matches(".md")
+        .to_string();
+    let basename = normalized_raw
+        .rsplit('/')
+        .next()
+        .unwrap_or(&normalized_raw)
+        .to_string();
+    for candidate in [raw.trim(), normalized_raw.as_str(), basename.as_str()] {
+        if ids.contains(candidate) {
+            return Some(candidate.to_string());
+        }
+        let normalized = candidate.to_lowercase().replace(' ', "-");
+        if let Some(id) = ids.iter().find(|id| {
+            id.to_lowercase() == normalized || id.to_lowercase() == candidate.to_lowercase()
+        }) {
+            return Some(id.clone());
+        }
     }
-    let normalized = raw.to_lowercase().replace(' ', "-");
-    ids.iter()
-        .find(|id| id.to_lowercase() == normalized || id.to_lowercase() == raw.to_lowercase())
-        .cloned()
+    None
 }
 
 fn handle_rescan(app: &AppHandle, project_id: &str) -> ApiResponse {
@@ -2589,6 +2606,22 @@ mod tests {
         let path = std::env::temp_dir().join(format!("llm-wiki-api-test-{id}-{seq}"));
         fs::create_dir_all(path.join("wiki")).unwrap();
         path
+    }
+
+    #[test]
+    fn resolve_link_accepts_wiki_root_relative_paths() {
+        let ids = BTreeSet::from([
+            "CompGCN".to_string(),
+            "inductive-kg-reasoning".to_string(),
+        ]);
+        assert_eq!(
+            resolve_link("concepts/inductive-kg-reasoning", &ids).as_deref(),
+            Some("inductive-kg-reasoning")
+        );
+        assert_eq!(
+            resolve_link("wiki/concepts/inductive-kg-reasoning.md", &ids).as_deref(),
+            Some("inductive-kg-reasoning")
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands/search.rs
+++ b/src-tauri/src/commands/search.rs
@@ -267,17 +267,34 @@ fn get_page_links_inner(project_path: &str, file_path: &str) -> Result<PageLinks
     })
 }
 
-/// Mirror `resolveRelatedSlug` in the frontend reader. Path-shaped links must
-/// match their project-relative path exactly; bare links resolve by exact
-/// filename after adding `.md`. Deliberately avoid title and fuzzy aliases so
-/// the links panel never claims a target that the rendered page cannot open.
+/// Mirror `resolveRelatedSlug` in the frontend reader. Path-shaped links may be
+/// project-relative (`wiki/concepts/foo.md`) or wiki-root-relative
+/// (`concepts/foo`). Bare links resolve by exact filename after adding `.md`.
+/// Deliberately avoid title and fuzzy aliases so the links panel never claims a
+/// target that the rendered page cannot open.
 fn resolve_reader_wikilink<'a>(
     pages: &'a BTreeMap<String, GraphPage>,
     link: &str,
 ) -> Option<&'a String> {
-    let link = link.trim().replace('\\', "/");
+    let link = link.trim().replace('\\', "/").trim_start_matches('/').to_string();
     if link.contains('/') {
-        return pages.get_key_value(&link).map(|(path, _)| path);
+        let candidates = if link.starts_with("wiki/") {
+            vec![link]
+        } else {
+            vec![link.clone(), format!("wiki/{link}")]
+        };
+        for candidate in candidates {
+            if let Some((path, _)) = pages.get_key_value(&candidate) {
+                return Some(path);
+            }
+            if !candidate.ends_with(".md") {
+                let with_ext = format!("{candidate}.md");
+                if let Some((path, _)) = pages.get_key_value(&with_ext) {
+                    return Some(path);
+                }
+            }
+        }
+        return None;
     }
     let filename = if link.ends_with(".md") {
         link
@@ -2156,7 +2173,7 @@ mod tests {
         write_page(
             &root,
             "wiki/concepts/current.md",
-            "[[wiki/concepts/target.md]] [[target#section]]",
+            "[[wiki/concepts/target.md]] [[concepts/target]] [[concepts/target.md]] [[target#section]]",
         );
         write_page(&root, "wiki/concepts/target.md", "# Target");
         write_page(&root, "wiki/concepts/not-markdown.txt", "text");

--- a/src/lib/__tests__/wiki-graph.test.ts
+++ b/src/lib/__tests__/wiki-graph.test.ts
@@ -27,6 +27,11 @@ function mdFile(name: string): FileNode {
   return { name, path: `/project/wiki/${name}`, is_dir: false }
 }
 
+function mdFileAt(path: string): FileNode {
+  const name = path.split("/").pop()!
+  return { name, path: `/project/wiki/${path}`, is_dir: false }
+}
+
 describe("buildWikiGraph frontmatter extraction", () => {
   it("does not read a title: line from the document body as the frontmatter title", async () => {
     const buildWikiGraph = await loadBuildWikiGraph()
@@ -131,5 +136,24 @@ describe("buildWikiGraph frontmatter extraction", () => {
     expect(second).toBe(first)
     expect(mockListDirectory).toHaveBeenCalledTimes(1)
     expect(mockReadFile).toHaveBeenCalledTimes(1)
+  })
+
+  it("resolves wiki-root-relative path links as graph edges", async () => {
+    const buildWikiGraph = await loadBuildWikiGraph()
+    mockListDirectory.mockResolvedValue([
+      mdFileAt("entities/CompGCN.md"),
+      mdFileAt("concepts/inductive-kg-reasoning.md"),
+    ])
+    mockReadFile.mockImplementation(async (path: string) =>
+      path.endsWith("CompGCN.md")
+        ? "---\ntitle: CompGCN\ntype: entity\n---\n# CompGCN\n\n[[concepts/inductive-kg-reasoning]]"
+        : "---\ntitle: Inductive KG Reasoning\ntype: concept\n---\n# Inductive KG Reasoning\n",
+    )
+
+    const graph = await buildWikiGraph("/project")
+
+    expect(graph.edges).toEqual([
+      expect.objectContaining({ source: "CompGCN", target: "inductive-kg-reasoning" }),
+    ])
   })
 })

--- a/src/lib/graph-relevance.ts
+++ b/src/lib/graph-relevance.ts
@@ -121,18 +121,33 @@ function extractWikilinks(content: string): string[] {
   return links
 }
 
+function normalizeLinkTarget(raw: string): string {
+  return raw.replace(/\\/g, "/")
+    .replace(/^\/+/, "")
+    .replace(/^wiki\//i, "")
+    .replace(/\.md$/i, "")
+    .trim()
+    .toLowerCase()
+}
+
+function fileBase(path: string): string {
+  return path.replace(/\\/g, "/").split("/").pop()?.replace(/\.md$/i, "") ?? path
+}
+
 function resolveTarget(
   raw: string,
-  nodeIds: ReadonlySet<string>,
+  nodes: readonly Pick<RetrievalNode, "id" | "path">[],
+  wikiRoot: string,
 ): string | null {
-  if (nodeIds.has(raw)) return raw
+  const normalized = normalizeLinkTarget(raw).replace(/\s+/g, "-")
 
-  const normalized = raw.toLowerCase().replace(/\s+/g, "-")
-  for (const id of nodeIds) {
-    const idLower = id.toLowerCase()
-    if (idLower === normalized) return id
-    if (idLower === raw.toLowerCase()) return id
-    if (idLower.replace(/\s+/g, "-") === normalized) return id
+  for (const node of nodes) {
+    const path = normalizePath(node.path)
+    const shortPath = path.startsWith(`${wikiRoot}/`) ? path.slice(wikiRoot.length + 1) : path
+    const keys = [node.id, shortPath, fileBase(shortPath)].map(normalizeLinkTarget)
+    if (keys.some((key) => key === normalized || key.replace(/\s+/g, "-") === normalized)) {
+      return node.id
+    }
   }
   return null
 }
@@ -206,6 +221,7 @@ export async function buildRetrievalGraph(
   }
 
   const nodeIds = new Set(rawNodes.map((n) => n.id))
+  const nodeLookup = rawNodes.map((n) => ({ id: n.id, path: n.path }))
 
   // Second pass: resolve links and build graph nodes
   const outLinksMap = new Map<string, Set<string>>()
@@ -218,7 +234,7 @@ export async function buildRetrievalGraph(
 
   for (const raw of rawNodes) {
     for (const linkTarget of raw.rawLinks) {
-      const resolvedId = resolveTarget(linkTarget, nodeIds)
+      const resolvedId = resolveTarget(linkTarget, nodeLookup, wikiRoot)
       if (resolvedId === null || resolvedId === raw.id) continue
       outLinksMap.get(raw.id)!.add(resolvedId)
       inLinksMap.get(resolvedId)!.add(raw.id)

--- a/src/lib/lint-structural-core.test.ts
+++ b/src/lib/lint-structural-core.test.ts
@@ -21,6 +21,27 @@ describe("computeStructuralLint", () => {
     expect(broken?.suggestedTarget).toBe("transformer.md")
   })
 
+  it("resolves wiki-root-relative path links", () => {
+    const pages: StructuralLintPage[] = [
+      {
+        shortName: "entities/CompGCN.md",
+        slug: "entities/CompGCN",
+        title: "CompGCN",
+        outlinks: ["concepts/inductive-kg-reasoning"],
+        tokens: ["compgcn"],
+      },
+      {
+        shortName: "concepts/inductive-kg-reasoning.md",
+        slug: "concepts/inductive-kg-reasoning",
+        title: "Inductive KG Reasoning",
+        outlinks: ["entities/CompGCN"],
+        tokens: ["inductive", "knowledge", "graph"],
+      },
+    ]
+
+    expect(computeStructuralLint(pages).filter((finding) => finding.type === "broken-link")).toEqual([])
+  })
+
   it("handles 5,000 pages without quadratic candidate expansion", () => {
     const pages = Array.from({ length: 5_000 }, (_, index) => page(index, 5_000))
     const started = performance.now()

--- a/src/lib/lint-structural-core.ts
+++ b/src/lib/lint-structural-core.ts
@@ -40,10 +40,15 @@ function fileName(path: string): string {
 
 function normalizeTarget(target: string): string {
   return target.replace(/\\/g, "/")
+    .replace(/^\/+/, "")
     .replace(/^wiki\//i, "")
     .replace(/\.md$/i, "")
     .trim()
     .toLowerCase()
+}
+
+function wikiRootRelativeTarget(target: string): string {
+  return normalizeTarget(target).split("/").slice(-2).join("/")
 }
 
 function levenshtein(a: string, b: string): number {
@@ -112,6 +117,8 @@ export function computeStructuralLint(
   pages.forEach((page, index) => {
     const basename = fileName(page.shortName).replace(/\.md$/i, "")
     slugMap.set(normalizeTarget(page.slug), index)
+    slugMap.set(normalizeTarget(page.shortName), index)
+    slugMap.set(wikiRootRelativeTarget(page.shortName), index)
     slugMap.set(normalizeTarget(basename), index)
     for (const token of page.tokenSet) addToIndex(tokenIndex, token, index)
     for (const value of [page.slug, page.shortName, page.title]) {

--- a/src/lib/wiki-graph.ts
+++ b/src/lib/wiki-graph.ts
@@ -116,20 +116,22 @@ function fileNameToId(fileName: string): string {
 }
 
 function targetAliases(value: string): string[] {
-  const lower = value.toLowerCase()
-  return [value, lower, lower.replace(/\s+/g, "-")]
+  const normalized = normalizeLinkTarget(value)
+  return [value, normalized, normalized.replace(/\s+/g, "-")]
 }
 
-function buildTargetIndex(nodeIds: Iterable<string>): Map<string, string> {
-  const ids = Array.from(nodeIds)
+function buildTargetIndex(nodes: Iterable<{ id: string; shortPath: string }>): Map<string, string> {
+  const items = Array.from(nodes)
   const index = new Map<string, string>()
   // Exact IDs must win over case-folded aliases. On a case-sensitive
   // filesystem, Foo.md and foo.md are distinct pages and [[foo]] must retain
   // the reader's exact-match behavior.
-  for (const id of ids) index.set(id, id)
-  for (const id of ids) {
-    for (const alias of targetAliases(id).slice(1)) {
-      if (!index.has(alias)) index.set(alias, id)
+  for (const node of items) index.set(node.id, node.id)
+  for (const node of items) {
+    for (const value of [node.id, node.shortPath, fileBase(node.shortPath)]) {
+      for (const alias of targetAliases(value)) {
+        if (!index.has(alias)) index.set(alias, node.id)
+      }
     }
   }
   return index
@@ -210,7 +212,7 @@ async function buildWikiGraphUncached(projectPath: string): Promise<WikiGraphRes
   // Build a map of id -> node data
   const nodeMap = new Map<
     string,
-    { id: string; label: string; type: string; path: string; links: string[] }
+    { id: string; label: string; type: string; path: string; shortPath: string; links: string[] }
   >()
 
   const parsedFiles = await mapWithConcurrency(
@@ -220,11 +222,16 @@ async function buildWikiGraphUncached(projectPath: string): Promise<WikiGraphRes
       try {
         const content = await readFile(file.path)
         const id = fileNameToId(file.name)
+        const normalizedPath = normalizePath(file.path)
+        const shortPath = normalizedPath.startsWith(`${wikiRoot}/`)
+          ? normalizedPath.slice(wikiRoot.length + 1)
+          : file.name
         return {
           id,
           label: extractTitle(content, file.name),
           type: extractType(content),
           path: file.path,
+          shortPath,
           links: extractWikilinks(content),
         }
       } catch {
@@ -253,7 +260,7 @@ async function buildWikiGraphUncached(projectPath: string): Promise<WikiGraphRes
   }
 
   const rawEdges: GraphEdge[] = []
-  const targetIndex = buildTargetIndex(nodeMap.keys())
+  const targetIndex = buildTargetIndex(nodeMap.values())
 
   for (const [sourceId, nodeData] of nodeMap) {
     for (const targetRaw of nodeData.links) {
@@ -326,6 +333,19 @@ async function buildWikiGraphUncached(projectPath: string): Promise<WikiGraphRes
   }))
 
   return { nodes, edges, communities }
+}
+
+function normalizeLinkTarget(raw: string): string {
+  return raw.replace(/\\/g, "/")
+    .replace(/^\/+/, "")
+    .replace(/^wiki\//i, "")
+    .replace(/\.md$/i, "")
+    .trim()
+    .toLowerCase()
+}
+
+function fileBase(path: string): string {
+  return path.replace(/\\/g, "/").split("/").pop()?.replace(/\.md$/i, "") ?? path
 }
 
 function resolveTarget(

--- a/src/lib/wiki-page-resolver.test.ts
+++ b/src/lib/wiki-page-resolver.test.ts
@@ -205,6 +205,15 @@ describe("resolveRelatedSlug", () => {
     )
   })
 
+  it("accepts wiki-root-relative paths with or without .md", () => {
+    expect(resolveRelatedSlug(INDEX, "concepts/bar", WIKI)).toBe(
+      `${WIKI}/concepts/bar.md`,
+    )
+    expect(resolveRelatedSlug(INDEX, "concepts/bar.md", WIKI)).toBe(
+      `${WIKI}/concepts/bar.md`,
+    )
+  })
+
   it("returns null when slug doesn't exist", () => {
     expect(resolveRelatedSlug(INDEX, "ghost", WIKI)).toBeNull()
   })

--- a/src/lib/wiki-page-resolver.ts
+++ b/src/lib/wiki-page-resolver.ts
@@ -107,10 +107,11 @@ export function findInTreeByName(
 
 /**
  * Resolve a `related:` reference to an absolute wiki page path.
- * Accepts three shapes the wiki has historically written:
+ * Accepts four shapes the wiki has historically written:
  *   1. project-relative path:  `wiki/entities/dpao.md`
- *   2. bare filename with .md: `dpao.md`
- *   3. bare slug:              `dpao`
+ *   2. wiki-root path:         `entities/dpao` or `entities/dpao.md`
+ *   3. bare filename with .md: `dpao.md`
+ *   4. bare slug:              `dpao`
  * Returns the absolute path of an existing file, or null if none
  * matches. Always restricts the lookup to `wiki/` to avoid pulling
  * in a same-named file from `raw/sources/`.
@@ -120,16 +121,27 @@ export function resolveRelatedSlug(
   ref: string,
   wikiRoot: string,
 ): string | null {
-  // Path-like → resolve relative to project root (one segment up
-  // from wikiRoot).
-  if (ref.includes("/")) {
-    const projectRoot = wikiRoot.replace(/\/wiki$/, "")
-    const target = `${projectRoot}/${ref}`
-    const found = findInTreeByPath(index, target)
-    return found && found.includes(`${wikiRoot}/`) ? found : null
+  const normalizedRef = ref.replace(/\\/g, "/").replace(/^\/+/, "").trim()
+  const projectRoot = wikiRoot.replace(/\/wiki$/, "")
+
+  // Path-like refs may be project-relative (`wiki/concepts/foo.md`) or
+  // wiki-root-relative (`concepts/foo`). LLM-generated pages historically
+  // used both, and many omitted the `.md` extension.
+  if (normalizedRef.includes("/")) {
+    const bases = normalizedRef.startsWith("wiki/")
+      ? [`${projectRoot}/${normalizedRef}`]
+      : [`${projectRoot}/${normalizedRef}`, `${wikiRoot}/${normalizedRef}`]
+    for (const base of bases) {
+      const candidates = base.endsWith(".md") ? [base] : [base, `${base}.md`]
+      for (const target of candidates) {
+        const found = findInTreeByPath(index, target)
+        if (found?.startsWith(`${wikiRoot}/`)) return found
+      }
+    }
+    return null
   }
 
-  const filename = ref.endsWith(".md") ? ref : `${ref}.md`
+  const filename = normalizedRef.endsWith(".md") ? normalizedRef : `${normalizedRef}.md`
   return findInTreeByName(index, filename, `${wikiRoot}/`)
 }
 


### PR DESCRIPTION
## Summary

- Resolve wiki-root-relative wikilinks such as `[[concepts/foo]]` to existing `wiki/concepts/foo.md` pages.
- Keep support for existing bare links and project-relative `wiki/...` links.
- Apply the same resolution behavior across reader links, page links, structural lint, graph building, graph relevance, and the local API graph.

## Why

LLM-generated wiki pages can emit links like `[[concepts/foo]]`. These links point to valid pages under `wiki/concepts/`, but some resolvers treated path-shaped links as project-relative only, causing false broken-link / missing-link reports and missing graph edges.

## Tests

- `npm run test:mocks -- src/lib/wiki-page-resolver.test.ts src/lib/lint-structural-core.test.ts src/lib/__tests__/wiki-graph.test.ts`
- `cargo test --manifest-path src-tauri/Cargo.toml commands::search::tests::page_links_require_markdown_input_and_exact_reader_paths`
- `cargo test --manifest-path src-tauri/Cargo.toml api_server::tests::resolve_link_accepts_wiki_root_relative_paths`