### PR TITLE
[codex] 导入 Markdown 时同步解析 Obsidian Vault 图片

### DIFF
--- a/src/lib/obsidian-image-import.ts
+++ b/src/lib/obsidian-image-import.ts
@@ -1,0 +1,128 @@
+import {
+  copyFile,
+  createDirectory,
+  fileExists,
+  listDirectory,
+  readFile,
+} from "@/commands/fs"
+import { findLocalMarkdownImageRefs } from "@/lib/extract-source-images"
+import { getFileName, normalizePath } from "@/lib/path-utils"
+import type { FileNode } from "@/types/wiki"
+
+/**
+ * 函数作用：取得路径的父目录。
+ * 输入参数：
+ *     path: 文件或目录路径。
+ * 输出参数：
+ *     返回规范化后的父目录；没有父目录时返回空字符串。
+ */
+function parentPath(path: string): string {
+  const normalized = normalizePath(path)
+  const index = normalized.lastIndexOf("/")
+  return index > 0 ? normalized.slice(0, index) : ""
+}
+
+/**
+ * 函数作用：把目录树展开为文件列表。
+ * 输入参数：
+ *     nodes: 文件目录树节点。
+ * 输出参数：
+ *     返回目录树中的全部文件节点。
+ */
+function flattenFiles(nodes: FileNode[]): FileNode[] {
+  const files: FileNode[] = []
+  for (const node of nodes) {
+    if (node.is_dir) {
+      files.push(...flattenFiles(node.children ?? []))
+    } else {
+      files.push(node)
+    }
+  }
+  return files
+}
+
+/**
+ * 函数作用：从 Markdown 所在目录向上查找 Obsidian Vault 根目录。
+ * 输入参数：
+ *     markdownPath: 原始 Markdown 文件路径。
+ * 输出参数：
+ *     返回包含 .obsidian 目录的路径；未找到时返回 null。
+ */
+async function findObsidianVaultRoot(markdownPath: string): Promise<string | null> {
+  let current = parentPath(markdownPath)
+  while (current) {
+    if (await fileExists(`${current}/.obsidian`)) return current
+    const next = parentPath(current)
+    if (!next || next === current) break
+    current = next
+  }
+  return null
+}
+
+/**
+ * 函数作用：根据 Obsidian 的解析习惯定位本地图片。
+ * 输入参数：
+ *     reference: Markdown 中的图片引用。
+ *     markdownDir: 原始 Markdown 所在目录。
+ *     vaultFilesByName: Vault 文件名索引。
+ * 输出参数：
+ *     返回图片的绝对路径；找不到时返回 null。
+ */
+async function resolveImageSource(
+  reference: string,
+  markdownDir: string,
+  vaultFilesByName: Map<string, string>,
+): Promise<string | null> {
+  const normalizedRef = normalizePath(reference)
+  const relativeCandidate = normalizePath(`${markdownDir}/${normalizedRef}`)
+  if (await fileExists(relativeCandidate)) return relativeCandidate
+
+  return vaultFilesByName.get(getFileName(normalizedRef).toLowerCase()) ?? null
+}
+
+/**
+ * 函数作用：把 Obsidian Markdown 引用的跨目录图片复制到导入目标旁边。
+ * 输入参数：
+ *     sourceMarkdownPath: 导入前的 Markdown 文件路径。
+ *     destinationMarkdownPath: 导入后的 Markdown 文件路径。
+ * 输出参数：
+ *     返回成功复制的图片数量。
+ */
+export async function importObsidianMarkdownImages(
+  sourceMarkdownPath: string,
+  destinationMarkdownPath: string,
+): Promise<number> {
+  const markdown = await readFile(sourceMarkdownPath)
+  const references = findLocalMarkdownImageRefs(markdown)
+  if (references.length === 0) return 0
+
+  const sourceDir = parentPath(sourceMarkdownPath)
+  const destinationDir = parentPath(destinationMarkdownPath)
+  const vaultRoot = await findObsidianVaultRoot(sourceMarkdownPath)
+  const vaultFilesByName = new Map<string, string>()
+
+  if (vaultRoot) {
+    const vaultFiles = flattenFiles(await listDirectory(vaultRoot))
+    for (const file of vaultFiles) {
+      const key = file.name.toLowerCase()
+      if (!vaultFilesByName.has(key)) vaultFilesByName.set(key, normalizePath(file.path))
+    }
+  }
+
+  let copied = 0
+  for (const reference of references) {
+    const sourceImage = await resolveImageSource(reference, sourceDir, vaultFilesByName)
+    if (!sourceImage) continue
+
+    const normalizedRef = normalizePath(reference)
+    const destinationImage = normalizedRef.includes("/")
+      ? normalizePath(`${destinationDir}/${normalizedRef}`)
+      : normalizePath(`${destinationDir}/${getFileName(normalizedRef)}`)
+    const imageParent = parentPath(destinationImage)
+    if (imageParent) await createDirectory(imageParent)
+    await copyFile(sourceImage, destinationImage)
+    copied += 1
+  }
+
+  return copied
+}

--- a/src/lib/source-lifecycle.test.ts
+++ b/src/lib/source-lifecycle.test.ts
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
   fileExists: vi.fn(),
   getFileSize: vi.fn(),
   listDirectory: vi.fn(),
+  readFile: vi.fn(),
   preprocessFile: vi.fn(),
   enqueueBatch: vi.fn(),
 }))
@@ -21,6 +22,7 @@ vi.mock("@/commands/fs", async () => {
     fileExists: mocks.fileExists,
     getFileSize: mocks.getFileSize,
     listDirectory: mocks.listDirectory,
+    readFile: mocks.readFile,
     preprocessFile: mocks.preprocessFile,
   }
 })
@@ -45,6 +47,7 @@ beforeEach(() => {
   mocks.fileExists.mockResolvedValue(false)
   mocks.getFileSize.mockResolvedValue(1024)
   mocks.listDirectory.mockResolvedValue([])
+  mocks.readFile.mockResolvedValue("")
   mocks.preprocessFile.mockResolvedValue("")
   mocks.enqueueBatch.mockResolvedValue(["task"])
 })
@@ -260,6 +263,71 @@ describe("source-lifecycle path helpers", () => {
         folderContext: "",
       },
     ])
+  })
+
+  it("imports bare Obsidian image embeds from other Vault folders", async () => {
+    mocks.readFile.mockResolvedValue(
+      "正文\n\n![[扩散波示意图.svg]]\n\n![[探头位置.png]]",
+    )
+    mocks.fileExists.mockImplementation(async (path: string) =>
+      path === "/vault/.obsidian",
+    )
+    mocks.listDirectory.mockResolvedValue([
+      {
+        name: "excalidraw",
+        path: "/vault/excalidraw",
+        is_dir: true,
+        children: [
+          {
+            name: "source",
+            path: "/vault/excalidraw/source",
+            is_dir: true,
+            children: [
+              {
+                name: "扩散波示意图.svg",
+                path: "/vault/excalidraw/source/扩散波示意图.svg",
+                is_dir: false,
+              },
+            ],
+          },
+        ],
+      },
+      {
+        name: "99附件文件夹",
+        path: "/vault/99附件文件夹",
+        is_dir: true,
+        children: [
+          {
+            name: "探头位置.png",
+            path: "/vault/99附件文件夹/探头位置.png",
+            is_dir: false,
+          },
+        ],
+      },
+    ])
+
+    const copied = await importSourceFiles(
+      { id: "p1", name: "Project", path: "/project" },
+      ["/vault/97 超声成像/超声延时规则.md"],
+      {
+        provider: "openai",
+        endpoint: "https://api.example.com/v1",
+        apiKey: "key",
+        model: "model",
+        customModel: "",
+        reasoning: { enabled: false, effort: "low" },
+      } as never,
+    )
+
+    expect(copied).toEqual(["/project/raw/sources/超声延时规则.md"])
+    expect(mocks.copyFile).toHaveBeenCalledWith(
+      "/vault/excalidraw/source/扩散波示意图.svg",
+      "/project/raw/sources/扩散波示意图.svg",
+    )
+    expect(mocks.copyFile).toHaveBeenCalledWith(
+      "/vault/99附件文件夹/探头位置.png",
+      "/project/raw/sources/探头位置.png",
+    )
   })
 
   it("allows an explicitly selected ebook with an older watch include-list", async () => {

--- a/src/lib/source-lifecycle.ts
+++ b/src/lib/source-lifecycle.ts
@@ -41,6 +41,7 @@ import type { SourceWatchConfig } from "@/stores/wiki-store"
 import { useWikiStore } from "@/stores/wiki-store"
 import { preprocessSourceFiles } from "@/lib/source-preprocess"
 import { moveParsedMarkdown, removeParsedMarkdown } from "@/lib/parsed-source-output"
+import { importObsidianMarkdownImages } from "@/lib/obsidian-image-import"
 
 export const INGESTABLE_SOURCE_EXTENSIONS = new Set([
   "md",
@@ -282,6 +283,16 @@ export async function enqueueSourceIngest(
   return enqueueBatch(project.id, files)
 }
 
+/**
+ * 函数作用：把用户选中的来源文件复制到项目并加入摄取队列；Markdown 会同时导入其 Obsidian 图片。
+ * 输入参数：
+ *     project: 当前 Wiki 项目。
+ *     sourcePaths: 用户选中的来源文件路径。
+ *     llmConfig: 摄取任务使用的模型配置。
+ *     sourceWatchConfig: 可选的来源监控与过滤配置。
+ * 输出参数：
+ *     返回成功导入到项目中的文件路径列表。
+ */
 export async function importSourceFiles(
   project: WikiProject,
   sourcePaths: string[],
@@ -317,6 +328,9 @@ export async function importSourceFiles(
     const destPath = await getUniqueDestPath(`${pp}/raw/sources`, originalName)
     try {
       await copyFile(sourcePath, destPath)
+      if (/\.mdx?$/i.test(sourcePath)) {
+        await importObsidianMarkdownImages(sourcePath, destPath)
+      }
       importedPaths.push(destPath)
     } catch (err) {
       console.error(`Failed to import ${originalName}:`, err)


### PR DESCRIPTION
## 修改内容

- 导入单个 Markdown 文件时，识别其中的本地 Markdown 图片和 Obsidian `![[...]]` 图片嵌入。
- 从 Markdown 所在目录向上查找 `.obsidian`，确定 Obsidian Vault 根目录。
- 优先解析相对路径；相对路径不存在时，在 Vault 中按文件名定位附件。
- 将找到的图片复制到导入后的 Markdown 相应位置，使现有摄取和 `wiki/media` 图片流程能够继续处理。
- 增加跨目录 SVG、PNG 图片导入的回归测试。

## 问题原因

单文件导入原先只复制 Markdown 本身。Obsidian 可以通过 Vault 索引解析 `![[image.svg]]`，即使图片位于 `attachments/` 或 `excalidraw/source/` 等其他目录；LLM Wiki 后续处理则只会从复制后的 Markdown 相对位置查找图片，因此附件无法导入。

## 用户影响

使用 Obsidian Vault 的用户现在可以单独导入包含裸文件名图片嵌入的 Markdown，跨目录附件也会随来源进入现有图片摄取流程。

## 验证

- `npx vitest run src/lib/source-lifecycle.test.ts src/lib/extract-source-images.test.ts`
- `npm run test:mocks`：127 个测试文件、1831 项测试通过
- `npm run typecheck`
- `npm run build`
- `npm run tauri -- build --no-bundle`
